### PR TITLE
Renamed receiver commands to rx_

### DIFF
--- a/slsDetectorSoftware/src/slsDetectorCommand.cpp
+++ b/slsDetectorSoftware/src/slsDetectorCommand.cpp
@@ -102,9 +102,9 @@ slsDetectorCommand::slsDetectorCommand(multiSlsDetector *det) {
     ++i;
 
     /*! \page test
-   - <b>exitreceiver</b> Shuts down all the receivers. Don't use it!!!!
+   - <b>rx_exit</b> Shuts down all the receivers. Don't use it!!!!
 	 */
-    descrToFuncMap[i].m_pFuncName = "exitreceiver";
+    descrToFuncMap[i].m_pFuncName = "rx_exit";
     descrToFuncMap[i].m_pFuncPtr = &slsDetectorCommand::cmdExitServer;
     ++i;
 
@@ -1536,16 +1536,16 @@ slsDetectorCommand::slsDetectorCommand(multiSlsDetector *det) {
     ++i;
 
     /*! \page output
-   - <b>index [i]</b> Sets/gets the current file index. \c Returns \c (int)
+   - <b>findex [i]</b> Sets/gets the current file index. \c Returns \c (int)
 	 */
-    descrToFuncMap[i].m_pFuncName = "index";
+    descrToFuncMap[i].m_pFuncName = "findex";
     descrToFuncMap[i].m_pFuncPtr = &slsDetectorCommand::cmdFileIndex;
     ++i;
 
     /*! \page output
-   - <b>enablefwrite [i]</b> Enables/disables file writing. 1 enables, 0 disables. \c Returns \c (int)
+   - <b>fwrite [i]</b> Enables/disables file writing. 1 enables, 0 disables. \c Returns \c (int)
 	 */
-    descrToFuncMap[i].m_pFuncName = "enablefwrite";
+    descrToFuncMap[i].m_pFuncName = "fwrite";
     descrToFuncMap[i].m_pFuncPtr = &slsDetectorCommand::cmdEnablefwrite;
     ++i;
 
@@ -2487,7 +2487,7 @@ std::string slsDetectorCommand::cmdExitServer(int narg, const char * const args[
                 return std::string("Server shut down.");
             else
                 return std::string("Error closing server\n");
-        } else if (cmd == "exitreceiver") {
+        } else if (cmd == "rx_exit") {
             myDet->setReceiverOnline(ONLINE_FLAG, detPos);
             if (myDet->exitReceiver(detPos) == OK)
                 return std::string("Receiver shut down\n");
@@ -2514,7 +2514,7 @@ std::string slsDetectorCommand::cmdExitServer(int narg, const char * const args[
 std::string slsDetectorCommand::helpExitServer(int action) {
     std::ostringstream os;
     os << std::string("exitserver \t shuts down all the detector servers. Don't use it!!!!\n");
-    os << std::string("exitreceiver \t shuts down all the receiver servers.\n");
+    os << std::string("rx_exit \t shuts down all the receiver servers.\n");
     os << std::string("execcommand \t executes command in detector server. Don't use it if you do not know what you are doing.\n");
     os << std::string("rx_execcommand \t executes command in receiver server. Don't use it if you do not know what you are doing.\n");
     return os.str();
@@ -2643,7 +2643,7 @@ std::string slsDetectorCommand::cmdEnablefwrite(int narg, const char * const arg
     if (action == HELP_ACTION) {
         return helpEnablefwrite(action);
     }
-    if (cmd == "enablefwrite") {
+    if (cmd == "fwrite") {
         if (action == PUT_ACTION) {
             if (sscanf(args[1], "%d", &i))
                 myDet->setFileWrite(i, detPos);
@@ -2671,11 +2671,11 @@ std::string slsDetectorCommand::cmdEnablefwrite(int narg, const char * const arg
 std::string slsDetectorCommand::helpEnablefwrite(int action) {
     std::ostringstream os;
     if (action == GET_ACTION || action == HELP_ACTION) {
-        os << std::string("enablefwrite \t When Enabled writes the data into the file\n");
+        os << std::string("fwrite \t When Enabled writes the data into the file\n");
         os << std::string("masterfile \t When Enabled writes the master file\n");
     }
     if (action == PUT_ACTION || action == HELP_ACTION) {
-        os << std::string("enablefwrite i \t  should be 1 or 0\n");
+        os << std::string("fwrite i \t  should be 1 or 0\n");
         os << std::string("masterfile i \t  sets the master file write enable. should be 1 or 0\n");
     }
     return os.str();
@@ -2721,9 +2721,9 @@ std::string slsDetectorCommand::cmdFileIndex(int narg, const char * const args[]
 std::string slsDetectorCommand::helpFileIndex(int action) {
     std::ostringstream os;
     if (action == GET_ACTION || action == HELP_ACTION)
-        os << std::string("index \t  gets the file index for the next the data file\n");
+        os << std::string("findex \t  gets the file index for the next the data file\n");
     if (action == PUT_ACTION || action == HELP_ACTION)
-        os << std::string("index i \t  sets the fileindex for the next data file\n");
+        os << std::string("findex i \t  sets the fileindex for the next data file\n");
     return os.str();
 }
 

--- a/slsDetectorSoftware/src/slsDetectorCommand.cpp
+++ b/slsDetectorSoftware/src/slsDetectorCommand.cpp
@@ -532,9 +532,9 @@ slsDetectorCommand::slsDetectorCommand(multiSlsDetector *det) {
     ++i;
 
     /*! \page config
-   - <b>receiverversion</b> Gets the software version of receiver. Only get! \c Returns \c (long int) in hexadecimal
+   - <b>rx_version</b> Gets the software version of receiver. Only get! \c Returns \c (long int) in hexadecimal
 	 */
-    descrToFuncMap[i].m_pFuncName = "receiverversion";
+    descrToFuncMap[i].m_pFuncName = "rx_version";
     descrToFuncMap[i].m_pFuncPtr = &slsDetectorCommand::cmdSN;
     ++i;
 
@@ -1790,23 +1790,23 @@ slsDetectorCommand::slsDetectorCommand(multiSlsDetector *det) {
 	 */
 
     /*! \page receiver
-   - <b>receiver [s]</b> starts/stops the receiver to listen to detector packets. Options: [ \c start, \c stop]. \c Returns \c (string) status of receiver[ \c idle, \c running].
+   - <b>rx_status [s]</b> starts/stops the receiver to listen to detector packets. Options: [ \c start, \c stop]. \c Returns \c (string) status of receiver[ \c idle, \c running].
 	 */
-    descrToFuncMap[i].m_pFuncName = "receiver";
+    descrToFuncMap[i].m_pFuncName = "rx_status";
     descrToFuncMap[i].m_pFuncPtr = &slsDetectorCommand::cmdReceiver;
     ++i;
 
     /*! \page receiver
-   - <b>r_online [i]</b> sets/gets the receiver in online/offline mode. 1 is online, 0 is offline. Get is from shared memory. \c Returns \c (int)
+   - <b>rx_online [i]</b> sets/gets the receiver in online/offline mode. 1 is online, 0 is offline. Get is from shared memory. \c Returns \c (int)
 	 */
-    descrToFuncMap[i].m_pFuncName = "r_online";
+    descrToFuncMap[i].m_pFuncName = "rx_online";
     descrToFuncMap[i].m_pFuncPtr = &slsDetectorCommand::cmdOnline;
     ++i;
 
     /*! \page receiver
-   - <b>r_checkonline</b> Checks the receiver if it is online/offline mode. Only get! \c Returns (string) "All online" or "[list of offline hostnames] : Not online".
+   - <b>rx_checkonline</b> Checks the receiver if it is online/offline mode. Only get! \c Returns (string) "All online" or "[list of offline hostnames] : Not online".
 	 */
-    descrToFuncMap[i].m_pFuncName = "r_checkonline";
+    descrToFuncMap[i].m_pFuncName = "rx_checkonline";
     descrToFuncMap[i].m_pFuncPtr = &slsDetectorCommand::cmdOnline;
     ++i;
 
@@ -1832,23 +1832,23 @@ slsDetectorCommand::slsDetectorCommand(multiSlsDetector *det) {
     ++i;
 
     /*! \page receiver
-   - <b>r_lock [i]</b> locks/unlocks the receiver to communicate with only this client. 1 locks, 0 unlocks. \c Returns \c (int)
+   - <b>rx_lock [i]</b> locks/unlocks the receiver to communicate with only this client. 1 locks, 0 unlocks. \c Returns \c (int)
 	 */
-    descrToFuncMap[i].m_pFuncName = "r_lock";
+    descrToFuncMap[i].m_pFuncName = "rx_lock";
     descrToFuncMap[i].m_pFuncPtr = &slsDetectorCommand::cmdLock;
     ++i;
 
     /*! \page receiver
-   - <b>r_lastclient</b> gets the last client communicating with the receiver. Only get! \c Returns \c (int)
+   - <b>rx_lastclient</b> gets the last client communicating with the receiver. Only get! \c Returns \c (int)
 	 */
-    descrToFuncMap[i].m_pFuncName = "r_lastclient";
+    descrToFuncMap[i].m_pFuncName = "rx_lastclient";
     descrToFuncMap[i].m_pFuncPtr = &slsDetectorCommand::cmdLastClient;
     ++i;
 
     /*! \page receiver
-   - <b>r_readfreq [i]</b> sets/gets the stream frequency of data from receiver to client. i > 0 is the nth frame being streamed. 0 sets frequency to a default timer (200ms). \c Returns \c (int)
+   - <b>rx_readfreq [i]</b> sets/gets the stream frequency of data from receiver to client. i > 0 is the nth frame being streamed. 0 sets frequency to a default timer (200ms). \c Returns \c (int)
 	 */
-    descrToFuncMap[i].m_pFuncName = "r_readfreq";
+    descrToFuncMap[i].m_pFuncName = "rx_readfreq";
     descrToFuncMap[i].m_pFuncPtr = &slsDetectorCommand::cmdReceiver;
     ++i;
 
@@ -1860,30 +1860,30 @@ slsDetectorCommand::slsDetectorCommand(multiSlsDetector *det) {
     ++i;
 
     /*! \page receiver
-   - <b>r_silent [i]</b> sets/gets receiver in silent mode, ie. it will not print anything during real time acquisition. 1 sets, 0 unsets. \c Returns \c (int)
+   - <b>rx_silent [i]</b> sets/gets receiver in silent mode, ie. it will not print anything during real time acquisition. 1 sets, 0 unsets. \c Returns \c (int)
 	 */
-    descrToFuncMap[i].m_pFuncName = "r_silent";
+    descrToFuncMap[i].m_pFuncName = "rx_silent";
     descrToFuncMap[i].m_pFuncPtr = &slsDetectorCommand::cmdReceiver;
     ++i;
 
     /*! \page receiver
-    - <b>r_framesperfile [i]</b> sets/gets the frames per file in receiver to i. 0 means infinite or all frames in a single file. \c Returns \c (int)
+    - <b>rx_framesperfile [i]</b> sets/gets the frames per file in receiver to i. 0 means infinite or all frames in a single file. \c Returns \c (int)
 	 */
-    descrToFuncMap[i].m_pFuncName = "r_framesperfile";
+    descrToFuncMap[i].m_pFuncName = "rx_framesperfile";
     descrToFuncMap[i].m_pFuncPtr = &slsDetectorCommand::cmdReceiver;
     ++i;
 
     /*! \page receiver
-    - <b>r_discardpolicy</b> sets/gets the frame discard policy in the receiver. nodiscard (default) - discards nothing, discardempty - discard only empty frames, discardpartial(fastest) - discards all partial frames. \c Returns \c (int)
+    - <b>rx_discardpolicy</b> sets/gets the frame discard policy in the receiver. nodiscard (default) - discards nothing, discardempty - discard only empty frames, discardpartial(fastest) - discards all partial frames. \c Returns \c (int)
 	 */
-    descrToFuncMap[i].m_pFuncName = "r_discardpolicy";
+    descrToFuncMap[i].m_pFuncName = "rx_discardpolicy";
     descrToFuncMap[i].m_pFuncPtr = &slsDetectorCommand::cmdReceiver;
     ++i;
 
     /*! \page receiver
-    - <b>r_padding</b> sets/gets the frame padding in the receiver. 0 does not pad partial frames(fastest), 1 (default) pads partial frames. \c Returns \c (int)
+    - <b>rx_padding</b> sets/gets the frame padding in the receiver. 0 does not pad partial frames(fastest), 1 (default) pads partial frames. \c Returns \c (int)
 	 */
-    descrToFuncMap[i].m_pFuncName = "r_padding";
+    descrToFuncMap[i].m_pFuncName = "rx_padding";
     descrToFuncMap[i].m_pFuncPtr = &slsDetectorCommand::cmdReceiver;
     ++i;
 
@@ -2205,13 +2205,13 @@ std::string slsDetectorCommand::cmdAcquire(int narg, const char * const args[], 
     }
 
     myDet->setOnline(ONLINE_FLAG, detPos);
-    int r_online = myDet->setReceiverOnline(ONLINE_FLAG, detPos);
+    int rx_online = myDet->setReceiverOnline(ONLINE_FLAG, detPos);
 
 
 
     if (myDet->acquire() == FAIL)
         return std::string("acquire failed");
-    if (r_online) {
+    if (rx_online) {
         char answer[100];
         sprintf(answer, "\nAcquired %d", myDet->getFramesCaughtByReceiver(detPos));
         return std::string(answer);
@@ -3195,7 +3195,7 @@ std::string slsDetectorCommand::cmdLock(int narg, const char * const args[], int
         sprintf(ans, "%d", myDet->lockServer(-1, detPos));
     }
 
-    else if (cmd == "r_lock") {
+    else if (cmd == "rx_lock") {
         myDet->setReceiverOnline(ONLINE_FLAG, detPos);
         if (action == PUT_ACTION) {
             if (sscanf(args[1], "%d", &val))
@@ -3217,11 +3217,11 @@ std::string slsDetectorCommand::helpLock(int action) {
     std::ostringstream os;
     if (action == PUT_ACTION || action == HELP_ACTION) {
         os << "lock i \n locks (1) or unlocks (0) the detector to communicate to this client" << std::endl;
-        os << "r_lock i \n locks (1) or unlocks (0) the receiver to communicate to this client" << std::endl;
+        os << "rx_lock i \n locks (1) or unlocks (0) the receiver to communicate to this client" << std::endl;
     }
     if (action == GET_ACTION || action == HELP_ACTION) {
         os << "lock \n returns the detector lock status" << std::endl;
-        os << "r_lock \n returns the receiver lock status" << std::endl;
+        os << "rx_lock \n returns the receiver lock status" << std::endl;
     }
     return os.str();
 }
@@ -3239,7 +3239,7 @@ std::string slsDetectorCommand::cmdLastClient(int narg, const char * const args[
         return myDet->getLastClientIP(detPos);
     }
 
-    else if (cmd == "r_lastclient") {
+    else if (cmd == "rx_lastclient") {
         myDet->setReceiverOnline(ONLINE_FLAG, detPos);
         return myDet->getReceiverLastClientIP(detPos);
     }
@@ -3252,7 +3252,7 @@ std::string slsDetectorCommand::helpLastClient(int action) {
     std::ostringstream os;
     if (action == GET_ACTION || action == HELP_ACTION) {
         os << "lastclient \n returns the last client communicating with the detector" << std::endl;
-        os << "r_lastclient \n returns the last client communicating with the receiver" << std::endl;
+        os << "rx_lastclient \n returns the last client communicating with the receiver" << std::endl;
     }
     return os.str();
 }
@@ -3301,7 +3301,7 @@ std::string slsDetectorCommand::cmdOnline(int narg, const char * const args[], i
         }
         int ret = myDet->setDeactivatedRxrPaddingMode(-1, detPos);
         sprintf(ans, "%d %s", myDet->activate(-1, detPos), ret == 1 ? "padding" : (ret == 0 ? "nopadding" : "unknown"));
-    } else if (cmd == "r_online") {
+    } else if (cmd == "rx_online") {
         if (action == PUT_ACTION) {
             if (sscanf(args[1], "%d", &ival))
                 myDet->setReceiverOnline(ival, detPos);
@@ -3328,14 +3328,14 @@ std::string slsDetectorCommand::helpOnline(int action) {
     std::ostringstream os;
     if (action == PUT_ACTION || action == HELP_ACTION) {
         os << "online i \n sets the detector in online (1) or offline (0) mode" << std::endl;
-        os << "r_online i \n sets the receiver in online (1) or offline (0) mode" << std::endl;
+        os << "rx_online i \n sets the receiver in online (1) or offline (0) mode" << std::endl;
         os << "activate i [p]\n sets the detector in  activated (1) or deactivated (0) mode (does not send data).  p is optional and can be padding (default) or nonpadding for receivers for deactivated detectors. Only for Eiger." << std::endl;
     }
     if (action == GET_ACTION || action == HELP_ACTION) {
         os << "online \n gets the detector online (1) or offline (0) mode" << std::endl;
         os << "checkonline \n returns the hostnames of all detectors in offline mode" << std::endl;
-        os << "r_online \n gets the receiver online (1) or offline (0) mode" << std::endl;
-        os << "r_checkonline \n returns the hostnames of all receiver in offline mode" << std::endl;
+        os << "rx_online \n gets the receiver online (1) or offline (0) mode" << std::endl;
+        os << "rx_checkonline \n returns the hostnames of all receiver in offline mode" << std::endl;
         os << "activate \n gets the detector activated (1) or deactivated (0) mode. And padding or nonpadding for the deactivated receiver. Only for Eiger." << std::endl;
     }
     return os.str();
@@ -3655,7 +3655,7 @@ std::string slsDetectorCommand::cmdSN(int narg, const char * const args[], int a
         return std::string(answer);
     }
 
-    if (cmd == "receiverversion") {
+    if (cmd == "rx_version") {
         myDet->setReceiverOnline(ONLINE_FLAG, detPos);
         int64_t retval = myDet->getReceiverSoftwareVersion(detPos);
         if (retval < 0)
@@ -3695,7 +3695,7 @@ std::string slsDetectorCommand::helpSN(int action) {
         os << "detectorversion \n gets the firmware version of the detector" << std::endl;
         os << "softwareversion \n gets the software version of the detector" << std::endl;
         os << "thisversion \n gets the version of this software" << std::endl;
-        os << "receiverversion \n gets the version of the receiver" << std::endl;
+        os << "rx_version \n gets the version of the receiver" << std::endl;
     }
     return os.str();
 }
@@ -5064,7 +5064,7 @@ std::string slsDetectorCommand::cmdReceiver(int narg, const char * const args[],
     myDet->setOnline(ONLINE_FLAG, detPos);
     myDet->setReceiverOnline(ONLINE_FLAG, detPos);
 
-    if (cmd == "receiver") {
+    if (cmd == "rx_status") {
         if (action == PUT_ACTION) {
             if (!strcasecmp(args[1], "start"))
                 myDet->startReceiver(detPos);
@@ -5104,7 +5104,7 @@ std::string slsDetectorCommand::cmdReceiver(int narg, const char * const args[],
             sprintf(answer, "%lu", myDet->getReceiverCurrentFrameIndex(detPos));
             return std::string(answer);
         }
-    } else if (cmd == "r_readfreq") {
+    } else if (cmd == "rx_readfreq") {
         if (action == PUT_ACTION) {
             if (!sscanf(args[1], "%d", &ival))
                 return std::string("Could not scan read frequency mode ") + std::string(args[1]);
@@ -5140,10 +5140,10 @@ std::string slsDetectorCommand::cmdReceiver(int narg, const char * const args[],
 
     }
 
-    else if (cmd == "r_silent") {
+    else if (cmd == "rx_silent") {
         if (action == PUT_ACTION) {
             if (!sscanf(args[1], "%d", &ival))
-                return std::string("Could not scan r_online input ") + std::string(args[1]);
+                return std::string("Could not scan rx_online input ") + std::string(args[1]);
             if (ival >= 0)
                 sprintf(answer, "%d", myDet->setReceiverSilentMode(ival, detPos));
         } else
@@ -5152,7 +5152,7 @@ std::string slsDetectorCommand::cmdReceiver(int narg, const char * const args[],
 
     }
 
-    else if (cmd == "r_framesperfile") {
+    else if (cmd == "rx_framesperfile") {
         if (action == PUT_ACTION) {
             if (sscanf(args[1], "%d", &ival)) {
                 myDet->setFramesPerFile(ival, detPos);
@@ -5164,7 +5164,7 @@ std::string slsDetectorCommand::cmdReceiver(int narg, const char * const args[],
         return std::string(answer);
     }
 
-    else if (cmd == "r_discardpolicy") {
+    else if (cmd == "rx_discardpolicy") {
         if (action == PUT_ACTION) {
             frameDiscardPolicy f = myDet->getReceiverFrameDiscardPolicy(std::string(args[1]));
             if (f == GET_FRAME_DISCARD_POLICY)
@@ -5174,7 +5174,7 @@ std::string slsDetectorCommand::cmdReceiver(int narg, const char * const args[],
         return myDet->getReceiverFrameDiscardPolicy(myDet->setReceiverFramesDiscardPolicy(GET_FRAME_DISCARD_POLICY, detPos));
     }
 
-    else if (cmd == "r_padding") {
+    else if (cmd == "rx_padding") {
         if (action == PUT_ACTION) {
             if (sscanf(args[1], "%d", &ival)) {
                 myDet->setPartialFramesPadding(ival, detPos);
@@ -5209,13 +5209,13 @@ std::string slsDetectorCommand::helpReceiver(int action) {
     if (action == PUT_ACTION || action == HELP_ACTION) {
         os << "receiver [status] \t starts/stops the receiver to listen to detector packets. - can be start, stop." << std::endl;
         os << "resetframescaught [any value] \t resets frames caught by receiver" << std::endl;
-        os << "r_readfreq \t sets the gui read frequency of the receiver, 0 if gui requests frame, >0 if receiver sends every nth frame to gui" << std::endl;
+        os << "rx_readfreq \t sets the gui read frequency of the receiver, 0 if gui requests frame, >0 if receiver sends every nth frame to gui" << std::endl;
         os << "tengiga \t sets system to be configure for 10Gbe if set to 1, else 1Gbe if set to 0" << std::endl;
         os << "rx_fifodepth [val]\t sets receiver fifo depth to val" << std::endl;
-        os << "r_silent [i]\t sets receiver in silent mode, ie. it will not print anything during real time acquisition. 1 sets, 0 unsets." << std::endl;
-        os << "r_framesperfile s\t sets the number of frames per file in receiver. 0 means infinite or all frames in a single file." << std::endl;
-        os << "r_discardpolicy s\t sets the frame discard policy in the receiver. nodiscard (default) - discards nothing, discardempty - discard only empty frames, discardpartial(fastest) - discards all partial frames." << std::endl;
-        os << "r_padding s\t enables/disables partial frames to be padded in the receiver. 0 does not pad partial frames(fastest), 1 (default) pads partial frames." << std::endl;
+        os << "rx_silent [i]\t sets receiver in silent mode, ie. it will not print anything during real time acquisition. 1 sets, 0 unsets." << std::endl;
+        os << "rx_framesperfile s\t sets the number of frames per file in receiver. 0 means infinite or all frames in a single file." << std::endl;
+        os << "rx_discardpolicy s\t sets the frame discard policy in the receiver. nodiscard (default) - discards nothing, discardempty - discard only empty frames, discardpartial(fastest) - discards all partial frames." << std::endl;
+        os << "rx_padding s\t enables/disables partial frames to be padded in the receiver. 0 does not pad partial frames(fastest), 1 (default) pads partial frames." << std::endl;
         os << "rx_jsonaddheader [t]\n sets additional json header to be streamed "
               "out with the zmq from receiver. Default is empty. t must be in the format '\"label1\":\"value1\",\"label2\":\"value2\"' etc."
               "Use only if it needs to be processed by an intermediate process." << std::endl;
@@ -5226,13 +5226,13 @@ std::string slsDetectorCommand::helpReceiver(int action) {
         os << "receiver \t returns the status of receiver - can be running or idle" << std::endl;
         os << "framescaught \t returns the number of frames caught by receiver(average for multi)" << std::endl;
         os << "frameindex \t returns the current frame index of receiver(average for multi)" << std::endl;
-        os << "r_readfreq \t returns the gui read frequency of the receiver" << std::endl;
+        os << "rx_readfreq \t returns the gui read frequency of the receiver" << std::endl;
         os << "tengiga \t returns 1 if the system is configured for 10Gbe else 0 for 1Gbe" << std::endl;
         os << "rx_fifodepth \t returns receiver fifo depth" << std::endl;
-        os << "r_silent \t returns receiver silent mode enable. 1 is silent, 0 not silent." << std::endl;
-        os << "r_framesperfile \t gets the number of frames per file in receiver. 0 means infinite or all frames in a single file." << std::endl;
-        os << "r_discardpolicy \t gets the frame discard policy in the receiver. nodiscard (default) - discards nothing, discardempty - discard only empty frames, discardpartial(fastest) - discards all partial frames." << std::endl;
-        os << "r_padding \t gets partial frames padding enable in the receiver. 0 does not pad partial frames(fastest), 1 (default) pads partial frames." << std::endl;
+        os << "rx_silent \t returns receiver silent mode enable. 1 is silent, 0 not silent." << std::endl;
+        os << "rx_framesperfile \t gets the number of frames per file in receiver. 0 means infinite or all frames in a single file." << std::endl;
+        os << "rx_discardpolicy \t gets the frame discard policy in the receiver. nodiscard (default) - discards nothing, discardempty - discard only empty frames, discardpartial(fastest) - discards all partial frames." << std::endl;
+        os << "rx_padding \t gets partial frames padding enable in the receiver. 0 does not pad partial frames(fastest), 1 (default) pads partial frames." << std::endl;
         os << "rx_jsonaddheader \n gets additional json header to be streamed "
               "out with the zmq from receiver." << std::endl;
         os << "rx_jsonpara [k] \n gets value of additional json header parameter k to be streamed out with the zmq from receiver. If empty, then no parameter found." << std::endl;

--- a/slsDetectorSoftware/src/slsDetectorCommand.cpp
+++ b/slsDetectorSoftware/src/slsDetectorCommand.cpp
@@ -497,9 +497,9 @@ slsDetectorCommand::slsDetectorCommand(multiSlsDetector *det) {
     ++i;
 
     /*! \page config
-   - <b>checkrecversion</b> Checks the version compatibility with receiver server (if rx_hostname is in shared memory). Only get! Only for Eiger, Jungfrau & Gotthard. \c Returns \c ("compatible", "incompatible")
+   - <b>rx_checkversion</b> Checks the version compatibility with receiver server (if rx_hostname is in shared memory). Only get! Only for Eiger, Jungfrau & Gotthard. \c Returns \c ("compatible", "incompatible")
 	 */
-    descrToFuncMap[i].m_pFuncName = "checkrecversion";
+    descrToFuncMap[i].m_pFuncName = "rx_checkversion";
     descrToFuncMap[i].m_pFuncPtr = &slsDetectorCommand::cmdSN;
     ++i;
 
@@ -3673,7 +3673,7 @@ std::string slsDetectorCommand::cmdSN(int narg, const char * const args[], int a
         return std::string(answer);
     }
 
-    if (cmd == "checkrecversion") {
+    if (cmd == "rx_checkversion") {
         myDet->setReceiverOnline(ONLINE_FLAG, detPos);
         int retval = myDet->checkReceiverVersionCompatibility(detPos);
         if (retval < 0)
@@ -3690,7 +3690,7 @@ std::string slsDetectorCommand::helpSN(int action) {
     std::ostringstream os;
     if (action == GET_ACTION || action == HELP_ACTION) {
         os << "checkdetversion \n gets the version compatibility with detector server (if hostname is in shared memory). Only for Eiger, Jungfrau & Gotthard. Prints compatible/ incompatible." << std::endl;
-        os << "checkrecversion \n gets the version compatibility with receiver server (if rx_hostname is in shared memory). Only for Eiger, Jungfrau & Gotthard. Prints compatible/ incompatible." << std::endl;
+        os << "rx_checkversion \n gets the version compatibility with receiver server (if rx_hostname is in shared memory). Only for Eiger, Jungfrau & Gotthard. Prints compatible/ incompatible." << std::endl;
         os << "detectornumber \n gets the serial number of the detector (MAC)" << std::endl;
         os << "detectorversion \n gets the firmware version of the detector" << std::endl;
         os << "softwareversion \n gets the software version of the detector" << std::endl;

--- a/slsDetectorSoftware/src/slsDetectorCommand.cpp
+++ b/slsDetectorSoftware/src/slsDetectorCommand.cpp
@@ -1550,9 +1550,9 @@ slsDetectorCommand::slsDetectorCommand(multiSlsDetector *det) {
     ++i;
 
     /*! \page output
-    - <b>overwrite [i]</b> enables(1) /disables(0) file overwriting. \c Returns \c (int)
+    - <b>rx_overwrite [i]</b> enables(1) /disables(0) file overwriting. \c Returns \c (int)
 	 */
-    descrToFuncMap[i].m_pFuncName = "overwrite";
+    descrToFuncMap[i].m_pFuncName = "rx_overwrite";
     descrToFuncMap[i].m_pFuncPtr = &slsDetectorCommand::cmdOverwrite;
     ++i;
 
@@ -2692,7 +2692,7 @@ std::string slsDetectorCommand::cmdOverwrite(int narg, const char * const args[]
         if (sscanf(args[1], "%d", &i))
             myDet->setFileOverWrite(i, detPos);
         else
-            return std::string("could not decode overwrite");
+            return std::string("could not decode rx_overwrite");
     }
     sprintf(ans, "%d", myDet->getFileOverWrite(detPos));
     return std::string(ans);
@@ -2701,9 +2701,9 @@ std::string slsDetectorCommand::cmdOverwrite(int narg, const char * const args[]
 std::string slsDetectorCommand::helpOverwrite(int action) {
     std::ostringstream os;
     if (action == GET_ACTION || action == HELP_ACTION)
-        os << std::string("overwrite \t When Enabled overwrites files\n");
+        os << std::string("rx_overwrite \t When Enabled overwrites files\n");
     if (action == PUT_ACTION || action == HELP_ACTION)
-        os << std::string("overwrite i \t  should be 1 or 0 or -1\n");
+        os << std::string("rx_overwrite i \t  should be 1 or 0 or -1\n");
     return os.str();
 }
 

--- a/slsDetectorSoftware/src/slsDetectorCommand.cpp
+++ b/slsDetectorSoftware/src/slsDetectorCommand.cpp
@@ -1522,9 +1522,9 @@ slsDetectorCommand::slsDetectorCommand(multiSlsDetector *det) {
 	 */
 
     /*! \page output
-   - <b>outdir [dir]</b> Sets/gets the file output directory. \c Returns \c (string)
+   - <b>fpath [dir]</b> Sets/gets the file output directory. \c Returns \c (string)
 	 */
-    descrToFuncMap[i].m_pFuncName = "outdir";
+    descrToFuncMap[i].m_pFuncName = "fpath";
     descrToFuncMap[i].m_pFuncPtr = &slsDetectorCommand::cmdOutDir;
     ++i;
 
@@ -1557,16 +1557,16 @@ slsDetectorCommand::slsDetectorCommand(multiSlsDetector *det) {
     ++i;
 
     /*! \page output
-    - <b>fileformat [i]</b> sets/gets the file format for data in receiver. Options: [binary, hdf5]. \c Returns \c (string)
+    - <b>fformat [i]</b> sets/gets the file format for data in receiver. Options: [binary, hdf5]. \c Returns \c (string)
 	 */
-    descrToFuncMap[i].m_pFuncName = "fileformat";
+    descrToFuncMap[i].m_pFuncName = "fformat";
     descrToFuncMap[i].m_pFuncPtr = &slsDetectorCommand::cmdFileName;
     ++i;
 
      /*! \page output
-    - <b>masterfile [i]</b> sets/gets the master file write enable in receiver. \c Returns \c (int)
+    - <b>fmaster [i]</b> sets/gets the master file write enable in receiver. \c Returns \c (int)
 	 */
-    descrToFuncMap[i].m_pFuncName = "masterfile";
+    descrToFuncMap[i].m_pFuncName = "fmaster";
     descrToFuncMap[i].m_pFuncPtr = &slsDetectorCommand::cmdEnablefwrite;
     ++i;   
 
@@ -2593,9 +2593,9 @@ std::string slsDetectorCommand::cmdOutDir(int narg, const char * const args[], i
 std::string slsDetectorCommand::helpOutDir(int action) {
     std::ostringstream os;
     if (action == GET_ACTION || action == HELP_ACTION)
-        os << std::string("outdir \t  gets the directory where the output files will be written\n");
+        os << std::string("fpath \t  gets the directory where the output files will be written\n");
     if (action == PUT_ACTION || action == HELP_ACTION)
-        os << std::string("outdir dir \t  sets the directory where the output files will be written\n");
+        os << std::string("fpath dir \t  sets the directory where the output files will be written\n");
     return os.str();
 }
 
@@ -2608,7 +2608,7 @@ std::string slsDetectorCommand::cmdFileName(int narg, const char * const args[],
             myDet->setFileName(std::string(args[1]), detPos);
 
         return std::string(myDet->getFileName(detPos));
-    } else if (cmd == "fileformat") {
+    } else if (cmd == "fformat") {
         if (action == PUT_ACTION) {
             if (std::string(args[1]) == "binary")
                 myDet->setFileFormat(BINARY, detPos);
@@ -2626,11 +2626,11 @@ std::string slsDetectorCommand::helpFileName(int action) {
     std::ostringstream os;
     if (action == GET_ACTION || action == HELP_ACTION) {
         os << std::string("fname \t  gets the filename for the data without index and extension\n");
-        os << std::string("fileformat \t  gets the file format for data\n");
+        os << std::string("fformat \t  gets the file format for data\n");
     }
     if (action == PUT_ACTION || action == HELP_ACTION) {
         os << std::string("fname s \t  sets the filename for the data (index and extension will be automatically appended)\n");
-        os << std::string("fileformat s \t  sets the file format for the data (binary, hdf5)\n");
+        os << std::string("fformat s \t  sets the file format for the data (binary, hdf5)\n");
     }
     return os.str();
 }
@@ -2654,7 +2654,7 @@ std::string slsDetectorCommand::cmdEnablefwrite(int narg, const char * const arg
         return std::string(ans);
     }
 
-    else if (cmd == "masterfile") {
+    else if (cmd == "fmaster") {
         if (action == PUT_ACTION) {
             if (sscanf(args[1], "%d", &i))
                 myDet->setMasterFileWrite(i, detPos);
@@ -2672,11 +2672,11 @@ std::string slsDetectorCommand::helpEnablefwrite(int action) {
     std::ostringstream os;
     if (action == GET_ACTION || action == HELP_ACTION) {
         os << std::string("fwrite \t When Enabled writes the data into the file\n");
-        os << std::string("masterfile \t When Enabled writes the master file\n");
+        os << std::string("fmaster \t When Enabled writes the master file\n");
     }
     if (action == PUT_ACTION || action == HELP_ACTION) {
         os << std::string("fwrite i \t  should be 1 or 0\n");
-        os << std::string("masterfile i \t  sets the master file write enable. should be 1 or 0\n");
+        os << std::string("fmaster i \t  sets the master file write enable. should be 1 or 0\n");
     }
     return os.str();
 }

--- a/slsDetectorSoftware/src/slsDetectorCommand.cpp
+++ b/slsDetectorSoftware/src/slsDetectorCommand.cpp
@@ -1550,9 +1550,9 @@ slsDetectorCommand::slsDetectorCommand(multiSlsDetector *det) {
     ++i;
 
     /*! \page output
-    - <b>rx_overwrite [i]</b> enables(1) /disables(0) file overwriting. \c Returns \c (int)
+    - <b>foverwrite [i]</b> enables(1) /disables(0) file overwriting. \c Returns \c (int)
 	 */
-    descrToFuncMap[i].m_pFuncName = "rx_overwrite";
+    descrToFuncMap[i].m_pFuncName = "foverwrite";
     descrToFuncMap[i].m_pFuncPtr = &slsDetectorCommand::cmdOverwrite;
     ++i;
 
@@ -2692,7 +2692,7 @@ std::string slsDetectorCommand::cmdOverwrite(int narg, const char * const args[]
         if (sscanf(args[1], "%d", &i))
             myDet->setFileOverWrite(i, detPos);
         else
-            return std::string("could not decode rx_overwrite");
+            return std::string("could not decode foverwrite");
     }
     sprintf(ans, "%d", myDet->getFileOverWrite(detPos));
     return std::string(ans);
@@ -2701,9 +2701,9 @@ std::string slsDetectorCommand::cmdOverwrite(int narg, const char * const args[]
 std::string slsDetectorCommand::helpOverwrite(int action) {
     std::ostringstream os;
     if (action == GET_ACTION || action == HELP_ACTION)
-        os << std::string("rx_overwrite \t When Enabled overwrites files\n");
+        os << std::string("foverwrite \t When Enabled overwrites files\n");
     if (action == PUT_ACTION || action == HELP_ACTION)
-        os << std::string("rx_overwrite i \t  should be 1 or 0 or -1\n");
+        os << std::string("foverwrite i \t  should be 1 or 0 or -1\n");
     return os.str();
 }
 

--- a/slsDetectorSoftware/tests/test-multiSlsDetectorClient.cpp
+++ b/slsDetectorSoftware/tests/test-multiSlsDetectorClient.cpp
@@ -129,21 +129,21 @@ TEST_CASE("enableoverwrite", "[.cmd]") {
 //     }
 // }
 
-TEST_CASE("masterfile", "[.cmd]") {
+TEST_CASE("fmaster", "[.cmd]") {
     {
         std::ostringstream oss;
-        multiSlsDetectorClient("masterfile 0", PUT, nullptr, oss);
-        REQUIRE(oss.str() == "masterfile 0\n");
+        multiSlsDetectorClient("fmaster 0", PUT, nullptr, oss);
+        REQUIRE(oss.str() == "fmaster 0\n");
     }
     {
         std::ostringstream oss;
-        multiSlsDetectorClient("masterfile", GET, nullptr, oss);
-        REQUIRE(oss.str() == "masterfile 0\n");
+        multiSlsDetectorClient("fmaster", GET, nullptr, oss);
+        REQUIRE(oss.str() == "fmaster 0\n");
     }
     {
         std::ostringstream oss;
-        multiSlsDetectorClient("masterfile 1", PUT, nullptr, oss);
-        REQUIRE(oss.str() == "masterfile 1\n");
+        multiSlsDetectorClient("fmaster 1", PUT, nullptr, oss);
+        REQUIRE(oss.str() == "fmaster 1\n");
     }
 }
 

--- a/slsDetectorSoftware/tests/test-multiSlsDetectorClient.cpp
+++ b/slsDetectorSoftware/tests/test-multiSlsDetectorClient.cpp
@@ -3,6 +3,8 @@
 #include "sls_detector_defs.h"
 #include <sstream>
 
+#include "tests/globals.h"
+
 auto GET = slsDetectorDefs::GET_ACTION;
 auto PUT = slsDetectorDefs::PUT_ACTION;
 
@@ -47,26 +49,26 @@ TEST_CASE("frames", "[.cmd]") {
     }
 }
 
-TEST_CASE("receiver", "[.cmd]") {
+TEST_CASE("rx_status", "[.cmd]") {
     {
         std::ostringstream oss;
-        multiSlsDetectorClient("receiver start", PUT, nullptr, oss);
-        REQUIRE(oss.str() == "receiver running\n");
+        multiSlsDetectorClient("rx_status start", PUT, nullptr, oss);
+        REQUIRE(oss.str() == "rx_status running\n");
     }
     {
         std::ostringstream oss;
-        multiSlsDetectorClient("receiver", GET, nullptr, oss);
-        REQUIRE(oss.str() == "receiver running\n");
+        multiSlsDetectorClient("rx_status", GET, nullptr, oss);
+        REQUIRE(oss.str() == "rx_status running\n");
     }
     {
         std::ostringstream oss;
-        multiSlsDetectorClient("receiver stop", PUT, nullptr, oss);
-        REQUIRE(oss.str() == "receiver idle\n");
+        multiSlsDetectorClient("rx_status stop", PUT, nullptr, oss);
+        REQUIRE(oss.str() == "rx_status idle\n");
     }
     {
         std::ostringstream oss;
-        multiSlsDetectorClient("receiver", GET, nullptr, oss);
-        REQUIRE(oss.str() == "receiver idle\n");
+        multiSlsDetectorClient("rx_status", GET, nullptr, oss);
+        REQUIRE(oss.str() == "rx_status idle\n");
     }
 }
 
@@ -229,21 +231,21 @@ TEST_CASE("resetframescaught get framescaught", "[.cmd]") {
     }
 }
 
-TEST_CASE("r_silent", "[.cmd]") {
+TEST_CASE("rx_silent", "[.cmd]") {
     {
         std::ostringstream oss;
-        multiSlsDetectorClient("r_silent 1", PUT, nullptr, oss);
-        REQUIRE(oss.str() == "r_silent 1\n");
+        multiSlsDetectorClient("rx_silent 1", PUT, nullptr, oss);
+        REQUIRE(oss.str() == "rx_silent 1\n");
     }
     {
         std::ostringstream oss;
-        multiSlsDetectorClient("r_silent", GET, nullptr, oss);
-        REQUIRE(oss.str() == "r_silent 1\n");
+        multiSlsDetectorClient("rx_silent", GET, nullptr, oss);
+        REQUIRE(oss.str() == "rx_silent 1\n");
     }
     {
         std::ostringstream oss;
-        multiSlsDetectorClient("r_silent 0", PUT, nullptr, oss);
-        REQUIRE(oss.str() == "r_silent 0\n");
+        multiSlsDetectorClient("rx_silent 0", PUT, nullptr, oss);
+        REQUIRE(oss.str() == "rx_silent 0\n");
     }
 }
 
@@ -275,63 +277,131 @@ TEST_CASE("r_silent", "[.cmd]") {
 //     REQUIRE(oss.str() == "rx_udpsocksize 104857600\n");
 // }
 
-TEST_CASE("r_framesperfile", "[.cmd]") {
+TEST_CASE("rx_framesperfile", "[.cmd]") {
     {
         std::ostringstream oss;
-        multiSlsDetectorClient("r_framesperfile 50", PUT, nullptr, oss);
-        REQUIRE(oss.str() == "r_framesperfile 50\n");
+        multiSlsDetectorClient("rx_framesperfile 50", PUT, nullptr, oss);
+        REQUIRE(oss.str() == "rx_framesperfile 50\n");
     }
     {
         std::ostringstream oss;
-        multiSlsDetectorClient("r_framesperfile", GET, nullptr, oss);
-        REQUIRE(oss.str() == "r_framesperfile 50\n");
+        multiSlsDetectorClient("rx_framesperfile", GET, nullptr, oss);
+        REQUIRE(oss.str() == "rx_framesperfile 50\n");
     }
     {
         std::ostringstream oss;
-        multiSlsDetectorClient("r_framesperfile 10000", PUT, nullptr, oss);
-        REQUIRE(oss.str() == "r_framesperfile 10000\n");
-    }
-}
-
-TEST_CASE("r_discardpolicy", "[.cmd]") {
-    {
-        std::ostringstream oss;
-        multiSlsDetectorClient("r_discardpolicy discardempty", PUT, nullptr,
-                               oss);
-        REQUIRE(oss.str() == "r_discardpolicy discardempty\n");
-    }
-    {
-        std::ostringstream oss;
-        multiSlsDetectorClient("r_discardpolicy", GET, nullptr, oss);
-        REQUIRE(oss.str() == "r_discardpolicy discardempty\n");
-    }
-    {
-        std::ostringstream oss;
-        multiSlsDetectorClient("r_discardpolicy discardpartial", PUT, nullptr,
-                               oss);
-        REQUIRE(oss.str() == "r_discardpolicy discardpartial\n");
-    }
-    {
-        std::ostringstream oss;
-        multiSlsDetectorClient("r_discardpolicy nodiscard", PUT, nullptr, oss);
-        REQUIRE(oss.str() == "r_discardpolicy nodiscard\n");
+        multiSlsDetectorClient("rx_framesperfile 10000", PUT, nullptr, oss);
+        REQUIRE(oss.str() == "rx_framesperfile 10000\n");
     }
 }
 
-TEST_CASE("r_padding", "[.cmd]") {
+TEST_CASE("rx_discardpolicy", "[.cmd]") {
     {
         std::ostringstream oss;
-        multiSlsDetectorClient("r_padding 0", PUT, nullptr, oss);
-        REQUIRE(oss.str() == "r_padding 0\n");
+        multiSlsDetectorClient("rx_discardpolicy discardempty", PUT, nullptr,
+                               oss);
+        REQUIRE(oss.str() == "rx_discardpolicy discardempty\n");
     }
     {
         std::ostringstream oss;
-        multiSlsDetectorClient("r_padding", GET, nullptr, oss);
-        REQUIRE(oss.str() == "r_padding 0\n");
+        multiSlsDetectorClient("rx_discardpolicy", GET, nullptr, oss);
+        REQUIRE(oss.str() == "rx_discardpolicy discardempty\n");
     }
     {
         std::ostringstream oss;
-        multiSlsDetectorClient("r_padding 1", PUT, nullptr, oss);
-        REQUIRE(oss.str() == "r_padding 1\n");
+        multiSlsDetectorClient("rx_discardpolicy discardpartial", PUT, nullptr,
+                               oss);
+        REQUIRE(oss.str() == "rx_discardpolicy discardpartial\n");
     }
+    {
+        std::ostringstream oss;
+        multiSlsDetectorClient("rx_discardpolicy nodiscard", PUT, nullptr, oss);
+        REQUIRE(oss.str() == "rx_discardpolicy nodiscard\n");
+    }
+}
+
+TEST_CASE("rx_padding", "[.cmd]") {
+    {
+        std::ostringstream oss;
+        multiSlsDetectorClient("rx_padding 0", PUT, nullptr, oss);
+        REQUIRE(oss.str() == "rx_padding 0\n");
+    }
+    {
+        std::ostringstream oss;
+        multiSlsDetectorClient("rx_padding", GET, nullptr, oss);
+        REQUIRE(oss.str() == "rx_padding 0\n");
+    }
+    {
+        std::ostringstream oss;
+        multiSlsDetectorClient("rx_padding 1", PUT, nullptr, oss);
+        REQUIRE(oss.str() == "rx_padding 1\n");
+    }
+}
+
+TEST_CASE("rx_readfreq", "[.cmd]") {
+    {
+        std::ostringstream oss;
+        multiSlsDetectorClient("rx_readfreq 1", PUT, nullptr, oss);
+        REQUIRE(oss.str() == "rx_readfreq 1\n");
+    }
+    {
+        std::ostringstream oss;
+        multiSlsDetectorClient("rx_readfreq", GET, nullptr, oss);
+        REQUIRE(oss.str() == "rx_readfreq 1\n");
+    }
+    {
+        std::ostringstream oss;
+        multiSlsDetectorClient("rx_readfreq 0", PUT, nullptr, oss);
+        REQUIRE(oss.str() == "rx_readfreq 0\n");
+    }
+}
+
+TEST_CASE("rx_lock", "[.cmd]") {
+    {
+        std::ostringstream oss;
+        multiSlsDetectorClient("rx_lock 1", PUT, nullptr, oss);
+        REQUIRE(oss.str() == "rx_lock 1\n");
+    }
+    {
+        std::ostringstream oss;
+        multiSlsDetectorClient("rx_lock", GET, nullptr, oss);
+        REQUIRE(oss.str() == "rx_lock 1\n");
+    }
+    {
+        std::ostringstream oss;
+        multiSlsDetectorClient("rx_lock 0", PUT, nullptr, oss);
+        REQUIRE(oss.str() == "rx_lock 0\n");
+    }
+}
+
+TEST_CASE("rx_lastclient", "[.cmd]") {
+
+    std::ostringstream oss;
+    multiSlsDetectorClient("rx_lastclient", GET, nullptr, oss);
+    REQUIRE(oss.str() == "rx_lastclient " + test::my_ip + "\n");
+}
+
+TEST_CASE("rx_online", "[.cmd]") {
+    {
+        std::ostringstream oss;
+        multiSlsDetectorClient("rx_online 0", PUT, nullptr, oss);
+        REQUIRE(oss.str() == "rx_online 0\n");
+    }
+    {
+        std::ostringstream oss;
+        multiSlsDetectorClient("rx_online", GET, nullptr, oss);
+        REQUIRE(oss.str() == "rx_online 0\n");
+    }
+    {
+        std::ostringstream oss;
+        multiSlsDetectorClient("rx_online 1", PUT, nullptr, oss);
+        REQUIRE(oss.str() == "rx_online 1\n");
+    }
+}
+
+TEST_CASE("rx_checkonline", "[.cmd]") {
+
+    std::ostringstream oss;
+    multiSlsDetectorClient("rx_checkonline", GET, nullptr, oss);
+    REQUIRE(oss.str() == "rx_checkonline All receiver online\n");
 }

--- a/slsDetectorSoftware/tests/test-multiSlsDetectorClient.cpp
+++ b/slsDetectorSoftware/tests/test-multiSlsDetectorClient.cpp
@@ -406,3 +406,10 @@ TEST_CASE("rx_checkonline", "[.cmd]") {
     multiSlsDetectorClient("rx_checkonline", GET, nullptr, oss);
     REQUIRE(oss.str() == "rx_checkonline All receiver online\n");
 }
+
+TEST_CASE("rx_checkversion", "[.cmd]") {
+
+    std::ostringstream oss;
+    multiSlsDetectorClient("rx_checkversion", GET, nullptr, oss);
+    REQUIRE(oss.str() == "rx_checkversion compatible\n");
+}

--- a/slsDetectorSoftware/tests/test-multiSlsDetectorClient.cpp
+++ b/slsDetectorSoftware/tests/test-multiSlsDetectorClient.cpp
@@ -90,21 +90,21 @@ TEST_CASE("fwrite", "[.cmd]") {
     }
 }
 
-TEST_CASE("enablerx_overwrite", "[.cmd]") {
+TEST_CASE("enablefoverwrite", "[.cmd]") {
     {
         std::ostringstream oss;
-        multiSlsDetectorClient("rx_overwrite 1", PUT, nullptr, oss);
-        REQUIRE(oss.str() == "rx_overwrite 1\n");
+        multiSlsDetectorClient("foverwrite 1", PUT, nullptr, oss);
+        REQUIRE(oss.str() == "foverwrite 1\n");
     }
     {
         std::ostringstream oss;
-        multiSlsDetectorClient("rx_overwrite", GET, nullptr, oss);
-        REQUIRE(oss.str() == "rx_overwrite 1\n");
+        multiSlsDetectorClient("foverwrite", GET, nullptr, oss);
+        REQUIRE(oss.str() == "foverwrite 1\n");
     }
     {
         std::ostringstream oss;
-        multiSlsDetectorClient("rx_overwrite 0", PUT, nullptr, oss);
-        REQUIRE(oss.str() == "rx_overwrite 0\n");
+        multiSlsDetectorClient("foverwrite 0", PUT, nullptr, oss);
+        REQUIRE(oss.str() == "foverwrite 0\n");
     }
 }
 

--- a/slsDetectorSoftware/tests/test-multiSlsDetectorClient.cpp
+++ b/slsDetectorSoftware/tests/test-multiSlsDetectorClient.cpp
@@ -72,21 +72,21 @@ TEST_CASE("rx_status", "[.cmd]") {
     }
 }
 
-TEST_CASE("enablefwrite", "[.cmd]") {
+TEST_CASE("fwrite", "[.cmd]") {
     {
         std::ostringstream oss;
-        multiSlsDetectorClient("enablefwrite 1", PUT, nullptr, oss);
-        REQUIRE(oss.str() == "enablefwrite 1\n");
+        multiSlsDetectorClient("fwrite 1", PUT, nullptr, oss);
+        REQUIRE(oss.str() == "fwrite 1\n");
     }
     {
         std::ostringstream oss;
-        multiSlsDetectorClient("enablefwrite", GET, nullptr, oss);
-        REQUIRE(oss.str() == "enablefwrite 1\n");
+        multiSlsDetectorClient("fwrite", GET, nullptr, oss);
+        REQUIRE(oss.str() == "fwrite 1\n");
     }
     {
         std::ostringstream oss;
-        multiSlsDetectorClient("enablefwrite 0", PUT, nullptr, oss);
-        REQUIRE(oss.str() == "enablefwrite 0\n");
+        multiSlsDetectorClient("fwrite 0", PUT, nullptr, oss);
+        REQUIRE(oss.str() == "fwrite 0\n");
     }
 }
 
@@ -108,25 +108,26 @@ TEST_CASE("enableoverwrite", "[.cmd]") {
     }
 }
 
-TEST_CASE("activatecmd", "[.cmd]") {
+//EIGER ONLY
+// TEST_CASE("activatecmd", "[.cmd]") {
 
-    {
-        // TODO! read padding from somewhere
-        std::ostringstream oss;
-        multiSlsDetectorClient("activate 0", PUT, nullptr, oss);
-        REQUIRE(oss.str() == "activate 0 padding\n");
-    }
-    {
-        std::ostringstream oss;
-        multiSlsDetectorClient("activate", GET, nullptr, oss);
-        REQUIRE(oss.str() == "activate 0 padding\n");
-    }
-    {
-        std::ostringstream oss;
-        multiSlsDetectorClient("activate 1", PUT, nullptr, oss);
-        REQUIRE(oss.str() == "activate 1 padding\n");
-    }
-}
+//     {
+//         // TODO! read padding from somewhere
+//         std::ostringstream oss;
+//         multiSlsDetectorClient("activate 0", PUT, nullptr, oss);
+//         REQUIRE(oss.str() == "activate 0 padding\n");
+//     }
+//     {
+//         std::ostringstream oss;
+//         multiSlsDetectorClient("activate", GET, nullptr, oss);
+//         REQUIRE(oss.str() == "activate 0 padding\n");
+//     }
+//     {
+//         std::ostringstream oss;
+//         multiSlsDetectorClient("activate 1", PUT, nullptr, oss);
+//         REQUIRE(oss.str() == "activate 1 padding\n");
+//     }
+// }
 
 TEST_CASE("masterfile", "[.cmd]") {
     {
@@ -146,22 +147,22 @@ TEST_CASE("masterfile", "[.cmd]") {
     }
 }
 
-TEST_CASE("index", "[.cmd]") {
+TEST_CASE("findex", "[.cmd]") {
     {
         std::ostringstream oss;
-        multiSlsDetectorClient("index 57", PUT, nullptr, oss);
-        REQUIRE(oss.str() == "index 57\n");
+        multiSlsDetectorClient("findex 57", PUT, nullptr, oss);
+        REQUIRE(oss.str() == "findex 57\n");
     }
     {
         std::ostringstream oss;
-        multiSlsDetectorClient("index", GET, nullptr, oss);
-        REQUIRE(oss.str() == "index 57\n");
+        multiSlsDetectorClient("findex", GET, nullptr, oss);
+        REQUIRE(oss.str() == "findex 57\n");
     }
     {
 
         std::ostringstream oss;
-        multiSlsDetectorClient("index 0", PUT, nullptr, oss);
-        REQUIRE(oss.str() == "index 0\n");
+        multiSlsDetectorClient("findex 0", PUT, nullptr, oss);
+        REQUIRE(oss.str() == "findex 0\n");
     }
 }
 

--- a/slsDetectorSoftware/tests/test-multiSlsDetectorClient.cpp
+++ b/slsDetectorSoftware/tests/test-multiSlsDetectorClient.cpp
@@ -90,21 +90,21 @@ TEST_CASE("fwrite", "[.cmd]") {
     }
 }
 
-TEST_CASE("enableoverwrite", "[.cmd]") {
+TEST_CASE("enablerx_overwrite", "[.cmd]") {
     {
         std::ostringstream oss;
-        multiSlsDetectorClient("overwrite 1", PUT, nullptr, oss);
-        REQUIRE(oss.str() == "overwrite 1\n");
+        multiSlsDetectorClient("rx_overwrite 1", PUT, nullptr, oss);
+        REQUIRE(oss.str() == "rx_overwrite 1\n");
     }
     {
         std::ostringstream oss;
-        multiSlsDetectorClient("overwrite", GET, nullptr, oss);
-        REQUIRE(oss.str() == "overwrite 1\n");
+        multiSlsDetectorClient("rx_overwrite", GET, nullptr, oss);
+        REQUIRE(oss.str() == "rx_overwrite 1\n");
     }
     {
         std::ostringstream oss;
-        multiSlsDetectorClient("overwrite 0", PUT, nullptr, oss);
-        REQUIRE(oss.str() == "overwrite 0\n");
+        multiSlsDetectorClient("rx_overwrite 0", PUT, nullptr, oss);
+        REQUIRE(oss.str() == "rx_overwrite 0\n");
     }
 }
 

--- a/slsSupportLib/include/CmdProxy.h
+++ b/slsSupportLib/include/CmdProxy.h
@@ -70,7 +70,11 @@ template <typename T> class CmdProxy {
                                     {"r_framesperfile", "rx_framesperfile"},
                                     {"r_discardpolicy", "rx_discardpolicy"},
                                     {"receiverversion", "rx_version"},
-                                    {"receiver", "rx_status"}};
+                                    {"receiver", "rx_status"},
+                                    {"index", "findex"},
+                                    {"exitreceiver", "rx_exit"},
+                                    {"enablefwrite", "fwrite"},
+                                    {"checkrecversion", "rx_checkversion"}};
 
     template <typename U> std::string ResultToString(const U &ret) {
         std::ostringstream os;

--- a/slsSupportLib/include/CmdProxy.h
+++ b/slsSupportLib/include/CmdProxy.h
@@ -77,7 +77,8 @@ template <typename T> class CmdProxy {
                                     {"checkrecversion", "rx_checkversion"},
                                     {"masterfile", "fmaster"},
                                     {"outdir", "fpath"},
-                                    {"fileformat", "fformat"}};
+                                    {"fileformat", "fformat"},
+                                    {"overwrite", "rx_overwrite"}};
 
     template <typename U> std::string ResultToString(const U &ret) {
         std::ostringstream os;

--- a/slsSupportLib/include/CmdProxy.h
+++ b/slsSupportLib/include/CmdProxy.h
@@ -37,7 +37,7 @@ template <typename T> class CmdProxy {
         auto d_it = depreciated_functions.find(command);
         if (d_it != depreciated_functions.end()) {
             FILE_LOG(logWARNING)
-                << "WARNING: " << command
+                << command
                 << " is depreciated and will be removed. Please migrate to: "
                 << d_it->second;
             command = d_it->second;
@@ -74,7 +74,10 @@ template <typename T> class CmdProxy {
                                     {"index", "findex"},
                                     {"exitreceiver", "rx_exit"},
                                     {"enablefwrite", "fwrite"},
-                                    {"checkrecversion", "rx_checkversion"}};
+                                    {"checkrecversion", "rx_checkversion"},
+                                    {"masterfile", "fmaster"},
+                                    {"outdir", "fpath"},
+                                    {"fileformat", "fformat"}};
 
     template <typename U> std::string ResultToString(const U &ret) {
         std::ostringstream os;

--- a/slsSupportLib/include/CmdProxy.h
+++ b/slsSupportLib/include/CmdProxy.h
@@ -78,7 +78,7 @@ template <typename T> class CmdProxy {
                                     {"masterfile", "fmaster"},
                                     {"outdir", "fpath"},
                                     {"fileformat", "fformat"},
-                                    {"overwrite", "rx_overwrite"}};
+                                    {"overwrite", "foverwrite"}};
 
     template <typename U> std::string ResultToString(const U &ret) {
         std::ostringstream os;

--- a/slsSupportLib/include/CmdProxy.h
+++ b/slsSupportLib/include/CmdProxy.h
@@ -60,11 +60,17 @@ template <typename T> class CmdProxy {
     // Initialize maps for translating name and function
     FunctionMap functions{{"newfunc", &CmdProxy::NewFunction}};
 
-    StringMap depreciated_functions{{"oldvrfcmd", "vrf"},
-                                    {"veryveryold", "vcp"},
-                                    {"anothercmd", "vrs"},
-                                    {"this_as_well", "enablefwrite"}};
-
+    StringMap depreciated_functions{{"r_readfreq", "rx_readfreq"},
+                                    {"r_padding", "rx_padding"},
+                                    {"r_silent", "rx_silent"},
+                                    {"r_lastclient", "rx_lastclient"},
+                                    {"r_lock", "rx_lock"},
+                                    {"r_online", "rx_online"},
+                                    {"r_checkonline", "rx_checkonline"},
+                                    {"r_framesperfile", "rx_framesperfile"},
+                                    {"r_discardpolicy", "rx_discardpolicy"},
+                                    {"receiverversion", "rx_version"},
+                                    {"receiver", "rx_status"}};
 
     template <typename U> std::string ResultToString(const U &ret) {
         std::ostringstream os;
@@ -76,21 +82,22 @@ template <typename T> class CmdProxy {
 
     void WrongNumberOfParameters(size_t expected) {
         throw RuntimeError("ERROR: Expected " + std::to_string(expected) +
-                           " parameters but got " + std::to_string(args.size()) +
-                           "\n");
+                           " parameters but got " +
+                           std::to_string(args.size()) + "\n");
     }
 
     // Mapped functions
-    
-    //example
-    std::string NewFunction() { 
-        if(args.size() == 0){
+
+    // example
+    std::string NewFunction() {
+        if (args.size() == 0) {
             std::cout << "This is the new function function\n";
             return ResultToString(det->setExposureTime(-1, true));
-        }else if(args.size() == 1){
+        } else if (args.size() == 1) {
             std::cout << "Setting exposure time to " << args[0] << "s\n";
-            return ResultToString(det->setExposureTime(std::stod(args[0]), true, det_id));
-        }else{
+            return ResultToString(
+                det->setExposureTime(std::stod(args[0]), true, det_id));
+        } else {
             WrongNumberOfParameters(1);
             return {};
         }

--- a/tests/include/tests/globals.h
+++ b/tests/include/tests/globals.h
@@ -5,7 +5,10 @@ using ti = slsDetectorDefs::timerIndex;
 using ro = slsDetectorDefs::readOutFlags;
 using sv = slsDetectorDefs::speedVariable;
 using defs = slsDetectorDefs;
+
+namespace test {
 extern std::string hostname;
 extern std::string detector_type;
 extern dt type;
 extern std::string my_ip;
+} // namespace test

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -12,22 +12,24 @@
 using Opt = Catch::clara::Opt;
 using dt = slsDetectorDefs::detectorType;
 
+namespace test {
 std::string hostname;
 std::string detector_type;
 std::string my_ip;
 dt type;
+} // namespace test
 
 int main(int argc, char *argv[]) {
-    my_ip = "undefined";
+    test::my_ip = "undefined";
 
     Catch::Session session;
-    auto cli = session.cli() |
-               Opt(hostname, "hostname")["-hn"]["--hostname"](
-                   "Detector hostname for integration tests") |
-               Opt(detector_type, "detector_type")["-dt"]["--detector_type"](
-                   "Detector type for integration tests") |
-               Opt(my_ip, "my_ip")["-hip"]["--host_ip"](
-                   "Host ip address");
+    auto cli =
+        session.cli() |
+        Opt(test::hostname, "hostname")["-hn"]["--hostname"](
+            "Detector hostname for integration tests") |
+        Opt(test::detector_type, "detector_type")["-dt"]["--detector_type"](
+            "Detector type for integration tests") |
+        Opt(test::my_ip, "my_ip")["-hip"]["--host_ip"]("Host ip address");
 
     session.cli(cli);
 
@@ -36,7 +38,7 @@ int main(int argc, char *argv[]) {
         return ret;
     }
 
-    type = slsDetectorDefs::detectorTypeToEnum(detector_type);
+    test::type = slsDetectorDefs::detectorTypeToEnum(test::detector_type);
 
     return session.run();
 }


### PR DESCRIPTION
Renamed all receiver commands from r_ or receiver  to rx_. 
The old command will still work but print a warning.