### PR TITLE
Add slsReceiver ctor overload

### DIFF
--- a/slsReceiverSoftware/include/slsReceiver.h
+++ b/slsReceiverSoftware/include/slsReceiver.h
@@ -4,10 +4,9 @@
  * @short creates the UDP and TCP class objects
  ***********************************************/
 
+#include <memory>
 
-
-class slsReceiverTCPIPInterface;
-
+#include "slsReceiverTCPIPInterface.h"
 #include "sls_detector_defs.h"
 
 
@@ -27,11 +26,15 @@ class slsReceiver : private virtual slsDetectorDefs {
 	 * @param argv from command line
 	 */
 	slsReceiver(int argc, char *argv[]);
-
+	
 	/**
-	 * Destructor
+	 * Constructor
+	 * Starts up a Receiver server. Reads configuration file, options, and
+	 * assembles a Receiver using TCP and UDP detector interfaces
+	 * throws an exception in case of failure
+	 * @param tcpip_port_no TCP/IP port number
 	 */
-	~slsReceiver();
+	slsReceiver(int tcpip_port_no = 1954);
 
 	/**
 	 * starts listening on the TCP port for client comminication
@@ -95,6 +98,5 @@ class slsReceiver : private virtual slsDetectorDefs {
 
 
  private:
-	slsReceiverTCPIPInterface* tcpipInterface;
+	std::unique_ptr<slsReceiverTCPIPInterface> tcpipInterface;
 };
-

--- a/slsReceiverSoftware/include/slsReceiverUsers.h
+++ b/slsReceiverSoftware/include/slsReceiverUsers.h
@@ -3,8 +3,9 @@
 #include <stdio.h>
 #include <stdint.h>
 
+#include <memory>
 
-class slsReceiver;
+#include "slsReceiver.h"
 
   /** 
 @short Class for implementing the SLS data receiver in the users application. Callbacks can be defined for processing and/or saving data
@@ -23,10 +24,14 @@ public:
 	 * @param success socket creation was successfull
 	 */
 	slsReceiverUsers(int argc, char *argv[], int &success);
-
-
-	/** Destructor */
-	~slsReceiverUsers();
+	
+	/**
+	 * Constructor
+	 * reads config file, creates socket, assigns function table
+	 * @param tcpip_port_no TCP/IP port
+	 * @throws 
+	 */
+	slsReceiverUsers(int tcpip_port_no = 1954);
 
 	/**
 	 * starts listening on the TCP port for client comminication
@@ -83,6 +88,5 @@ public:
             char* datapointer, uint32_t &revDatasize, void*),void *arg);
 
 	//receiver object
-	slsReceiver* receiver;
+	std::unique_ptr<slsReceiver> receiver;
 };
-

--- a/slsReceiverSoftware/src/slsReceiver.cpp
+++ b/slsReceiverSoftware/src/slsReceiver.cpp
@@ -11,6 +11,7 @@
 #include <map>
 #include <getopt.h>
 
+#include "container_utils.h" // For sls::make_unique<>
 
 #include "slsReceiver.h"
 #include "slsReceiverTCPIPInterface.h"
@@ -78,17 +79,14 @@ slsReceiver::slsReceiver(int argc, char *argv[]):
 	}
 
 	// might throw an exception
-	//tcpipInterface = std::make_unique<slsReceiverTCPIPInterface>(tcpip_port_no);
-	tcpipInterface = std::unique_ptr<slsReceiverTCPIPInterface>(new slsReceiverTCPIPInterface(tcpip_port_no));
-
+	tcpipInterface = sls::make_unique<slsReceiverTCPIPInterface>(tcpip_port_no);
 }
 
 
 slsReceiver::slsReceiver(int tcpip_port_no)
 {
 	// might throw an exception
-	//tcpipInterface = std::make_unique<slsReceiverTCPIPInterface>(tcpip_port_no);
-	tcpipInterface = std::unique_ptr<slsReceiverTCPIPInterface>(new slsReceiverTCPIPInterface(tcpip_port_no));
+	tcpipInterface = sls::make_unique<slsReceiverTCPIPInterface>(tcpip_port_no);
 }
 
 

--- a/slsReceiverSoftware/src/slsReceiver.cpp
+++ b/slsReceiverSoftware/src/slsReceiver.cpp
@@ -78,14 +78,17 @@ slsReceiver::slsReceiver(int argc, char *argv[]):
 	}
 
 	// might throw an exception
-	tcpipInterface = new slsReceiverTCPIPInterface(tcpip_port_no);
+	//tcpipInterface = std::make_unique<slsReceiverTCPIPInterface>(tcpip_port_no);
+	tcpipInterface = std::unique_ptr<slsReceiverTCPIPInterface>(new slsReceiverTCPIPInterface(tcpip_port_no));
 
 }
 
 
-slsReceiver::~slsReceiver() {
-	if(tcpipInterface)
-		delete tcpipInterface;
+slsReceiver::slsReceiver(int tcpip_port_no)
+{
+	// might throw an exception
+	//tcpipInterface = std::make_unique<slsReceiverTCPIPInterface>(tcpip_port_no);
+	tcpipInterface = std::unique_ptr<slsReceiverTCPIPInterface>(new slsReceiverTCPIPInterface(tcpip_port_no));
 }
 
 

--- a/slsReceiverSoftware/src/slsReceiverUsers.cpp
+++ b/slsReceiverSoftware/src/slsReceiverUsers.cpp
@@ -1,10 +1,11 @@
+#include "container_utils.h" // For sls::make_unique<>
+
 #include "slsReceiverUsers.h"
 
 slsReceiverUsers::slsReceiverUsers(int argc, char *argv[], int &success) {
 	// catch the exception here to limit it to within the library (for current version)
 	try {
-		//receiver = std::make_unique<slsReceiver>(argc, argv);
-		receiver = std::unique_ptr<slsReceiver>(new slsReceiver(argc, argv));
+		receiver = sls::make_unique<slsReceiver>(argc, argv);
 		success = slsDetectorDefs::OK;
 	} catch (...) {
 		success = slsDetectorDefs::FAIL;
@@ -12,8 +13,7 @@ slsReceiverUsers::slsReceiverUsers(int argc, char *argv[], int &success) {
 }
 
 slsReceiverUsers::slsReceiverUsers(int tcpip_port_no) {
-	//receiver = std::make_unique<slsReceiver>(tcpip_port_no);
-	receiver = std::unique_ptr<slsReceiver>(new slsReceiver(tcpip_port_no));
+	receiver = sls::make_unique<slsReceiver>(tcpip_port_no);
 }
 
 int slsReceiverUsers::start() {

--- a/slsReceiverSoftware/src/slsReceiverUsers.cpp
+++ b/slsReceiverSoftware/src/slsReceiverUsers.cpp
@@ -1,19 +1,19 @@
 #include "slsReceiverUsers.h"
-#include "slsReceiver.h"
 
 slsReceiverUsers::slsReceiverUsers(int argc, char *argv[], int &success) {
 	// catch the exception here to limit it to within the library (for current version)
 	try {
-		slsReceiver* r = new slsReceiver(argc, argv);
-		receiver = r;
+		//receiver = std::make_unique<slsReceiver>(argc, argv);
+		receiver = std::unique_ptr<slsReceiver>(new slsReceiver(argc, argv));
 		success = slsDetectorDefs::OK;
 	} catch (...) {
 		success = slsDetectorDefs::FAIL;
 	}
 }
 
-slsReceiverUsers::~slsReceiverUsers() {
-	delete receiver;
+slsReceiverUsers::slsReceiverUsers(int tcpip_port_no) {
+	//receiver = std::make_unique<slsReceiver>(tcpip_port_no);
+	receiver = std::unique_ptr<slsReceiver>(new slsReceiver(tcpip_port_no));
 }
 
 int slsReceiverUsers::start() {


### PR DESCRIPTION
I suggest to add a constructor overload of `slsReceiverUsers` (and `slsReceiver`) that takes the TCP/IP port in argument. IMHO, it is the responsibility of the application that uses the slsDetector libraries to parse the command line/config file and provide the argument.

Also I would recommend to use `std::unique_ptr<>` instead of raw pointers, see [Avoid calling new and delete explicitly](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#r11-avoid-calling-new-and-delete-explicitly) for the rationale.

Tell me if I'm not targeting the right branch for these modifications!