### PR TITLE
Fixed rx_start

### DIFF
--- a/slsDetectorSoftware/src/Module.cpp
+++ b/slsDetectorSoftware/src/Module.cpp
@@ -932,7 +932,7 @@ void Module::setFileIndex(int64_t file_index) {
 }
 
 void Module::incrementFileIndex() {
-    sendToReceiver(F_INCREMENT_FILE_INDEX, nullptr, nullptr);
+    sendToReceiver(F_INCREMENT_FILE_INDEX);
 }
 
 bool Module::getFileWrite() {
@@ -2273,7 +2273,7 @@ void Module::copyDetectorServer(const std::string &fname,
 }
 
 void Module::rebootController() {
-    sendToDetector(F_REBOOT_CONTROLLER, nullptr, nullptr);
+    sendToDetector(F_REBOOT_CONTROLLER);
     LOG(logINFO) << "Controller rebooted successfully!";
 }
 
@@ -2817,7 +2817,7 @@ void Module::checkReceiverVersionCompatibility() {
 }
 
 void Module::restreamStopFromReceiver() {
-    sendToReceiver(F_RESTREAM_STOP_FROM_RECEIVER, nullptr, nullptr);
+    sendToReceiver(F_RESTREAM_STOP_FROM_RECEIVER);
 }
 
 int Module::sendModule(sls_detector_module *myMod, sls::ClientSocket &client) {

--- a/slsDetectorSoftware/src/Module.cpp
+++ b/slsDetectorSoftware/src/Module.cpp
@@ -391,7 +391,7 @@ void Module::setExternalSignalFlags(int signalIndex, externalSignalFlag type) {
 
 void Module::startReceiver() {
     shm()->stoppedFlag = false;
-    sendToReceiver(F_START_RECEIVER, nullptr, nullptr);
+    sendToReceiver(F_START_RECEIVER);
 }
 
 void Module::stopReceiver() {
@@ -2671,6 +2671,20 @@ template <typename Ret> Ret Module::sendToReceiver(int fnum) const {
     sendToReceiver(fnum, nullptr, 0, &retval, sizeof(retval));
     LOG(logDEBUG1) << "Got back: " << ToString(retval);
     return retval;
+}
+
+void Module::sendToReceiver(int fnum) {
+    LOG(logDEBUG1) << "Sending to Receiver: ["
+                   << getFunctionNameFromEnum(static_cast<detFuncs>(fnum))
+                   << ", nullptr, 0, nullptr, 0]";
+    sendToReceiver(fnum, nullptr, 0, nullptr, 0);
+}
+
+void Module::sendToReceiver(int fnum) const {
+    LOG(logDEBUG1) << "Sending to Receiver: ["
+                   << getFunctionNameFromEnum(static_cast<detFuncs>(fnum))
+                   << ", nullptr, 0, nullptr, 0]";
+    sendToReceiver(fnum, nullptr, 0, nullptr, 0);
 }
 
 template <typename Ret, typename Arg>

--- a/slsDetectorSoftware/src/Module.h
+++ b/slsDetectorSoftware/src/Module.h
@@ -607,6 +607,10 @@ class Module : public virtual slsDetectorDefs {
 
     template <typename Ret> Ret sendToReceiver(int fnum) const;
 
+    void sendToReceiver(int fnum);
+
+    void sendToReceiver(int fnum) const;
+
     template <typename Ret, typename Arg>
     Ret sendToReceiver(int fnum, const Arg &args);
 


### PR DESCRIPTION
Fix for mismatched send receiver that lead to error message not being visible on RH7. Added overload for void sendToReceiver(int fnum)