### PR TITLE
Integration tests for the command line

### DIFF
--- a/slsDetectorSoftware/include/multiSlsDetectorClient.h
+++ b/slsDetectorSoftware/include/multiSlsDetectorClient.h
@@ -48,22 +48,22 @@ class multiSlsDetectorClient {
         bool update = true;
         if (action_ == slsDetectorDefs::PUT_ACTION &&
             parser.n_arguments() == 0) {
-            std::cout << "Wrong usage - should be: " << parser.executable()
+            os << "Wrong usage - should be: " << parser.executable()
                       << "[id-][pos:]channel arg" << std::endl;
-            std::cout << std::endl;
+            os << std::endl;
             return;
         };
         if (action_ == slsDetectorDefs::GET_ACTION &&
             parser.command().empty()) {
-            std::cout << "Wrong usage - should be: " << parser.executable()
+            os << "Wrong usage - should be: " << parser.executable()
                       << "[id-][pos:]channel arg" << std::endl;
-            std::cout << std::endl;
+            os << std::endl;
             return;
         };
 
         if (action_ == slsDetectorDefs::READOUT_ACTION &&
             parser.detector_id() != -1) {
-            std::cout << "detector_id: " << parser.detector_id()
+            os << "detector_id: " << parser.detector_id()
                       << " ,readout of individual detectors is not allowed!"
                       << std::endl;
             return;
@@ -81,7 +81,7 @@ class multiSlsDetectorClient {
             update = false;
         }
 
-        // std::cout<<"id:"<<id<<" pos:"<<pos<<std::endl;
+        // os<<"id:"<<id<<" pos:"<<pos<<std::endl;
         // create multiSlsDetector class if required
         std::unique_ptr<multiSlsDetector> localDet;
         if (detPtr == nullptr) {
@@ -90,15 +90,15 @@ class multiSlsDetectorClient {
                                                               verify, update);
                 detPtr = localDet.get();
             } catch (const RuntimeError &e) {
-                /*std::cout << e.GetMessage() << std::endl;*/
+                /*os << e.GetMessage() << std::endl;*/
                 return;
             } catch (...) {
-                std::cout << " caught exception\n";
+                os << " caught exception\n";
                 return;
             }
         }
         if (parser.detector_id() >= detPtr->getNumberOfDetectors()) {
-            std::cout << "position is out of bounds.\n";
+            os << "position is out of bounds.\n";
             return;
         }
 
@@ -123,13 +123,13 @@ class multiSlsDetectorClient {
                               action_, parser.detector_id());
 
         if (parser.multi_id() != 0)
-            std::cout << parser.multi_id() << '-';
+            os << parser.multi_id() << '-';
         if (parser.detector_id() != -1)
-            std::cout << parser.detector_id() << ':';
+            os << parser.detector_id() << ':';
 
         if (action_ != slsDetectorDefs::READOUT_ACTION) {
-            std::cout << parser.command() << " ";
+            os << parser.command() << " ";
         }
-        std::cout << answer << std::endl;
+        os << answer << std::endl;
     }
 };

--- a/slsDetectorSoftware/include/multiSlsDetectorClient.h
+++ b/slsDetectorSoftware/include/multiSlsDetectorClient.h
@@ -49,14 +49,14 @@ class multiSlsDetectorClient {
         if (action_ == slsDetectorDefs::PUT_ACTION &&
             parser.n_arguments() == 0) {
             os << "Wrong usage - should be: " << parser.executable()
-                      << "[id-][pos:]channel arg" << std::endl;
+               << "[id-][pos:]channel arg" << std::endl;
             os << std::endl;
             return;
         };
         if (action_ == slsDetectorDefs::GET_ACTION &&
             parser.command().empty()) {
             os << "Wrong usage - should be: " << parser.executable()
-                      << "[id-][pos:]channel arg" << std::endl;
+               << "[id-][pos:]channel arg" << std::endl;
             os << std::endl;
             return;
         };
@@ -64,8 +64,8 @@ class multiSlsDetectorClient {
         if (action_ == slsDetectorDefs::READOUT_ACTION &&
             parser.detector_id() != -1) {
             os << "detector_id: " << parser.detector_id()
-                      << " ,readout of individual detectors is not allowed!"
-                      << std::endl;
+               << " ,readout of individual detectors is not allowed!"
+               << std::endl;
             return;
         }
 

--- a/slsDetectorSoftware/include/multiSlsDetectorClient.h
+++ b/slsDetectorSoftware/include/multiSlsDetectorClient.h
@@ -3,6 +3,7 @@
 #include <string>
 
 #include "CmdLineParser.h"
+#include "CmdProxy.h"
 #include "container_utils.h"
 #include "string_utils.h"
 #include "multiSlsDetector.h"

--- a/slsDetectorSoftware/include/multiSlsDetectorClient.h
+++ b/slsDetectorSoftware/include/multiSlsDetectorClient.h
@@ -3,12 +3,11 @@
 #include <string>
 
 #include "CmdLineParser.h"
-#include "CmdProxy.h"
 #include "container_utils.h"
+#include "string_utils.h"
 #include "multiSlsDetector.h"
 #include "slsDetectorCommand.h"
 #include "sls_detector_exceptions.h"
-#include "string_utils.h"
 
 #include <cstdlib>
 #include <memory>
@@ -23,14 +22,17 @@ inline int dummyCallback(detectorData *d, int p, void *) {
 class multiSlsDetectorClient {
   public:
     multiSlsDetectorClient(int argc, char *argv[], int action,
-                           multiSlsDetector *myDetector = nullptr)
-        : action_(action), detPtr(myDetector) {
+                           multiSlsDetector *myDetector = nullptr,
+                           std::ostream &output = std::cout)
+        : action_(action), detPtr(myDetector), os(output) {
         parser.Parse(argc, argv);
         runCommand();
+
     }
     multiSlsDetectorClient(const std::string &args, int action,
-                           multiSlsDetector *myDetector = nullptr)
-        : action_(action), detPtr(myDetector) {
+                           multiSlsDetector *myDetector = nullptr,
+                           std::ostream &output = std::cout)
+        : action_(action), detPtr(myDetector), os(output) {
         parser.Parse(args);
         runCommand();
     }
@@ -39,6 +41,7 @@ class multiSlsDetectorClient {
     int action_;
     CmdLineParser parser;
     multiSlsDetector *detPtr = nullptr;
+    std::ostream &os;
 
     void runCommand() {
         bool verify = true;

--- a/slsDetectorSoftware/include/multiSlsDetectorClient.h
+++ b/slsDetectorSoftware/include/multiSlsDetectorClient.h
@@ -82,7 +82,6 @@ class multiSlsDetectorClient {
             update = false;
         }
 
-        // os<<"id:"<<id<<" pos:"<<pos<<std::endl;
         // create multiSlsDetector class if required
         std::unique_ptr<multiSlsDetector> localDet;
         if (detPtr == nullptr) {

--- a/slsDetectorSoftware/src/sls_detector_client.cpp
+++ b/slsDetectorSoftware/src/sls_detector_client.cpp
@@ -26,5 +26,6 @@ int main(int argc, char *argv[]) {
 #ifdef HELP
     int action = slsDetectorDefs::HELP_ACTION;
 #endif
+
     multiSlsDetectorClient(argc, argv, action);
 }

--- a/slsDetectorSoftware/tests/CMakeLists.txt
+++ b/slsDetectorSoftware/tests/CMakeLists.txt
@@ -2,4 +2,5 @@ target_sources(tests PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/test-SharedMemory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test-slsDetector.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test-multiSlsDetector.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test-multiSlsDetectorClient.cpp
 )

--- a/slsDetectorSoftware/tests/test-multiSlsDetectorClient.cpp
+++ b/slsDetectorSoftware/tests/test-multiSlsDetectorClient.cpp
@@ -1,5 +1,21 @@
 #include "catch.hpp"
+#include "multiSlsDetectorClient.h"
+#include "sls_detector_defs.h"
+#include <sstream>
+
+auto GET = slsDetectorDefs::GET_ACTION;
+auto PUT = slsDetectorDefs::PUT_ACTION;
 
 TEST_CASE("fail", "[.cmd]"){
-    REQUIRE(false);
+    std::ostringstream oss1;
+    multiSlsDetectorClient("rx_fifodepth 10", PUT, nullptr, oss1);
+    REQUIRE(oss1.str() == "rx_fifodepth 10\n");
+
+    std::ostringstream oss2;
+    multiSlsDetectorClient("rx_fifodepth 100", PUT, nullptr, oss2);
+    REQUIRE(oss2.str() == "rx_fifodepth 100\n");
+
+    std::ostringstream oss3;
+    multiSlsDetectorClient("rx_fifodepth", GET, nullptr, oss3);
+    REQUIRE(oss3.str() == "rx_fifodepth 100\n");
 }

--- a/slsDetectorSoftware/tests/test-multiSlsDetectorClient.cpp
+++ b/slsDetectorSoftware/tests/test-multiSlsDetectorClient.cpp
@@ -7,15 +7,30 @@ auto GET = slsDetectorDefs::GET_ACTION;
 auto PUT = slsDetectorDefs::PUT_ACTION;
 
 TEST_CASE("rx_fifodepth", "[.cmd]") {
-    std::ostringstream oss1;
-    multiSlsDetectorClient("rx_fifodepth 10", PUT, nullptr, oss1);
-    REQUIRE(oss1.str() == "rx_fifodepth 10\n");
+    auto oss = std::ostringstream{};
+    multiSlsDetectorClient("rx_fifodepth 10", PUT, nullptr, oss);
+    REQUIRE(oss.str() == "rx_fifodepth 10\n");
 
-    std::ostringstream oss2;
-    multiSlsDetectorClient("rx_fifodepth 100", PUT, nullptr, oss2);
-    REQUIRE(oss2.str() == "rx_fifodepth 100\n");
+    oss = std::ostringstream{};
+    multiSlsDetectorClient("rx_fifodepth 100", PUT, nullptr, oss);
+    REQUIRE(oss.str() == "rx_fifodepth 100\n");
 
-    std::ostringstream oss3;
-    multiSlsDetectorClient("rx_fifodepth", GET, nullptr, oss3);
-    REQUIRE(oss3.str() == "rx_fifodepth 100\n");
+    oss = std::ostringstream{};
+    multiSlsDetectorClient("rx_fifodepth", GET, nullptr, oss);
+    REQUIRE(oss.str() == "rx_fifodepth 100\n");
+}
+
+TEST_CASE("frames", "[.cmd]"){
+    auto oss = std::ostringstream{};
+    multiSlsDetectorClient("frames 1000", PUT, nullptr, oss);
+    REQUIRE(oss.str() == "frames 1000\n");
+
+    oss = std::ostringstream{};
+    multiSlsDetectorClient("frames", GET, nullptr, oss);
+    REQUIRE(oss.str() == "frames 1000\n");
+
+    oss = std::ostringstream{};
+    multiSlsDetectorClient("frames 1", PUT, nullptr, oss);
+    REQUIRE(oss.str() == "frames 1\n");
+
 }

--- a/slsDetectorSoftware/tests/test-multiSlsDetectorClient.cpp
+++ b/slsDetectorSoftware/tests/test-multiSlsDetectorClient.cpp
@@ -1,0 +1,5 @@
+#include "catch.hpp"
+
+TEST_CASE("fail", "[.cmd]"){
+    REQUIRE(false);
+}

--- a/slsDetectorSoftware/tests/test-multiSlsDetectorClient.cpp
+++ b/slsDetectorSoftware/tests/test-multiSlsDetectorClient.cpp
@@ -6,7 +6,7 @@
 auto GET = slsDetectorDefs::GET_ACTION;
 auto PUT = slsDetectorDefs::PUT_ACTION;
 
-TEST_CASE("fail", "[.cmd]"){
+TEST_CASE("rx_fifodepth", "[.cmd]") {
     std::ostringstream oss1;
     multiSlsDetectorClient("rx_fifodepth 10", PUT, nullptr, oss1);
     REQUIRE(oss1.str() == "rx_fifodepth 10\n");

--- a/slsDetectorSoftware/tests/test-multiSlsDetectorClient.cpp
+++ b/slsDetectorSoftware/tests/test-multiSlsDetectorClient.cpp
@@ -18,6 +18,10 @@ TEST_CASE("rx_fifodepth", "[.cmd]") {
     oss = std::ostringstream{};
     multiSlsDetectorClient("rx_fifodepth", GET, nullptr, oss);
     REQUIRE(oss.str() == "rx_fifodepth 100\n");
+
+    oss = std::ostringstream{};
+    multiSlsDetectorClient("0:rx_fifodepth", GET, nullptr, oss);
+    REQUIRE(oss.str() == "0:rx_fifodepth 100\n");
 }
 
 TEST_CASE("frames", "[.cmd]"){


### PR DESCRIPTION
Adding the output stream as a parameter to multiSlsDetectorCommand allows for testing of the command line interface. 