### PR TITLE
Receiver tries to create path when fpath is set

### DIFF
--- a/slsReceiverSoftware/src/slsReceiverImplementation.cpp
+++ b/slsReceiverSoftware/src/slsReceiverImplementation.cpp
@@ -13,6 +13,7 @@
 #include "GeneralData.h"
 #include "Listener.h"
 #include "ZmqSocket.h" //just for the zmq port define
+#include "file_utils.h"
 
 #include <cerrno>  //eperm
 #include <cstdlib> //system
@@ -555,12 +556,8 @@ void slsReceiverImplementation::setFilePath(const char c[]) {
     FILE_LOG(logDEBUG3) << __SHORT_AT__ << " called";
 
     if (strlen(c)) {
-        // check if filepath exists
-        struct stat st;
-        if (stat(c, &st) == 0)
-            strcpy(filePath, c);
-        else
-            FILE_LOG(logERROR) << "FilePath does not exist: " << c;
+        mkdir_p(c); //throws if it can't create
+        strcpy(filePath, c);
     }
     FILE_LOG(logINFO) << "File path: " << filePath;
 }

--- a/slsReceiverSoftware/src/slsReceiverTCPIPInterface.cpp
+++ b/slsReceiverSoftware/src/slsReceiverTCPIPInterface.cpp
@@ -808,6 +808,8 @@ int slsReceiverTCPIPInterface::set_file_dir(Interface &socket) {
 
     if (strlen(fPath) != 0) {
         FILE_LOG(logDEBUG1) << "Setting file path: " << fPath;
+        if(fPath[0] != '/')
+            throw RuntimeError("Receiver path needs to be absolute path");
         impl()->setFilePath(fPath);
     }
     std::string s = impl()->getFilePath();

--- a/slsSupportLib/include/file_utils.h
+++ b/slsSupportLib/include/file_utils.h
@@ -52,5 +52,5 @@ int writeDataFile(std::string fname,int nch, short int *data);
 
 
 
-
-
+// mkdir -p path implemented by recursive calls
+void mkdir_p(const std::string& path, std::string dir="");

--- a/slsSupportLib/src/file_utils.cpp
+++ b/slsSupportLib/src/file_utils.cpp
@@ -1,9 +1,12 @@
 #include "file_utils.h"
 #include "logger.h"
+#include "sls_detector_exceptions.h"
 
 #include <iostream>
 #include <sstream>
-
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <errno.h>
 
 int readDataFile(std::ifstream &infile, short int *data, int nch, int offset) {
 	int ichan, iline=0;
@@ -75,6 +78,26 @@ int writeDataFile(std::string fname,int nch, short int *data) {
 	}
 }
 
+
+
+void mkdir_p(const std::string& path, std::string dir) {
+    if (path.length() == 0)
+        return;
+
+    size_t i = 0;
+    for (; i < path.length(); i++) {
+        dir += path[i];
+        if (path[i] == '/')
+            break;
+    }
+    if(mkdir(dir.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH) != 0){
+        if (errno != EEXIST)
+            throw sls::RuntimeError("Could not create: " + dir);
+    }
+
+    if (i + 1 < path.length())
+        mkdir_p(path.substr(i + 1), dir);
+}
 
 
 


### PR DESCRIPTION
Receiver will try to create the file path when the path is set. 
If the path is existing the operation succeeds (like mkdir -p)
On failure the function throws

This type of things would be great to do with C++17 std::filesystem (or boost.filesystem) instead of custom system calls...