### PR TITLE
Removed prepareAcquisition from multiSlsDetector

### DIFF
--- a/slsDetectorSoftware/include/multiSlsDetector.h
+++ b/slsDetectorSoftware/include/multiSlsDetector.h
@@ -566,13 +566,6 @@ class multiSlsDetector : public virtual slsDetectorDefs {
     runStatus getRunStatus(int detPos = -1);
 
     /**
-     * Prepares detector for acquisition (Eiger)
-     * @param detPos -1 for all detectors in  list or specific detector position
-     * @returns OK if all detectors are ready for acquisition, FAIL otherwise
-     */
-    int prepareAcquisition(int detPos = -1);
-
-    /**
      * Start detector acquisition (Non blocking)
      * @param detPos -1 for all detectors in  list or specific detector position
      * @returns OK or FAIL if even one does not start properly

--- a/slsDetectorSoftware/src/multiSlsDetector.cpp
+++ b/slsDetectorSoftware/src/multiSlsDetector.cpp
@@ -954,22 +954,8 @@ int multiSlsDetector::prepareAcquisition(int detPos) {
 }
 
 int multiSlsDetector::startAcquisition(int detPos) {
-    // single
-    if (detPos >= 0) {
-        if (detectors[detPos]->getDetectorTypeAsEnum() == EIGER) {
-            if (detectors[detPos]->prepareAcquisition() == FAIL) {
-                return FAIL;
-            }
-        }
+    if (detPos >= 0)
         return detectors[detPos]->startAcquisition();
-    }
-
-    // multi
-    if (getDetectorTypeAsEnum() == EIGER) {
-        if (prepareAcquisition() == FAIL) {
-            return FAIL;
-        }
-    }
     auto r = parallelCall(&slsDetector::startAcquisition);
     return sls::allEqualTo(r, static_cast<int>(OK)) ? OK : FAIL;
 }

--- a/slsDetectorSoftware/src/multiSlsDetector.cpp
+++ b/slsDetectorSoftware/src/multiSlsDetector.cpp
@@ -942,17 +942,6 @@ slsDetectorDefs::runStatus multiSlsDetector::getRunStatus(int detPos) {
     return IDLE;
 }
 
-int multiSlsDetector::prepareAcquisition(int detPos) {
-    // single
-    if (detPos >= 0) {
-        return detectors[detPos]->prepareAcquisition();
-    }
-
-    // multi
-    auto r = parallelCall(&slsDetector::prepareAcquisition);
-    return sls::allEqualTo(r, static_cast<int>(OK)) ? OK : FAIL;
-}
-
 int multiSlsDetector::startAcquisition(int detPos) {
     if (detPos >= 0)
         return detectors[detPos]->startAcquisition();
@@ -969,7 +958,6 @@ int multiSlsDetector::stopAcquisition(int detPos) {
         if (detectors.size() == 1) {
             multi_shm()->stoppedFlag = 1;
         }
-
         return detectors[detPos]->stopAcquisition();
     } else {
         multi_shm()->stoppedFlag = 1;
@@ -990,22 +978,8 @@ int multiSlsDetector::sendSoftwareTrigger(int detPos) {
 }
 
 int multiSlsDetector::startAndReadAll(int detPos) {
-    // single
-    if (detPos >= 0) {
-        if (detectors[detPos]->getDetectorTypeAsEnum() == EIGER) {
-            if (detectors[detPos]->prepareAcquisition() == FAIL) {
-                return FAIL;
-            }
-        }
+    if (detPos >= 0) 
         return detectors[detPos]->startAndReadAll();
-    }
-
-    // multi
-    if (getDetectorTypeAsEnum() == EIGER) {
-        if (prepareAcquisition() == FAIL) {
-            return FAIL;
-        }
-    }
     auto r = parallelCall(&slsDetector::startAndReadAll);
     return sls::allEqualTo(r, static_cast<int>(OK)) ? OK : FAIL;
 }

--- a/slsDetectorSoftware/src/slsDetector.cpp
+++ b/slsDetectorSoftware/src/slsDetector.cpp
@@ -1358,6 +1358,10 @@ int slsDetector::startAndReadAll() {
     int ret = FAIL;
     FILE_LOG(logDEBUG1) << "Starting and reading all frames";
     shm()->stoppedFlag = 0;
+    if (getDetectorTypeAsEnum() == EIGER){
+        if(prepareAcquisition() == FAIL)
+            return FAIL;
+    }
     if (shm()->onlineFlag == ONLINE_FLAG) {
         ret = sendToDetector(F_START_AND_READ_ALL);
         // TODO! how to we hande this? ret == FAIL -->

--- a/slsDetectorSoftware/src/slsDetector.cpp
+++ b/slsDetectorSoftware/src/slsDetector.cpp
@@ -1311,6 +1311,10 @@ int slsDetector::startAcquisition() {
     int ret = FAIL;
     FILE_LOG(logDEBUG1) << "Starting Acquisition";
     shm()->stoppedFlag = 0;
+    if (getDetectorTypeAsEnum() == EIGER){
+        if(prepareAcquisition() == FAIL)
+            return FAIL;
+    }
     if (shm()->onlineFlag == ONLINE_FLAG) {
         ret = sendToDetector(F_START_ACQUISITION);
         FILE_LOG(logDEBUG1) << "Starting Acquisition successful";


### PR DESCRIPTION
Removed the prepareAcquisition from the multiSlsDetector and instead calling it in the slsDetector functions where it's needed. This removes some of the logic from the multi and slightly simplifies the code. 