### PR TITLE
Replaced usleep with std::this_thread::sleep_for

### DIFF
--- a/slsDetectorSoftware/src/Detector.cpp
+++ b/slsDetectorSoftware/src/Detector.cpp
@@ -10,6 +10,8 @@
 #include "versionAPI.h"
 
 #include <fstream>
+#include <chrono>
+#include <thread>
 
 namespace sls {
 
@@ -399,7 +401,7 @@ void Detector::setPowerChip(bool on, Positions pos) {
     if ((pos.empty() || pos[0] == -1) && on && pimpl->size() > 3) {
         for (int i = 0; i != pimpl->size(); ++i) {
             pimpl->Parallel(&Module::setPowerChip, {i}, on);
-            usleep(1000 * 1000);
+            std::this_thread::sleep_for(std::chrono::seconds(1));
         }
     } else {
         pimpl->Parallel(&Module::setPowerChip, pos, on);

--- a/slsDetectorSoftware/src/Module.cpp
+++ b/slsDetectorSoftware/src/Module.cpp
@@ -15,6 +15,8 @@
 #include <bitset>
 #include <cassert>
 #include <cmath>
+#include <chrono>
+#include <thread>
 #include <cstdlib>
 #include <iomanip>
 #include <iterator>
@@ -3160,7 +3162,7 @@ void Module::programFPGAviaBlackfin(std::vector<char> buffer) {
     const int ERASE_TIME = 65;
     int count = ERASE_TIME + 1;
     while (count > 0) {
-        usleep(1 * 1000 * 1000);
+        std::this_thread::sleep_for(std::chrono::seconds(1));
         --count;
         printf(
             "%d%%\r",

--- a/slsReceiverSoftware/src/Implementation.cpp
+++ b/slsReceiverSoftware/src/Implementation.cpp
@@ -13,6 +13,8 @@
 #include <cstring>
 #include <cstring> //strcpy
 #include <fstream>
+#include <chrono>
+#include <thread>
 #include <iostream>
 #include <sys/stat.h> // stat
 #include <unistd.h>
@@ -739,7 +741,7 @@ void Implementation::stopReceiver() {
         for (const auto &it : dataProcessor)
             if (it->IsRunning())
                 running = true;
-        usleep(5000);
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
     }
 
     // create virtual file
@@ -763,7 +765,7 @@ void Implementation::stopReceiver() {
         for (const auto &it : dataStreamer)
             if (it->IsRunning())
                 running = true;
-        usleep(5000);
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
     }
 
     status = RUN_FINISHED;
@@ -821,7 +823,8 @@ void Implementation::startReadout() {
                     << "waiting for all packets, previousValue:"
                     << previousValue
                     << " totalPacketsReceived: " << totalPacketsReceived;
-                usleep(5 * 1000); /* TODO! Need to find optimal time **/
+                /* TODO! Need to find optimal time **/
+                std::this_thread::sleep_for(std::chrono::milliseconds(5));
                 previousValue = totalPacketsReceived;
                 totalPacketsReceived = 0;
                 for (const auto &it : listener)

--- a/slsSupportLib/src/ZmqSocket.cpp
+++ b/slsSupportLib/src/ZmqSocket.cpp
@@ -3,7 +3,8 @@
 #include <errno.h>
 #include <iostream>
 #include <string.h>
-#include <unistd.h> //usleep in some machines
+#include <chrono>
+#include <thread>
 #include <vector>
 #include <sstream>
 #include <zmq.h>
@@ -76,8 +77,8 @@ ZmqSocket::ZmqSocket(const uint32_t portnumber, const char *ethip)
         PrintError();
         throw sls::ZmqSocketError("Could not bind socket");
     }
-    // sleep for a few milliseconds to allow a slow-joiner
-    usleep(200 * 1000);
+    // sleep to allow a slow-joiner
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
 };
 
 int ZmqSocket::Connect() {


### PR DESCRIPTION
Replaced usleep with the portable and more readable std::this_thread::sleep_for. 
Times can now be passed in using std::chrono. 

In the future (c++14) it could be even further improved using std::literals
```cpp
using namespace std::literals;
std::this_thread::sleep_for(2min);
```