### PR TITLE
Fix sprintf warnings

### DIFF
--- a/slsReceiverSoftware/src/slsReceiverTCPIPInterface.cpp
+++ b/slsReceiverSoftware/src/slsReceiverTCPIPInterface.cpp
@@ -292,10 +292,10 @@ void slsReceiverTCPIPInterface::validate(T arg, T retval, std::string modename, 
 		ret = FAIL;
 		if (hex)
 			sprintf(mess, "Could not %s. Set 0x%x, but read 0x%x\n",
-				modename.c_str(), arg, retval);
+				modename.c_str(), (unsigned int) arg, (unsigned int) retval);
 		else
 			sprintf(mess, "Could not %s. Set %d, but read %d\n",
-				modename.c_str(), arg, retval);
+				modename.c_str(), (unsigned int) arg, (unsigned int) retval);
 		FILE_LOG(logERROR) << mess;
 	}
 }


### PR DESCRIPTION
Reported by gcc 7.3.

Here, iostreams (`std::ostringstream`) would offer a better solution as the type of the (template) variables `arg` and `retval` are automatically deduced while `sprintf` uses a hardcoded format string.