### PR TITLE
[WIP] Add CMake packages (and versions)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,23 @@
 cmake_minimum_required(VERSION 2.8)
 # cmake_minimum_required(VERSION 3.5)
 project(slsDetectorPackage)
+include(cmake/project_version.cmake)
+
+# Include additional modules that are used unconditionally
+include(GNUInstallDirs)
+
+# If conda build, always set lib dir to 'lib'
+if($ENV{CONDA_BUILD})
+  set(CMAKE_INSTALL_LIBDIR "lib")
+endif()
+
+# Set lower / upper case project names
+string(TOUPPER "${PROJECT_NAME}" PROJECT_NAME_UPPER)
+string(TOLOWER "${PROJECT_NAME}" PROJECT_NAME_LOWER)
+
+# Set targets export name (used by slsDetectorPackage and dependencies)
+set(TARGETS_EXPORT_NAME "${PROJECT_NAME_LOWER}-targets")
+#set(namespace "${PROJECT_NAME}::")
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 set (CALIBRATE OFF)
@@ -17,6 +34,7 @@ option (SLS_USE_TEXTCLIENT "Text Client" OFF)
 option (SLS_USE_RECEIVER "Receiver" OFF)
 option (SLS_USE_GUI "GUI" OFF)
 option (SLS_USE_TESTS "TESTS" ON)
+option (SLS_USE_INTEGRATION_TESTS "Integration Tests" ON)
 
 #Testing for minimum version for compilers
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
@@ -31,6 +49,8 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wno-misleading-indentation")
 endif()
 
+#set (CMAKE_CXX_STANDARD 11)
+#set (CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -std=c++11 ")
 
 # set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=thread")
@@ -45,16 +65,16 @@ find_package(Qwt 6)
 find_package(CBF)
 find_package(Doxygen)
 
-if (USE_TESTS)
+if (SLS_USE_TESTS)
     enable_testing()
-endif(USE_TESTS)
+endif(SLS_USE_TESTS)
 
 # Support library containing functionallity common to 
 # detector and receiver
 add_subdirectory(slsSupportLib)
 
 if (SLS_USE_HDF5)
-	find_package(HDF5 1.10 COMPONENTS CXX)
+    find_package(HDF5 1.10 COMPONENTS CXX)
 endif (SLS_USE_HDF5)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
@@ -70,26 +90,23 @@ set_target_properties(zmq PROPERTIES
 )
 
 if (SLS_USE_TEXTCLIENT)
-       add_subdirectory(slsDetectorSoftware)
+    add_subdirectory(slsDetectorSoftware)
 endif (SLS_USE_TEXTCLIENT)
 
 if (SLS_USE_RECEIVER)
-       add_subdirectory(slsReceiverSoftware)
-       add_subdirectory(manual/manual-api)    
+    add_subdirectory(slsReceiverSoftware)
+    add_subdirectory(manual/manual-api)    
 endif (SLS_USE_RECEIVER)
-                    
+
 if (SLS_USE_GUI)   
-       if (QT4_FOUND AND QWT_FOUND)
-       add_subdirectory(slsDetectorGui)
-       endif()
+    if (QT4_FOUND AND QWT_FOUND)
+        add_subdirectory(slsDetectorGui)
+    endif()
 endif (SLS_USE_GUI)
 
-if (SLS_MASTER_PROJECT)
-    # Set targets export name (otherwise set by upstream project)
-    set(TARGETS_EXPORT_NAME "slsdetector-targets")
-endif (SLS_MASTER_PROJECT)
-
-add_subdirectory(integrationTests)
+if (SLS_USE_INTEGRATION_TESTS)
+    add_subdirectory(integrationTests)
+endif (SLS_USE_INTEGRATION_TESTS)
 
 if (CALIBRATE)
     if (DEFINED ENV{ROOTSYS})
@@ -103,3 +120,12 @@ endif(CALIBRATE)
 
 install(FILES ${ZMQ_STATIC_ARCHIVE}
 DESTINATION lib) 
+
+if(SLS_MASTER_PROJECT)
+    # Set install dir CMake packages
+    set(CMAKE_INSTALL_DIR ${CMAKE_INSTALL_DATADIR}/cmake/sls)
+    # Set the list of exported targets
+    set(PROJECT_LIBRARIES slsSupportLib slsDetectorShared slsReceiverShared)
+    # Generate and install package config file and version
+    include(cmake/package_config.cmake)
+endif()

--- a/cmake/package_config.cmake
+++ b/cmake/package_config.cmake
@@ -1,0 +1,31 @@
+# This cmake code creates the configuration that is found and used by
+# find_package() of another cmake project
+
+# get lower and upper case project name for the configuration files
+
+# configure and install the configuration files
+include(CMakePackageConfigHelpers)
+
+configure_package_config_file(
+  "${CMAKE_SOURCE_DIR}/cmake/project-config.cmake.in"
+  "${PROJECT_BINARY_DIR}/${PROJECT_NAME_LOWER}-config.cmake"
+  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME_LOWER}
+  PATH_VARS CMAKE_INSTALL_DIR)
+
+write_basic_package_version_file(
+  "${PROJECT_BINARY_DIR}/${PROJECT_NAME_LOWER}-config-version.cmake"
+  VERSION ${PROJECT_VERSION}
+  COMPATIBILITY SameMajorVersion)
+
+install(FILES
+  "${PROJECT_BINARY_DIR}/${PROJECT_NAME_LOWER}-config.cmake"
+  "${PROJECT_BINARY_DIR}/${PROJECT_NAME_LOWER}-config-version.cmake"
+  COMPONENT devel
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME_LOWER})
+
+if (PROJECT_LIBRARIES OR PROJECT_STATIC_LIBRARIES)
+  install(
+    EXPORT "${TARGETS_EXPORT_NAME}"
+    FILE ${PROJECT_NAME_LOWER}-targets.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME_LOWER})
+endif ()

--- a/cmake/project-config.cmake.in
+++ b/cmake/project-config.cmake.in
@@ -1,0 +1,24 @@
+# Config file for @PROJECT_NAME_LOWER@
+#
+# It defines the following variables:
+#
+# @PROJECT_NAME_UPPER@_INCLUDE_DIRS     - include directory
+# @PROJECT_NAME_UPPER@_LIBRARIES        - all dynamic libraries
+# @PROJECT_NAME_UPPER@_STATIC_LIBRARIES - all static libraries
+
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+set(SLS_USE_HDF5 "@SLS_USE_HDF5@")
+
+# Add optional dependencies here
+find_dependency(Threads)
+if (SLS_USE_HDF5)
+    find_dependency(HDF5)
+endif ()
+
+set_and_check(@PROJECT_NAME_UPPER@_CMAKE_INCLUDE_DIRS "@PACKAGE_CMAKE_INSTALL_DIR@")
+
+include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
+check_required_components("@PROJECT_NAME@")

--- a/cmake/project_version.cc.in
+++ b/cmake/project_version.cc.in
@@ -1,0 +1,14 @@
+#include "project_version.h"
+/// project version as major.minor.patch string
+const char* @PROJECT_NAME@_runtime_project_version(){ return "@PROJECT_VERSION@"; }
+/// package version as string, possibly with git commit: v1.2.3+4+g56789abc
+const char* @PROJECT_NAME@_runtime_package_version(){ return "@PACKAGE_VERSION@"; }
+/// project version as integer: major * 10000 + minor * 100 + patch
+int @PROJECT_NAME@_runtime_version_int()  { return @PROJECT_VERSION_INT@; }
+/// project version as integer: major
+int @PROJECT_NAME@_runtime_version_major(){ return @PACKAGE_VERSION_MAJOR@; }
+/// project version as integer: minor
+int @PROJECT_NAME@_runtime_version_minor(){ return @PACKAGE_VERSION_MINOR@; }
+/// project version as integer: patch
+int @PROJECT_NAME@_runtime_version_patch(){ return @PACKAGE_VERSION_PATCH@; }
+

--- a/cmake/project_version.cmake
+++ b/cmake/project_version.cmake
@@ -1,0 +1,154 @@
+#
+# Sets PROJECT_VERSION and PACKAGE_VERSION
+#
+
+# Don't set PROJECT_VERSION to empty string when no VERSION is given to project() command.
+#if(POLICY CMP0048)
+#  cmake_policy(SET CMP0048 OLD)
+#endif()
+
+# Split a version number into separate components
+# version the version number to split
+# major variable name to store the major version in
+# minor variable name to store the minor version in
+# patch variable name to store the patch version in
+# extra variable name to store a version suffix in
+function(version_split version major minor patch extra)
+    string(REGEX MATCH "([0-9]+)\\.([0-9]+)\\.([0-9]+)(.*)?" version_valid ${version})
+    if(version_valid)
+        string(REGEX REPLACE "([0-9]+)\\.([0-9]+)\\.([0-9]+)(.*)?" "\\1;\\2;\\3;\\4" VERSION_MATCHES ${version})
+        list(GET VERSION_MATCHES 0 version_major)
+        set(${major} ${version_major} PARENT_SCOPE)
+        list(GET VERSION_MATCHES 1 version_minor)
+        set(${minor} ${version_minor} PARENT_SCOPE)
+        list(GET VERSION_MATCHES 2 version_patch)
+        set(${patch} ${version_patch} PARENT_SCOPE)
+        list(GET VERSION_MATCHES 3 version_extra)
+        set(${extra} ${version_extra} PARENT_SCOPE)
+    else(version_valid)
+        message(AUTHOR_WARNING "Bad version ${version}; falling back to 0 (have you made an initial release?)")
+        set(${major} "0" PARENT_SCOPE)
+        set(${minor} "0" PARENT_SCOPE)
+        set(${patch} "0" PARENT_SCOPE)
+        set(${extra} "" PARENT_SCOPE)
+    endif(version_valid)
+endfunction(version_split)
+
+##############################
+# get PROJECT_VERSION from git
+##############################
+find_program(GIT_CMD git)
+mark_as_advanced(GIT_CMD)
+if (GIT_CMD)
+    execute_process(COMMAND ${GIT_CMD} rev-parse --show-toplevel
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+            OUTPUT_VARIABLE GIT_TOPLEVEL
+            ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif()
+if (GIT_CMD AND NOT "${GIT_TOPLEVEL}" STREQUAL "")
+    execute_process(COMMAND ${GIT_CMD} rev-parse --short HEAD
+            WORKING_DIRECTORY ${GIT_TOPLEVEL}
+            OUTPUT_VARIABLE GIT_SHA1
+            OUTPUT_STRIP_TRAILING_WHITESPACE)
+    #message(STATUS "GIT_SHA1: " ${GIT_SHA1})
+    execute_process(COMMAND ${GIT_CMD} describe --match "*[0-9].[0-9]*" HEAD
+            WORKING_DIRECTORY ${GIT_TOPLEVEL}
+            OUTPUT_VARIABLE GIT_DESCRIBE
+            ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+    #message(STATUS "GIT_DESCRIBE: " ${GIT_DESCRIBE})
+
+    if (GIT_DESCRIBE)
+        string(REGEX REPLACE "v?([0-9.]+).*" "\\1" GIT_VERSION ${GIT_DESCRIBE})
+        message(STATUS "GIT_VERSION: " ${GIT_VERSION})
+
+        # as package version we use the full version from git describe: 1.7.1+7+ge324c81
+        if (GIT_DESCRIBE MATCHES ".*-g.*")
+            # convert a git describe string to usable debian version, e.g. v1.7.1-7-ge324c81 to 1.7.1+7+ge324c81
+            string(REGEX REPLACE "v?([0-9]*.[0-9.]*).*-([0-9]*)-([a-g0-9]*)" "\\1+\\2+\\3" GIT_FULL_VERSION ${GIT_DESCRIBE})
+        else()
+            # current HEAD is git tag (i.e. releaase), directly use the version
+            set(GIT_FULL_VERSION ${GIT_VERSION})
+        endif()
+    else ()
+        # no (suitable) tag found
+        set(GIT_VERSION "0.0.0")
+        # get number of commits in repo
+        execute_process(COMMAND ${GIT_CMD} rev-list --count HEAD
+                WORKING_DIRECTORY ${GIT_TOPLEVEL}
+                OUTPUT_VARIABLE GIT_COMMIT_COUNT
+                OUTPUT_STRIP_TRAILING_WHITESPACE)
+        set(GIT_FULL_VERSION 0.0.0+${GIT_COMMIT_COUNT}+g${GIT_SHA1})
+    endif ()
+endif ()
+
+# get version from package.xml if it exists
+if (EXISTS "${PROJECT_SOURCE_DIR}/package.xml")
+    file(STRINGS "${PROJECT_SOURCE_DIR}/package.xml" PACKAGE_XML_VERSION_LINE REGEX <version>[0-9.]*</version>)
+    string(REGEX REPLACE .*<version>\([0-9.]*\)</version>.* \\1 PACKAGE_XML_VERSION "${PACKAGE_XML_VERSION_LINE}")
+    MESSAGE(STATUS "PACKAGE_XML_VERSION: " ${PACKAGE_XML_VERSION})
+endif ()
+
+# set version (if not already manually specified)
+# check versions from different sources and set actually used version
+if (NOT PROJECT_VERSION)
+    # set PROJECT_VERSION to MAJOR.MINOR.PATCH
+    # PACKAGE_VERSION can have extra info
+    if (GIT_VERSION)
+        set(PROJECT_VERSION ${GIT_VERSION})
+        set(PACKAGE_VERSION ${GIT_FULL_VERSION})
+    elseif (PACKAGE_XML_VERSION)
+        set(PROJECT_VERSION ${PACKAGE_XML_VERSION})
+        set(PACKAGE_VERSION ${PROJECT_VERSION})
+    else ()
+        message(WARNING "PROJECT_VERSION not set. Defaulting to 0.0.0")
+        set(PROJECT_VERSION "0.0.0")
+    endif ()
+endif ()
+if (NOT PACKAGE_VERSION)
+    message(WARNING "PACKAGE_VERSION not set! Falling back to (${PROJECT_VERSION})")
+    set(PACKAGE_VERSION ${PROJECT_VERSION})
+endif ()
+
+# warn if versions don't match
+if (GIT_VERSION AND NOT GIT_VERSION MATCHES ${PROJECT_VERSION})
+    message(WARNING "Version from git (${GIT_VERSION}) doesn't match PROJECT_VERSION (${PROJECT_VERSION})")
+endif()
+if (PACKAGE_XML_VERSION AND NOT PACKAGE_XML_VERSION MATCHES ${PROJECT_VERSION})
+    message(WARNING "Version from package.xml (${PACKAGE_XML_VERSION}) doesn't match PROJECT_VERSION (${PROJECT_VERSION})")
+endif()
+
+message(STATUS "PROJECT_VERSION: " ${PROJECT_VERSION})
+message(STATUS "PACKAGE_VERSION: " ${PACKAGE_VERSION})
+
+
+version_split(${PROJECT_VERSION} PACKAGE_VERSION_MAJOR PACKAGE_VERSION_MINOR PACKAGE_VERSION_PATCH extra)
+#message(STATUS "PACKAGE_VERSION_MAJOR: " ${PACKAGE_VERSION_MAJOR})
+#message(STATUS "PACKAGE_VERSION_MINOR: " ${PACKAGE_VERSION_MINOR})
+#message(STATUS "PACKAGE_VERSION_PATCH: " ${PACKAGE_VERSION_PATCH})
+
+# generate an integer version number: major * 10000 + minor * 100 + patch
+math(EXPR PROJECT_VERSION_INT "${PACKAGE_VERSION_MAJOR} * 10000 + ${PACKAGE_VERSION_MINOR} * 100 + ${PACKAGE_VERSION_PATCH}")
+
+# make PROJECT_VERSION available as define in the project source
+#add_definitions(-DPROJECT_VERSION="${PROJECT_VERSION}")
+#add_definitions(-DPROJECT_VERSION_INT=${PROJECT_VERSION_INT})
+#add_definitions(-DPACKAGE_VERSION="${PACKAGE_VERSION}")
+#add_definitions(-DPACKAGE_VERSION_MAJOR=${PACKAGE_VERSION_MAJOR})
+#add_definitions(-DPACKAGE_VERSION_MINOR=${PACKAGE_VERSION_MINOR})
+#add_definitions(-DPACKAGE_VERSION_PATCH=${PACKAGE_VERSION_PATCH})
+
+# set ABI version to major.minor, which will be used for the SOVERSION
+set(abiversion "${PACKAGE_VERSION_MAJOR}.${PACKAGE_VERSION_MINOR}")
+
+# generate a version.h file in the binary output dir, don't forget to install it...
+string(TOUPPER "${PROJECT_NAME}" PROJECT_NAME_UPPER)
+
+# These files provide compile-time and runtime version information about your project.
+# To offer the version info to the users of your library, you need to
+# adapt the following lines in your respective CMakeLists.txt:
+#   add_library(<yourlibraryname> SHARED <your code files> ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}/project_version.cc)
+#   install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}/project_version.h COMPONENT dev DESTINATION include/<your-include-dir>)
+# To use it within your library or tests you need to add the include directory:
+# > target_include_directories(yourtarget PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME})
+configure_file(${CMAKE_CURRENT_LIST_DIR}/project_version.h.in  ${PROJECT_NAME}/project_version.h @ONLY)
+configure_file(${CMAKE_CURRENT_LIST_DIR}/project_version.cc.in ${PROJECT_NAME}/project_version.cc @ONLY)

--- a/cmake/project_version.h.in
+++ b/cmake/project_version.h.in
@@ -1,0 +1,34 @@
+#ifndef @PROJECT_NAME_UPPER@_VERSION_H_
+#define @PROJECT_NAME_UPPER@_VERSION_H_
+
+/// project version as major.minor.patch string
+#define @PROJECT_NAME_UPPER@_VERSION "@PROJECT_VERSION@"
+/// project version as integer: major * 10000 + minor * 100 + patch
+#define @PROJECT_NAME_UPPER@_VERSION_INT @PROJECT_VERSION_INT@
+#define @PROJECT_NAME_UPPER@_VERSION_MAJOR @PACKAGE_VERSION_MAJOR@
+#define @PROJECT_NAME_UPPER@_VERSION_MINOR @PACKAGE_VERSION_MINOR@
+#define @PROJECT_NAME_UPPER@_VERSION_PATCH @PACKAGE_VERSION_PATCH@
+/// package version as string, possibly with git commit: v1.2.3+4+g56789abc
+#define @PROJECT_NAME_UPPER@_PACKAGE_VERSION "@PACKAGE_VERSION@"
+
+///runtime versions, where the above values are linked into a lib and therefore reflect the version
+///of the library itself (not the version of the header at compile time of the user code)
+const char* @PROJECT_NAME@_runtime_project_version();
+const char* @PROJECT_NAME@_runtime_package_version();
+int @PROJECT_NAME@_runtime_version_int();
+int @PROJECT_NAME@_runtime_version_major();
+int @PROJECT_NAME@_runtime_version_minor();
+int @PROJECT_NAME@_runtime_version_patch();
+
+///Check consistency of runtime vs compile-time version number. I.e. the header used
+///for compilation was from the same version as the linked library.
+inline bool @PROJECT_NAME@_check_version_consistency(bool major_minor_only)
+{
+  return @PROJECT_NAME@_runtime_version_major() == @PROJECT_NAME_UPPER@_VERSION_MAJOR &&
+         @PROJECT_NAME@_runtime_version_minor() == @PROJECT_NAME_UPPER@_VERSION_MINOR &&
+         (major_minor_only ||
+          @PROJECT_NAME@_runtime_version_patch() == @PROJECT_NAME_UPPER@_VERSION_PATCH);
+}
+
+
+#endif

--- a/slsDetectorSoftware/CMakeLists.txt
+++ b/slsDetectorSoftware/CMakeLists.txt
@@ -19,15 +19,16 @@ add_library(slsDetectorShared SHARED
     ${SOURCES}
     ${HEADERS}
 )
-target_include_directories(slsDetectorShared PUBLIC 
-    multiSlsDetector 
-    sharedMemory
-    slsDetector 
+target_include_directories(slsDetectorShared PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/multiSlsDetector>"
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/sharedMemory>"
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/slsDetector>"
+    "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
 )
 
-target_link_libraries(slsDetectorShared
+target_link_libraries(slsDetectorShared PUBLIC
     slsSupportLib
-	zmq
+    zmq
 )
 
 set(PUBLICHEADERS
@@ -57,7 +58,8 @@ endif()
 
 install(TARGETS slsDetectorShared
     EXPORT "${TARGETS_EXPORT_NAME}"
-    LIBRARY DESTINATION lib
-    PUBLIC_HEADER DESTINATION include
-    ARCHIVE DESTINATION lib
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )

--- a/slsReceiverSoftware/CMakeLists.txt
+++ b/slsReceiverSoftware/CMakeLists.txt
@@ -79,7 +79,7 @@ install(TARGETS slsReceiverShared slsReceiver
         RUNTIME DESTINATION bin
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib
-        PUBLIC_HEADER DESTINATION include
-)
-        
-      
+        PUBLIC_HEADER DESTINATION include)
+
+install(FILES ${ZMQ_STATIC_ARCHIVE}
+DESTINATION lib)       

--- a/slsReceiverSoftware/CMakeLists.txt
+++ b/slsReceiverSoftware/CMakeLists.txt
@@ -38,8 +38,13 @@ add_library(slsReceiverShared SHARED
     ${HEADERS}
 )
 
-target_link_libraries(slsReceiverShared slsSupportLib)
-target_include_directories(slsReceiverShared PUBLIC include)
+target_link_libraries(slsReceiverShared PUBLIC
+    slsSupportLib
+)
+
+target_include_directories(slsReceiverShared PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
 
 #What is included in slsReceiverLib?
 set(PUBLICHEADERS
@@ -60,7 +65,7 @@ set_target_properties(slsReceiver PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
 )
 
-target_link_libraries(slsReceiver
+target_link_libraries(slsReceiver PUBLIC
     slsSupportLib
     slsReceiverShared
     pthread
@@ -69,17 +74,17 @@ target_link_libraries(slsReceiver
 )
 
 if (HDF5_FOUND)
-    target_link_libraries(slsReceiver ${HDF5_LIBRARIES})
+    target_link_libraries(slsReceiver PUBLIC ${HDF5_LIBRARIES})
 endif ()
 
 
 
-install(TARGETS slsReceiverShared slsReceiver
+install(TARGETS slsReceiverShared
         EXPORT "${TARGETS_EXPORT_NAME}"
-        RUNTIME DESTINATION bin
-        LIBRARY DESTINATION lib
-        ARCHIVE DESTINATION lib
-        PUBLIC_HEADER DESTINATION include)
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 install(FILES ${ZMQ_STATIC_ARCHIVE}
-DESTINATION lib)       
+DESTINATION lib)

--- a/slsSupportLib/CMakeLists.txt
+++ b/slsSupportLib/CMakeLists.txt
@@ -37,7 +37,10 @@ add_library(slsSupportLib SHARED
     ${HEADERS}
 )
 
-target_include_directories(slsSupportLib PUBLIC include)
+target_include_directories(slsSupportLib PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
+)
 
 set_target_properties(slsSupportLib PROPERTIES
     LIBRARY_OUTPUT_NAME SlsSupport
@@ -49,8 +52,10 @@ if (USE_TESTS)
     add_subdirectory(tests)
 endif(USE_TESTS)
 
+# Install the library
 install(TARGETS slsSupportLib
-    LIBRARY DESTINATION lib
-    PUBLIC_HEADER DESTINATION include
-    ARCHIVE DESTINATION lib
+    EXPORT "${TARGETS_EXPORT_NAME}"
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )


### PR DESCRIPTION
This is work in progress, some targets are not exported properly yet.

The modifications include:

 - Use GNUInstallDirs module to get the install dir (but force libraries to `lib` for conda)
 - `project_version.cmake` will try to get the version from git refs (things like v1.20.5 are accepted but not `jungfrau3.0.0.9`)
- to make the package relocatable, one need to use `$<BUILD_INTERFACE:XXX>` and `$<BUILD_INTERFACE:XXX>` generators when specifying include directories (I whish this is simpler)

After `make install`, you should get `lib\cmake\slsdetectorpackage\slsdetectorpackage-targets.cmake` and the like, that are used by downstream projects with `find_dependency`.