### PR TITLE
Don't print full list if command is not found

### DIFF
--- a/slsDetectorSoftware/include/slsDetectorCommand.h
+++ b/slsDetectorSoftware/include/slsDetectorCommand.h
@@ -4,7 +4,7 @@
 
 
 #include "sls_detector_defs.h"
-
+#include <vector>
 class multiSlsDetector;
 
 
@@ -31,6 +31,9 @@ class slsDetectorCommand : public virtual slsDetectorDefs {
    */
   std::string executeLine(int narg, const char * const args[], int action, int detPos = -1);
   
+
+  std::vector<std::string> getAllCommands();
+
   /*   /\** */
   /*      returns the help for the executeLine command  */
   /*      \param os output stream to return the help to */

--- a/slsDetectorSoftware/src/slsDetectorCommand.cpp
+++ b/slsDetectorSoftware/src/slsDetectorCommand.cpp
@@ -2162,10 +2162,17 @@ std::string slsDetectorCommand::executeLine(int narg, const char * const args[],
 }
 
 std::string slsDetectorCommand::cmdUnknown(int narg, const char * const args[], int action, int detPos) {
-    return std::string("Unknown command ") + std::string(args[0]) + std::string("\n") + helpLine(0, args, action, detPos);
+    return std::string("Unknown command, use list to list all commands ");
 }
 std::string slsDetectorCommand::cmdUnderDevelopment(int narg, const char * const args[], int action, int detPos) {
     return std::string("Must still develop ") + std::string(args[0]) + std::string(" ( ") + cmd + std::string(" )\n");
+}
+
+std::vector<std::string> slsDetectorCommand::getAllCommands(){
+    std::vector<std::string> commands;
+    for (int i = 0; i!= numberOfCommands; ++i)
+        commands.emplace_back(descrToFuncMap[i].m_pFuncName);
+    return commands;
 }
 
 std::string slsDetectorCommand::helpLine(int narg, const char * const args[], int action, int detPos) {


### PR DESCRIPTION
Command line client doesn't print all possible commands on failure to decode, instead informs about new list command. 

Also added sls_detector_get list deprecated to list all deprecated commands. 