### PR TITLE
Check args for sending to detector/receiver

### DIFF
--- a/slsDetectorSoftware/src/Module.cpp
+++ b/slsDetectorSoftware/src/Module.cpp
@@ -58,7 +58,7 @@ void Module::freeSharedMemory() {
     }
 }
 
-bool Module::isFixedPatternSharedMemoryCompatible() {
+bool Module::isFixedPatternSharedMemoryCompatible() const {
     return (shm()->shmversion >= SLS_SHMAPIVERSION);
 }
 
@@ -84,15 +84,15 @@ void Module::setHostname(const std::string &hostname,
     }
 }
 
-int64_t Module::getFirmwareVersion() {
+int64_t Module::getFirmwareVersion() const {
     return sendToDetector<int64_t>(F_GET_FIRMWARE_VERSION);
 }
 
-int64_t Module::getDetectorServerVersion() {
+int64_t Module::getDetectorServerVersion() const {
     return sendToDetector<int64_t>(F_GET_SERVER_VERSION);
 }
 
-int64_t Module::getSerialNumber() {
+int64_t Module::getSerialNumber() const {
     return sendToDetector<int64_t>(F_GET_SERIAL_NUMBER);
 }
 
@@ -145,7 +145,7 @@ void Module::updateNumberOfDetector(slsDetectorDefs::xy det) {
     sendToDetector(F_SET_POSITION, args, nullptr);
 }
 
-slsDetectorDefs::detectorSettings Module::getSettings() {
+slsDetectorDefs::detectorSettings Module::getSettings() const {
     auto r = sendToDetector<int>(F_SET_SETTINGS, GET_FLAG);
     return static_cast<detectorSettings>(r);
 }
@@ -179,7 +179,7 @@ void Module::loadSettingsFile(const std::string &fname) {
     setModule(myMod);
 }
 
-int Module::getAllTrimbits() {
+int Module::getAllTrimbits() const {
     return sendToDetector<int>(F_SET_ALL_TRIMBITS, GET_FLAG);
 }
 
@@ -187,7 +187,7 @@ void Module::setAllTrimbits(int val) {
     sendToDetector<int>(F_SET_ALL_TRIMBITS, val);
 }
 
-int64_t Module::getNumberOfFrames() {
+int64_t Module::getNumberOfFrames() const{
     return sendToDetector<int64_t>(F_GET_NUM_FRAMES);
 }
 
@@ -198,7 +198,7 @@ void Module::setNumberOfFrames(int64_t value) {
     }
 }
 
-int64_t Module::getNumberOfTriggers() {
+int64_t Module::getNumberOfTriggers() const{
     return sendToDetector<int64_t>(F_GET_NUM_TRIGGERS);
 }
 
@@ -209,7 +209,7 @@ void Module::setNumberOfTriggers(int64_t value) {
     }
 }
 
-int64_t Module::getExptime(int gateIndex) {
+int64_t Module::getExptime(int gateIndex) const{
     return sendToDetector<int64_t>(F_GET_EXPTIME, gateIndex);
 }
 
@@ -228,7 +228,7 @@ void Module::setExptime(int gateIndex, int64_t value) {
     }
 }
 
-int64_t Module::getPeriod() { return sendToDetector<int64_t>(F_GET_PERIOD); }
+int64_t Module::getPeriod() const { return sendToDetector<int64_t>(F_GET_PERIOD); }
 
 void Module::setPeriod(int64_t value) {
     sendToDetector(F_SET_PERIOD, value, nullptr);
@@ -237,7 +237,7 @@ void Module::setPeriod(int64_t value) {
     }
 }
 
-int64_t Module::getDelayAfterTrigger() {
+int64_t Module::getDelayAfterTrigger() const {
     return sendToDetector<int64_t>(F_GET_DELAY_AFTER_TRIGGER);
 }
 
@@ -261,7 +261,7 @@ int64_t Module::getPeriodLeft() const {
     return sendToDetectorStop<int64_t>(F_GET_PERIOD_LEFT);
 }
 
-int Module::getDynamicRange() {
+int Module::getDynamicRange() const {
     return sendToDetector<int>(F_SET_DYNAMIC_RANGE, GET_FLAG);
 }
 
@@ -293,7 +293,7 @@ void Module::setDynamicRange(int n) {
     }
 }
 
-slsDetectorDefs::timingMode Module::getTimingMode() {
+slsDetectorDefs::timingMode Module::getTimingMode() const {
     return sendToDetector<timingMode>(F_SET_TIMING_MODE, GET_FLAG);
 }
 
@@ -304,7 +304,7 @@ void Module::setTimingMode(timingMode value) {
     }
 }
 
-int Module::getClockDivider(int clkIndex) {
+int Module::getClockDivider(int clkIndex) const {
     return sendToDetector<int>(F_GET_CLOCK_DIVIDER, clkIndex);
 }
 
@@ -313,7 +313,7 @@ void Module::setClockDivider(int clkIndex, int value) {
     sendToDetector(F_SET_CLOCK_DIVIDER, args, nullptr);
 }
 
-int Module::getClockPhase(int clkIndex, bool inDegrees) {
+int Module::getClockPhase(int clkIndex, bool inDegrees) const {
     int args[]{clkIndex, static_cast<int>(inDegrees)};
     return sendToDetector<int>(F_GET_CLOCK_PHASE, args);
 }
@@ -323,11 +323,11 @@ void Module::setClockPhase(int clkIndex, int value, bool inDegrees) {
     sendToDetector(F_SET_CLOCK_PHASE, args, nullptr);
 }
 
-int Module::getMaxClockPhaseShift(int clkIndex) {
+int Module::getMaxClockPhaseShift(int clkIndex) const{
     return sendToDetector<int>(F_GET_MAX_CLOCK_PHASE_SHIFT, clkIndex);
 }
 
-int Module::getClockFrequency(int clkIndex) {
+int Module::getClockFrequency(int clkIndex) const {
     return sendToDetector<int>(F_GET_CLOCK_FREQUENCY, clkIndex);
 }
 
@@ -336,7 +336,7 @@ void Module::setClockFrequency(int clkIndex, int value) {
     sendToDetector(F_SET_CLOCK_FREQUENCY, args, nullptr);
 }
 
-int Module::getDAC(dacIndex index, bool mV) {
+int Module::getDAC(dacIndex index, bool mV) const {
     int args[]{static_cast<int>(index), static_cast<int>(mV), GET_FLAG};
     return sendToDetector<int>(F_SET_DAC, args);
 }
@@ -346,7 +346,7 @@ void Module::setDAC(int val, dacIndex index, bool mV) {
     sendToDetector<int>(F_SET_DAC, args);
 }
 
-bool Module::getPowerChip() {
+bool Module::getPowerChip() const {
     int arg = GET_FLAG;
     return sendToDetector<int>(F_POWER_CHIP, arg);
 }
@@ -355,7 +355,7 @@ void Module::setPowerChip(bool on) {
     sendToDetector<int>(F_POWER_CHIP, static_cast<int>(on));
 }
 
-int Module::getImageTestMode() {
+int Module::getImageTestMode() const {
     return sendToDetector<int>(F_GET_IMAGE_TEST_MODE);
 }
 
@@ -363,11 +363,11 @@ void Module::setImageTestMode(const int value) {
     sendToDetector(F_SET_IMAGE_TEST_MODE, value, nullptr);
 }
 
-int Module::getADC(dacIndex index) {
+int Module::getADC(dacIndex index) const {
     return sendToDetectorStop<int>(F_GET_ADC, static_cast<int>(index));
 }
 
-int Module::getOnChipDAC(slsDetectorDefs::dacIndex index, int chipIndex) {
+int Module::getOnChipDAC(slsDetectorDefs::dacIndex index, int chipIndex) const {
     int args[]{static_cast<int>(index), chipIndex};
     return sendToDetector<int>(F_GET_ON_CHIP_DAC, args);
 }
@@ -379,7 +379,7 @@ void Module::setOnChipDAC(slsDetectorDefs::dacIndex index, int chipIndex,
 }
 
 slsDetectorDefs::externalSignalFlag
-Module::getExternalSignalFlags(int signalIndex) {
+Module::getExternalSignalFlags(int signalIndex) const {
     return sendToDetector<slsDetectorDefs::externalSignalFlag>(
         F_GET_EXTERNAL_SIGNAL_FLAG, signalIndex);
 }
@@ -473,7 +473,7 @@ std::vector<uint64_t> Module::getNumMissingPackets() const {
     throw RuntimeError("No receiver to get missing packets.");
 }
 
-uint64_t Module::getStartingFrameNumber() {
+uint64_t Module::getStartingFrameNumber() const {
     return sendToDetector<uint64_t>(F_GET_STARTING_FRAME_NUMBER);
 }
 
@@ -483,7 +483,7 @@ void Module::setStartingFrameNumber(uint64_t value) {
 
 void Module::sendSoftwareTrigger() { sendToDetectorStop(F_SOFTWARE_TRIGGER); }
 
-defs::scanParameters Module::getScan() {
+defs::scanParameters Module::getScan() const {
     return sendToDetector<defs::scanParameters>(F_GET_SCAN);
 }
 
@@ -493,7 +493,7 @@ void Module::setScan(const defs::scanParameters t) {
     setNumberOfFrames(retval);
 }
 
-std::string Module::getScanErrorMessage() {
+std::string Module::getScanErrorMessage() const {
     char retval[MAX_STR_LENGTH]{};
     sendToDetector(F_GET_SCAN_ERROR_MESSAGE, nullptr, retval);
     return retval;
@@ -501,11 +501,11 @@ std::string Module::getScanErrorMessage() {
 
 // Network Configuration (Detector<->Receiver)
 
-int Module::getNumberofUDPInterfacesFromShm() {
+int Module::getNumberofUDPInterfacesFromShm() const{
     return shm()->numUDPInterfaces;
 }
 
-int Module::getNumberofUDPInterfaces() {
+int Module::getNumberofUDPInterfaces() const{
     shm()->numUDPInterfaces = sendToDetector<int>(F_GET_NUM_INTERFACES);
     return shm()->numUDPInterfaces;
 }
@@ -518,7 +518,7 @@ void Module::setNumberofUDPInterfaces(int n) {
     }
 }
 
-int Module::getSelectedUDPInterface() {
+int Module::getSelectedUDPInterface() const {
     return sendToDetector<int>(F_GET_INTERFACE_SEL);
 }
 
@@ -526,7 +526,7 @@ void Module::selectUDPInterface(int n) {
     sendToDetector(F_SET_INTERFACE_SEL, n, nullptr);
 }
 
-sls::IpAddr Module::getSourceUDPIP() {
+sls::IpAddr Module::getSourceUDPIP() const {
     return sendToDetector<sls::IpAddr>(F_GET_SOURCE_UDP_IP);
 }
 
@@ -537,7 +537,7 @@ void Module::setSourceUDPIP(const IpAddr ip) {
     sendToDetector(F_SET_SOURCE_UDP_IP, ip, nullptr);
 }
 
-sls::IpAddr Module::getSourceUDPIP2() {
+sls::IpAddr Module::getSourceUDPIP2() const{
     return sendToDetector<sls::IpAddr>(F_GET_SOURCE_UDP_IP2);
 }
 
@@ -548,7 +548,7 @@ void Module::setSourceUDPIP2(const IpAddr ip) {
     sendToDetector(F_SET_SOURCE_UDP_IP2, ip, nullptr);
 }
 
-sls::MacAddr Module::getSourceUDPMAC() {
+sls::MacAddr Module::getSourceUDPMAC() const {
     return sendToDetector<sls::MacAddr>(F_GET_SOURCE_UDP_MAC);
 }
 
@@ -559,7 +559,7 @@ void Module::setSourceUDPMAC(const sls::MacAddr mac) {
     sendToDetector(F_SET_SOURCE_UDP_MAC, mac, nullptr);
 }
 
-sls::MacAddr Module::getSourceUDPMAC2() {
+sls::MacAddr Module::getSourceUDPMAC2() const {
     return sendToDetector<sls::MacAddr>(F_GET_SOURCE_UDP_MAC2);
 }
 
@@ -570,7 +570,7 @@ void Module::setSourceUDPMAC2(const sls::MacAddr mac) {
     sendToDetector(F_SET_SOURCE_UDP_MAC2, mac, nullptr);
 }
 
-sls::IpAddr Module::getDestinationUDPIP() {
+sls::IpAddr Module::getDestinationUDPIP() const {
     return sendToDetector<sls::IpAddr>(F_GET_DEST_UDP_IP);
 }
 
@@ -588,7 +588,7 @@ void Module::setDestinationUDPIP(const IpAddr ip) {
     }
 }
 
-sls::IpAddr Module::getDestinationUDPIP2() {
+sls::IpAddr Module::getDestinationUDPIP2() const {
     return sendToDetector<sls::IpAddr>(F_GET_DEST_UDP_IP2);
 }
 
@@ -608,7 +608,7 @@ void Module::setDestinationUDPIP2(const IpAddr ip) {
     }
 }
 
-sls::MacAddr Module::getDestinationUDPMAC() {
+sls::MacAddr Module::getDestinationUDPMAC() const {
     return sendToDetector<sls::MacAddr>(F_GET_DEST_UDP_MAC);
 }
 
@@ -619,7 +619,7 @@ void Module::setDestinationUDPMAC(const MacAddr mac) {
     sendToDetector(F_SET_DEST_UDP_MAC, mac, nullptr);
 }
 
-sls::MacAddr Module::getDestinationUDPMAC2() {
+sls::MacAddr Module::getDestinationUDPMAC2() const {
     return sendToDetector<sls::MacAddr>(F_GET_DEST_UDP_MAC2);
 }
 
@@ -630,7 +630,7 @@ void Module::setDestinationUDPMAC2(const MacAddr mac) {
     sendToDetector(F_SET_DEST_UDP_MAC2, mac, nullptr);
 }
 
-int Module::getDestinationUDPPort() {
+int Module::getDestinationUDPPort() const {
     return sendToDetector<int>(F_GET_DEST_UDP_PORT);
 }
 
@@ -641,7 +641,7 @@ void Module::setDestinationUDPPort(const int port) {
     }
 }
 
-int Module::getDestinationUDPPort2() {
+int Module::getDestinationUDPPort2() const{
     return sendToDetector<int>(F_GET_DEST_UDP_PORT2);
 }
 
@@ -680,7 +680,7 @@ std::string Module::printReceiverConfiguration() {
     return os.str();
 }
 
-bool Module::getTenGiga() {
+bool Module::getTenGiga() const {
     int arg = GET_FLAG;
     return static_cast<bool>(sendToDetector<int>(F_ENABLE_TEN_GIGA, arg));
 }
@@ -695,7 +695,7 @@ void Module::setTenGiga(bool value) {
     }
 }
 
-bool Module::getTenGigaFlowControl() {
+bool Module::getTenGigaFlowControl() const {
     return sendToDetector<int>(F_GET_TEN_GIGA_FLOW_CONTROL);
 }
 
@@ -704,7 +704,7 @@ void Module::setTenGigaFlowControl(bool enable) {
     sendToDetector(F_SET_TEN_GIGA_FLOW_CONTROL, arg, nullptr);
 }
 
-int Module::getTransmissionDelayFrame() {
+int Module::getTransmissionDelayFrame() const {
     return sendToDetector<int>(F_GET_TRANSMISSION_DELAY_FRAME);
 }
 
@@ -712,7 +712,7 @@ void Module::setTransmissionDelayFrame(int value) {
     sendToDetector(F_SET_TRANSMISSION_DELAY_FRAME, value, nullptr);
 }
 
-int Module::getTransmissionDelayLeft() {
+int Module::getTransmissionDelayLeft() const {
     return sendToDetector<int>(F_GET_TRANSMISSION_DELAY_LEFT);
 }
 
@@ -720,7 +720,7 @@ void Module::setTransmissionDelayLeft(int value) {
     sendToDetector(F_SET_TRANSMISSION_DELAY_LEFT, value, nullptr);
 }
 
-int Module::getTransmissionDelayRight() {
+int Module::getTransmissionDelayRight() const {
     return sendToDetector<int>(F_GET_TRANSMISSION_DELAY_RIGHT);
 }
 
@@ -818,7 +818,7 @@ int Module::setReceiverPort(int port_number) {
     return shm()->rxTCPPort;
 }
 
-int Module::getReceiverFifoDepth() {
+int Module::getReceiverFifoDepth() const {
     int arg = GET_FLAG;
     return sendToReceiver<int>(F_SET_RECEIVER_FIFO_DEPTH, arg);
 }
@@ -827,7 +827,7 @@ void Module::setReceiverFifoDepth(int n_frames) {
     sendToReceiver<int>(F_SET_RECEIVER_FIFO_DEPTH, n_frames);
 }
 
-bool Module::getReceiverSilentMode() {
+bool Module::getReceiverSilentMode() const {
     return sendToReceiver<int>(F_GET_RECEIVER_SILENT_MODE);
 }
 
@@ -836,7 +836,7 @@ void Module::setReceiverSilentMode(bool enable) {
                    nullptr);
 }
 
-slsDetectorDefs::frameDiscardPolicy Module::getReceiverFramesDiscardPolicy() {
+slsDetectorDefs::frameDiscardPolicy Module::getReceiverFramesDiscardPolicy() const {
     return static_cast<frameDiscardPolicy>(
         sendToReceiver<int>(F_GET_RECEIVER_DISCARD_POLICY));
 }
@@ -845,7 +845,7 @@ void Module::setReceiverFramesDiscardPolicy(frameDiscardPolicy f) {
     sendToReceiver(F_SET_RECEIVER_DISCARD_POLICY, static_cast<int>(f), nullptr);
 }
 
-bool Module::getPartialFramesPadding() {
+bool Module::getPartialFramesPadding() const {
     return sendToReceiver<int>(F_GET_RECEIVER_PADDING);
 }
 
@@ -866,7 +866,7 @@ void Module::setReceiverUDPSocketBufferSize(int64_t udpsockbufsize) {
     sendToReceiver<int64_t>(F_RECEIVER_UDP_SOCK_BUF_SIZE, udpsockbufsize);
 }
 
-bool Module::getReceiverLock() {
+bool Module::getReceiverLock() const {
     int arg = GET_FLAG;
     return static_cast<bool>(sendToReceiver<int>(F_LOCK_RECEIVER, arg));
 }
@@ -886,7 +886,7 @@ std::array<pid_t, NUM_RX_THREAD_IDS> Module::getReceiverThreadIds() const {
 
 // File
 
-slsDetectorDefs::fileFormat Module::getFileFormat() {
+slsDetectorDefs::fileFormat Module::getFileFormat() const{
     return static_cast<fileFormat>(
         sendToReceiver<int>(F_GET_RECEIVER_FILE_FORMAT));
 }
@@ -895,7 +895,7 @@ void Module::setFileFormat(fileFormat f) {
     sendToReceiver(F_SET_RECEIVER_FILE_FORMAT, static_cast<int>(f), nullptr);
 }
 
-std::string Module::getFilePath() {
+std::string Module::getFilePath() const {
     char ret[MAX_STR_LENGTH]{};
     sendToReceiver(F_GET_RECEIVER_FILE_PATH, nullptr, ret);
     return ret;
@@ -910,7 +910,7 @@ void Module::setFilePath(const std::string &path) {
     sendToReceiver(F_SET_RECEIVER_FILE_PATH, args, nullptr);
 }
 
-std::string Module::getFileName() {
+std::string Module::getFileName() const {
     char retvals[MAX_STR_LENGTH]{};
     sendToReceiver(F_GET_RECEIVER_FILE_NAME, nullptr, retvals);
     return std::string(retvals);
@@ -925,7 +925,7 @@ void Module::setFileName(const std::string &fname) {
     sendToReceiver(F_SET_RECEIVER_FILE_NAME, args, nullptr);
 }
 
-int64_t Module::getFileIndex() {
+int64_t Module::getFileIndex() const {
     return sendToReceiver<int64_t>(F_GET_RECEIVER_FILE_INDEX);
 }
 
@@ -935,7 +935,7 @@ void Module::setFileIndex(int64_t file_index) {
 
 void Module::incrementFileIndex() { sendToReceiver(F_INCREMENT_FILE_INDEX); }
 
-bool Module::getFileWrite() {
+bool Module::getFileWrite() const {
     return sendToReceiver<int>(F_GET_RECEIVER_FILE_WRITE);
 }
 
@@ -943,7 +943,7 @@ void Module::setFileWrite(bool value) {
     sendToReceiver(F_SET_RECEIVER_FILE_WRITE, static_cast<int>(value), nullptr);
 }
 
-bool Module::getMasterFileWrite() {
+bool Module::getMasterFileWrite() const {
     return sendToReceiver<int>(F_GET_RECEIVER_MASTER_FILE_WRITE);
 }
 
@@ -952,7 +952,7 @@ void Module::setMasterFileWrite(bool value) {
                    nullptr);
 }
 
-bool Module::getFileOverWrite() {
+bool Module::getFileOverWrite() const {
     return sendToReceiver<int>(F_GET_RECEIVER_OVERWRITE);
 }
 
@@ -960,7 +960,7 @@ void Module::setFileOverWrite(bool value) {
     sendToReceiver(F_SET_RECEIVER_OVERWRITE, static_cast<int>(value), nullptr);
 }
 
-int Module::getFramesPerFile() {
+int Module::getFramesPerFile() const {
     return sendToReceiver<int>(F_GET_RECEIVER_FRAMES_PER_FILE);
 }
 
@@ -970,7 +970,7 @@ void Module::setFramesPerFile(int n_frames) {
 
 // ZMQ Streaming Parameters (Receiver<->Client)
 
-bool Module::getReceiverStreaming() {
+bool Module::getReceiverStreaming() const {
     return sendToReceiver<int>(F_GET_RECEIVER_STREAMING);
 }
 
@@ -978,7 +978,7 @@ void Module::setReceiverStreaming(bool enable) {
     sendToReceiver(F_SET_RECEIVER_STREAMING, static_cast<int>(enable), nullptr);
 }
 
-int Module::getReceiverStreamingFrequency() {
+int Module::getReceiverStreamingFrequency() const {
     return sendToReceiver<int>(F_GET_RECEIVER_STREAMING_FREQUENCY);
 }
 
@@ -990,7 +990,7 @@ void Module::setReceiverStreamingFrequency(int freq) {
     sendToReceiver(F_SET_RECEIVER_STREAMING_FREQUENCY, freq, nullptr);
 }
 
-int Module::getReceiverStreamingTimer() {
+int Module::getReceiverStreamingTimer() const {
     int arg = GET_FLAG;
     return sendToReceiver<int>(F_RECEIVER_STREAMING_TIMER, arg);
 }
@@ -999,7 +999,7 @@ void Module::setReceiverStreamingTimer(int time_in_ms) {
     sendToReceiver<int>(F_RECEIVER_STREAMING_TIMER, time_in_ms);
 }
 
-int Module::getReceiverStreamingStartingFrame() {
+int Module::getReceiverStreamingStartingFrame() const {
     return sendToReceiver<int>(F_GET_RECEIVER_STREAMING_START_FNUM);
 }
 
@@ -1011,7 +1011,7 @@ void Module::setReceiverStreamingStartingFrame(int fnum) {
     sendToReceiver(F_SET_RECEIVER_STREAMING_START_FNUM, fnum, nullptr);
 }
 
-int Module::getReceiverStreamingPort() {
+int Module::getReceiverStreamingPort() const {
     return sendToReceiver<int>(F_GET_RECEIVER_STREAMING_PORT);
 }
 
@@ -1019,7 +1019,7 @@ void Module::setReceiverStreamingPort(int port) {
     sendToReceiver(F_SET_RECEIVER_STREAMING_PORT, port, nullptr);
 }
 
-sls::IpAddr Module::getReceiverStreamingIP() {
+sls::IpAddr Module::getReceiverStreamingIP() const {
     return sendToReceiver<sls::IpAddr>(F_GET_RECEIVER_STREAMING_SRC_IP);
 }
 
@@ -1034,11 +1034,11 @@ void Module::setReceiverStreamingIP(const sls::IpAddr ip) {
     sendToReceiver(F_SET_RECEIVER_STREAMING_SRC_IP, ip, nullptr);
 }
 
-int Module::getClientStreamingPort() { return shm()->zmqport; }
+int Module::getClientStreamingPort() const { return shm()->zmqport; }
 
 void Module::setClientStreamingPort(int port) { shm()->zmqport = port; }
 
-sls::IpAddr Module::getClientStreamingIP() { return shm()->zmqip; }
+sls::IpAddr Module::getClientStreamingIP() const { return shm()->zmqip; }
 
 void Module::setClientStreamingIP(const sls::IpAddr ip) {
     if (ip == 0) {
@@ -1049,7 +1049,7 @@ void Module::setClientStreamingIP(const sls::IpAddr ip) {
 
 //  Eiger Specific
 
-int64_t Module::getSubExptime() {
+int64_t Module::getSubExptime() const {
     return sendToDetector<int64_t>(F_GET_SUB_EXPTIME);
 }
 
@@ -1067,7 +1067,7 @@ void Module::setSubExptime(int64_t value) {
     }
 }
 
-int64_t Module::getSubDeadTime() {
+int64_t Module::getSubDeadTime() const {
     return sendToDetector<int64_t>(F_GET_SUB_DEADTIME);
 }
 
@@ -1078,7 +1078,7 @@ void Module::setSubDeadTime(int64_t value) {
     }
 }
 
-int Module::getThresholdEnergy() {
+int Module::getThresholdEnergy() const {
     // moench - get threshold energy from json header
     if (shm()->myDetectorType == MOENCH) {
         getAdditionalJsonHeader();
@@ -1110,14 +1110,14 @@ void Module::setThresholdEnergy(int e_eV, detectorSettings isettings,
     }
 }
 
-std::string Module::getSettingsDir() { return std::string(shm()->settingsDir); }
+std::string Module::getSettingsDir() const { return std::string(shm()->settingsDir); }
 
 std::string Module::setSettingsDir(const std::string &dir) {
     sls::strcpy_safe(shm()->settingsDir, dir.c_str());
     return shm()->settingsDir;
 }
 
-bool Module::getParallelMode() {
+bool Module::getParallelMode() const {
     auto r = sendToDetector<int>(F_GET_PARALLEL_MODE);
     return static_cast<bool>(r);
 }
@@ -1126,7 +1126,7 @@ void Module::setParallelMode(const bool enable) {
     sendToDetector(F_SET_PARALLEL_MODE, static_cast<int>(enable), nullptr);
 }
 
-bool Module::getOverFlowMode() {
+bool Module::getOverFlowMode() const {
     auto r = sendToDetector<int>(F_GET_OVERFLOW_MODE);
     return static_cast<bool>(r);
 }
@@ -1136,7 +1136,7 @@ void Module::setOverFlowMode(const bool enable) {
     sendToDetector(F_SET_OVERFLOW_MODE, arg, nullptr);
 }
 
-bool Module::getFlippedDataX() {
+bool Module::getFlippedDataX() const {
     return sendToReceiver<int>(F_SET_FLIPPED_DATA_RECEIVER, GET_FLAG);
 }
 
@@ -1144,7 +1144,7 @@ void Module::setFlippedDataX(bool value) {
     sendToReceiver<int>(F_SET_FLIPPED_DATA_RECEIVER, static_cast<int>(value));
 }
 
-std::vector<int> Module::getTrimEn() {
+std::vector<int> Module::getTrimEn() const {
     if (shm()->myDetectorType != EIGER) {
         throw RuntimeError("getTrimEn not implemented for this detector.");
     }
@@ -1167,7 +1167,7 @@ int Module::setTrimEn(const std::vector<int> &energies) {
     return shm()->trimEnergies.size();
 }
 
-int64_t Module::getRateCorrection() {
+int64_t Module::getRateCorrection() const {
     return sendToDetector<int64_t>(F_GET_RATE_CORRECT);
 }
 
@@ -1180,7 +1180,7 @@ void Module::setRateCorrection(int64_t t) {
     sendToDetector(F_SET_RATE_CORRECT, t, nullptr);
 }
 
-int Module::getReadNLines() { return sendToDetector<int>(F_GET_READ_N_LINES); }
+int Module::getReadNLines() const { return sendToDetector<int>(F_GET_READ_N_LINES); }
 
 void Module::setReadNLines(const int value) {
     sendToDetector(F_SET_READ_N_LINES, value, nullptr);
@@ -1189,7 +1189,7 @@ void Module::setReadNLines(const int value) {
     }
 }
 
-bool Module::getInterruptSubframe() {
+bool Module::getInterruptSubframe() const {
     auto r = sendToDetector<int>(F_GET_INTERRUPT_SUBFRAME);
     return static_cast<bool>(r);
 }
@@ -1207,7 +1207,7 @@ int64_t Module::getMeasuredSubFramePeriod() const {
     return sendToDetectorStop<int64_t>(F_GET_MEASURED_SUBPERIOD);
 }
 
-bool Module::getActivate() {
+bool Module::getActivate() const {
     int arg = GET_FLAG;
     auto retval = sendToDetector<int>(F_ACTIVATE, arg);
     auto retval2 = sendToDetectorStop<int>(F_ACTIVATE, arg);
@@ -1229,7 +1229,7 @@ void Module::setActivate(const bool enable) {
     }
 }
 
-bool Module::getDeactivatedRxrPaddingMode() {
+bool Module::getDeactivatedRxrPaddingMode() const {
     return sendToReceiver<int>(F_GET_RECEIVER_DEACTIVATED_PADDING);
 }
 
@@ -1238,7 +1238,7 @@ void Module::setDeactivatedRxrPaddingMode(bool padding) {
                    static_cast<int>(padding), nullptr);
 }
 
-bool Module::getCounterBit() {
+bool Module::getCounterBit() const {
     int arg = GET_FLAG;
     return (!static_cast<bool>(sendToDetector<int>(F_SET_COUNTER_BIT, arg)));
 }
@@ -1261,7 +1261,7 @@ void Module::pulseChip(int n_pulses) {
     sendToDetector(F_PULSE_CHIP, n_pulses, nullptr);
 }
 
-bool Module::getQuad() { return sendToDetector<int>(F_GET_QUAD) != 0; }
+bool Module::getQuad() const { return sendToDetector<int>(F_GET_QUAD) != 0; }
 
 void Module::setQuad(const bool enable) {
     int value = enable ? 1 : 0;
@@ -2142,7 +2142,7 @@ void Module::startPattern() { sendToDetector(F_START_PATTERN); }
 
 // Moench
 
-std::map<std::string, std::string> Module::getAdditionalJsonHeader() {
+std::map<std::string, std::string> Module::getAdditionalJsonHeader() const {
     if (!shm()->useReceiverFlag) {
         throw RuntimeError("Set rx_hostname first to use receiver parameters "
                            "(zmq json header)");
@@ -2217,7 +2217,7 @@ void Module::setAdditionalJsonHeader(
     }
 }
 
-std::string Module::getAdditionalJsonParameter(const std::string &key) {
+std::string Module::getAdditionalJsonParameter(const std::string &key) const {
     char arg[SHORT_STR_LENGTH]{};
     sls::strcpy_safe(arg, key.c_str());
     char retval[SHORT_STR_LENGTH]{};
@@ -2387,7 +2387,7 @@ uint64_t Module::getReceiverCurrentFrameIndex() const {
 // private
 
 void Module::checkArgs(const void *args, size_t args_size, void *retval,
-                              size_t retval_size) const {
+                       size_t retval_size) const {
     if (args == nullptr && args_size != 0)
         throw RuntimeError(
             "Passed nullptr as args to Send function but size is not 0");

--- a/slsDetectorSoftware/src/Module.cpp
+++ b/slsDetectorSoftware/src/Module.cpp
@@ -2386,7 +2386,7 @@ uint64_t Module::getReceiverCurrentFrameIndex() const {
 
 // private
 
-void Module::preSendArgsCheck(const void *args, size_t args_size, void *retval,
+void Module::checkArgs(const void *args, size_t args_size, void *retval,
                               size_t retval_size) const {
     if (args == nullptr && args_size != 0)
         throw RuntimeError(
@@ -2415,7 +2415,7 @@ void Module::sendToDetector(int fnum, const void *args, size_t args_size,
     // This is the only function that actually sends data to the detector
     // the other versions use templates to deduce sizes and create
     // the return type
-    preSendArgsCheck(args, args_size, retval, retval_size);
+    checkArgs(args, args_size, retval, retval_size);
     auto client = DetectorSocket(shm()->hostname, shm()->controlPort);
     client.sendCommandThenRead(fnum, args, args_size, retval, retval_size);
     client.close();
@@ -2528,7 +2528,7 @@ void Module::sendToDetectorStop(int fnum, const void *args, size_t args_size,
     // This is the only function that actually sends data to the detector stop
     // the other versions use templates to deduce sizes and create
     // the return type
-    preSendArgsCheck(args, args_size, retval, retval_size);
+    checkArgs(args, args_size, retval, retval_size);
     auto stop = DetectorSocket(shm()->hostname, shm()->stopPort);
     stop.sendCommandThenRead(fnum, args, args_size, retval, retval_size);
     stop.close();
@@ -2650,7 +2650,7 @@ void Module::sendToReceiver(int fnum, const void *args, size_t args_size,
         oss << getFunctionNameFromEnum(static_cast<detFuncs>(fnum));
         throw RuntimeError(oss.str());
     }
-    preSendArgsCheck(args, args_size, retval, retval_size);
+    checkArgs(args, args_size, retval, retval_size);
     auto receiver = ReceiverSocket(shm()->rxHostname, shm()->rxTCPPort);
     receiver.sendCommandThenRead(fnum, args, args_size, retval, retval_size);
     receiver.close();

--- a/slsDetectorSoftware/src/Module.cpp
+++ b/slsDetectorSoftware/src/Module.cpp
@@ -1273,7 +1273,7 @@ void Module::setQuad(const bool enable) {
 
 // Jungfrau Specific
 
-int Module::getThresholdTemperature() {
+int Module::getThresholdTemperature() const {
     int arg = GET_FLAG;
     auto retval = sendToDetectorStop<int>(F_THRESHOLD_TEMP, arg);
     if (retval != 0) {
@@ -1291,7 +1291,7 @@ void Module::setThresholdTemperature(int val) {
     sendToDetectorStop<int>(F_THRESHOLD_TEMP, val);
 }
 
-bool Module::getTemperatureControl() {
+bool Module::getTemperatureControl() const {
     int arg = GET_FLAG;
     return static_cast<bool>(sendToDetectorStop<int>(F_TEMP_CONTROL, arg));
 }
@@ -1300,7 +1300,7 @@ void Module::setTemperatureControl(bool val) {
     sendToDetectorStop<int>(F_TEMP_CONTROL, static_cast<int>(val));
 }
 
-int Module::getTemperatureEvent() {
+int Module::getTemperatureEvent() const {
     int arg = GET_FLAG;
     return sendToDetectorStop<int>(F_TEMP_EVENT, arg);
 }
@@ -1310,7 +1310,7 @@ void Module::resetTemperatureEvent() {
     sendToDetectorStop<int>(F_TEMP_EVENT, arg);
 }
 
-bool Module::getAutoComparatorDisableMode() {
+bool Module::getAutoComparatorDisableMode() const{
     int arg = GET_FLAG;
     return static_cast<bool>(sendToDetector<int>(F_AUTO_COMP_DISABLE, arg));
 }
@@ -1319,7 +1319,7 @@ void Module::setAutoComparatorDisableMode(bool val) {
     sendToDetector<int>(F_AUTO_COMP_DISABLE, static_cast<int>(val));
 }
 
-int Module::getNumberOfAdditionalStorageCells() {
+int Module::getNumberOfAdditionalStorageCells() const {
     return sendToDetector<int>(F_GET_NUM_ADDITIONAL_STORAGE_CELLS);
 }
 
@@ -1327,7 +1327,7 @@ void Module::setNumberOfAdditionalStorageCells(int value) {
     sendToDetector(F_SET_NUM_ADDITIONAL_STORAGE_CELLS, value, nullptr);
 }
 
-int Module::getStorageCellStart() {
+int Module::getStorageCellStart() const {
     int arg = GET_FLAG;
     return sendToDetector<int>(F_STORAGE_CELL_START, arg);
 }
@@ -1336,7 +1336,7 @@ void Module::setStorageCellStart(int pos) {
     sendToDetector<int>(F_STORAGE_CELL_START, pos);
 }
 
-int64_t Module::getStorageCellDelay() {
+int64_t Module::getStorageCellDelay() const {
     return sendToDetector<int64_t>(F_GET_STORAGE_CELL_DELAY);
 }
 
@@ -1346,7 +1346,7 @@ void Module::setStorageCellDelay(int64_t value) {
 
 // Gotthard Specific
 
-slsDetectorDefs::ROI Module::getROI() {
+slsDetectorDefs::ROI Module::getROI() const {
     return sendToDetector<slsDetectorDefs::ROI>(F_GET_ROI);
 }
 
@@ -1369,7 +1369,7 @@ int64_t Module::getExptimeLeft() const {
 
 // Gotthard2 Specific
 
-int64_t Module::getNumberOfBursts() {
+int64_t Module::getNumberOfBursts() const {
     return sendToDetector<int64_t>(F_GET_NUM_BURSTS);
 }
 
@@ -1380,7 +1380,7 @@ void Module::setNumberOfBursts(int64_t value) {
     }
 }
 
-int64_t Module::getBurstPeriod() {
+int64_t Module::getBurstPeriod() const {
     return sendToDetector<int64_t>(F_GET_BURST_PERIOD);
 }
 
@@ -1388,7 +1388,7 @@ void Module::setBurstPeriod(int64_t value) {
     sendToDetector(F_SET_BURST_PERIOD, value, nullptr);
 }
 
-std::array<int, 2> Module::getInjectChannel() {
+std::array<int, 2> Module::getInjectChannel() const {
     return sendToDetector<std::array<int, 2>>(F_GET_INJECT_CHANNEL);
 }
 
@@ -1398,7 +1398,7 @@ void Module::setInjectChannel(const int offsetChannel,
     sendToDetector(F_SET_INJECT_CHANNEL, args, nullptr);
 }
 
-std::vector<int> Module::getVetoPhoton(const int chipIndex) {
+std::vector<int> Module::getVetoPhoton(const int chipIndex) const {
     int fnum = F_GET_VETO_PHOTON;
     int ret = FAIL;
     auto client = DetectorSocket(shm()->hostname, shm()->controlPort);
@@ -1609,7 +1609,7 @@ void Module::setVetoFile(const int chipIndex, const std::string &fname) {
     }
 }
 
-slsDetectorDefs::burstMode Module::getBurstMode() {
+slsDetectorDefs::burstMode Module::getBurstMode() const{
     auto r = sendToDetector<int>(F_GET_BURST_MODE);
     return static_cast<slsDetectorDefs::burstMode>(r);
 }
@@ -1622,19 +1622,19 @@ void Module::setBurstMode(slsDetectorDefs::burstMode value) {
     }
 }
 
-bool Module::getCDSGain() { return sendToDetector<int>(F_GET_CDS_GAIN); }
+bool Module::getCDSGain() const { return sendToDetector<int>(F_GET_CDS_GAIN); }
 
 void Module::setCDSGain(bool value) {
     sendToDetector(F_SET_CDS_GAIN, static_cast<int>(value), nullptr);
 }
 
-int Module::getFilter() { return sendToDetector<int>(F_GET_FILTER); }
+int Module::getFilter() const { return sendToDetector<int>(F_GET_FILTER); }
 
 void Module::setFilter(int value) {
     sendToDetector(F_SET_FILTER, value, nullptr);
 }
 
-bool Module::getCurrentSource() {
+bool Module::getCurrentSource() const {
     return sendToDetector<int>(F_GET_CURRENT_SOURCE);
 }
 
@@ -1642,7 +1642,7 @@ void Module::setCurrentSource(bool value) {
     sendToDetector(F_SET_CURRENT_SOURCE, static_cast<int>(value), nullptr);
 }
 
-slsDetectorDefs::timingSourceType Module::getTimingSource() {
+slsDetectorDefs::timingSourceType Module::getTimingSource() const {
     auto r = sendToDetector<int>(F_GET_TIMING_SOURCE);
     return static_cast<slsDetectorDefs::timingSourceType>(r);
 }
@@ -1651,13 +1651,13 @@ void Module::setTimingSource(slsDetectorDefs::timingSourceType value) {
     sendToDetector(F_SET_TIMING_SOURCE, static_cast<int>(value), nullptr);
 }
 
-bool Module::getVeto() { return sendToDetector<int>(F_GET_VETO); }
+bool Module::getVeto() const { return sendToDetector<int>(F_GET_VETO); }
 
 void Module::setVeto(bool enable) {
     sendToDetector(F_SET_VETO, static_cast<int>(enable), nullptr);
 }
 
-int Module::getADCConfiguration(const int chipIndex, const int adcIndex) {
+int Module::getADCConfiguration(const int chipIndex, const int adcIndex) const {
     int args[]{chipIndex, adcIndex};
     return sendToDetector<int>(F_GET_ADC_CONFIGURATION, args);
 }
@@ -1668,7 +1668,7 @@ void Module::setADCConfiguration(const int chipIndex, const int adcIndex,
     sendToDetector(F_SET_ADC_CONFIGURATION, args, nullptr);
 }
 
-void Module::getBadChannels(const std::string &fname) {
+void Module::getBadChannels(const std::string &fname) const {
     LOG(logDEBUG1) << "Getting bad channels to " << fname;
     int fnum = F_GET_BAD_CHANNELS;
     int ret = FAIL;
@@ -1754,7 +1754,7 @@ void Module::setBadChannels(const std::string &fname) {
 
 // Mythen3 Specific
 
-uint32_t Module::getCounterMask() {
+uint32_t Module::getCounterMask() const {
     return sendToDetector<uint32_t>(F_GET_COUNTER_MASK);
 }
 
@@ -1768,7 +1768,7 @@ void Module::setCounterMask(uint32_t countermask) {
     }
 }
 
-int Module::getNumberOfGates() { return sendToDetector<int>(F_GET_NUM_GATES); }
+int Module::getNumberOfGates() const { return sendToDetector<int>(F_GET_NUM_GATES); }
 
 void Module::setNumberOfGates(int value) {
     sendToDetector(F_SET_NUM_GATES, value, nullptr);
@@ -1777,12 +1777,12 @@ void Module::setNumberOfGates(int value) {
     }
 }
 
-std::array<time::ns, 3> Module::getExptimeForAllGates() {
+std::array<time::ns, 3> Module::getExptimeForAllGates() const {
     static_assert(sizeof(time::ns) == 8, "ns needs to be 64bit");
     return sendToDetector<std::array<time::ns, 3>>(F_GET_EXPTIME_ALL_GATES);
 }
 
-int64_t Module::getGateDelay(int gateIndex) {
+int64_t Module::getGateDelay(int gateIndex) const {
     return sendToDetector<int64_t>(F_GET_GATE_DELAY, gateIndex);
 }
 
@@ -1794,14 +1794,14 @@ void Module::setGateDelay(int gateIndex, int64_t value) {
     }
 }
 
-std::array<time::ns, 3> Module::getGateDelayForAllGates() {
+std::array<time::ns, 3> Module::getGateDelayForAllGates() const {
     static_assert(sizeof(time::ns) == 8, "ns needs to be 64bit");
     return sendToDetector<std::array<time::ns, 3>>(F_GET_GATE_DELAY_ALL_GATES);
 }
 
 // CTB / Moench Specific
 
-int Module::getNumberOfAnalogSamples() {
+int Module::getNumberOfAnalogSamples() const {
     return sendToDetector<int>(F_GET_NUM_ANALOG_SAMPLES);
 }
 
@@ -1814,7 +1814,7 @@ void Module::setNumberOfAnalogSamples(int value) {
     }
 }
 
-int Module::getPipeline(int clkIndex) {
+int Module::getPipeline(int clkIndex) const {
     return sendToDetector<int>(F_GET_PIPELINE, clkIndex);
 }
 
@@ -1823,7 +1823,7 @@ void Module::setPipeline(int clkIndex, int value) {
     sendToDetector(F_SET_PIPELINE, args, nullptr);
 }
 
-uint32_t Module::getADCEnableMask() {
+uint32_t Module::getADCEnableMask() const {
     return sendToDetector<uint32_t>(F_GET_ADC_ENABLE_MASK);
 }
 
@@ -1841,7 +1841,7 @@ void Module::setADCEnableMask(uint32_t mask) {
     }
 }
 
-uint32_t Module::getTenGigaADCEnableMask() {
+uint32_t Module::getTenGigaADCEnableMask() const {
     return sendToDetector<uint32_t>(F_GET_ADC_ENABLE_MASK_10G);
 }
 
@@ -1861,7 +1861,7 @@ void Module::setTenGigaADCEnableMask(uint32_t mask) {
 
 // CTB Specific
 
-int Module::getNumberOfDigitalSamples() {
+int Module::getNumberOfDigitalSamples() const {
     return sendToDetector<int>(F_GET_NUM_DIGITAL_SAMPLES);
 }
 
@@ -1877,7 +1877,7 @@ void Module::setNumberOfDigitalSamples(int value) {
     }
 }
 
-slsDetectorDefs::readoutMode Module::getReadoutMode() {
+slsDetectorDefs::readoutMode Module::getReadoutMode() const {
     auto r = sendToDetector<int>(F_GET_READOUT_MODE);
     return static_cast<readoutMode>(r);
 }
@@ -1903,7 +1903,7 @@ int Module::setExternalSamplingSource(int value) {
     return sendToDetector<int>(F_EXTERNAL_SAMPLING_SOURCE, value);
 }
 
-bool Module::getExternalSampling() {
+bool Module::getExternalSampling() const{
     int arg = GET_FLAG;
     return sendToDetector<int>(F_EXTERNAL_SAMPLING, arg);
 }
@@ -1932,7 +1932,7 @@ void Module::setReceiverDbitList(const std::vector<int> &list) {
     sendToReceiver(F_SET_RECEIVER_DBIT_LIST, arg, nullptr);
 }
 
-int Module::getReceiverDbitOffset() {
+int Module::getReceiverDbitOffset() const {
     return sendToReceiver<int>(F_GET_RECEIVER_DBIT_OFFSET);
 }
 
@@ -1945,7 +1945,7 @@ void Module::setDigitalIODelay(uint64_t pinMask, int delay) {
     sendToDetector(F_DIGITAL_IO_DELAY, args, nullptr);
 }
 
-bool Module::getLEDEnable() {
+bool Module::getLEDEnable() const {
     int arg = GET_FLAG;
     return static_cast<bool>(sendToDetector<int>(F_LED, arg));
 }
@@ -2058,7 +2058,7 @@ void Module::setPattern(const std::string &fname) {
                    0);
 }
 
-uint64_t Module::getPatternIOControl() {
+uint64_t Module::getPatternIOControl() const {
     int64_t arg = GET_FLAG;
     return sendToDetector<uint64_t>(F_SET_PATTERN_IO_CONTROL, arg);
 }
@@ -2067,7 +2067,7 @@ void Module::setPatternIOControl(uint64_t word) {
     sendToDetector<uint64_t>(F_SET_PATTERN_IO_CONTROL, word);
 }
 
-uint64_t Module::getPatternWord(int addr) {
+uint64_t Module::getPatternWord(int addr) const {
     uint64_t args[]{static_cast<uint64_t>(addr),
                     static_cast<uint64_t>(GET_FLAG)};
     return sendToDetector<uint64_t>(F_SET_PATTERN_WORD, args);
@@ -2078,7 +2078,7 @@ void Module::setPatternWord(int addr, uint64_t word) {
     sendToDetector<uint64_t>(F_SET_PATTERN_WORD, args);
 }
 
-std::array<int, 2> Module::getPatternLoopAddresses(int level) {
+std::array<int, 2> Module::getPatternLoopAddresses(int level) const {
     int args[]{level, GET_FLAG, GET_FLAG};
     std::array<int, 2> retvals{};
     sendToDetector(F_SET_PATTERN_LOOP_ADDRESSES, args, retvals);
@@ -2091,7 +2091,7 @@ void Module::setPatternLoopAddresses(int level, int start, int stop) {
     sendToDetector(F_SET_PATTERN_LOOP_ADDRESSES, args, retvals);
 }
 
-int Module::getPatternLoopCycles(int level) {
+int Module::getPatternLoopCycles(int level) const {
     int args[]{level, GET_FLAG};
     return sendToDetector<int>(F_SET_PATTERN_LOOP_CYCLES, args);
 }
@@ -2101,7 +2101,7 @@ void Module::setPatternLoopCycles(int level, int n) {
     sendToDetector<int>(F_SET_PATTERN_LOOP_CYCLES, args);
 }
 
-int Module::getPatternWaitAddr(int level) {
+int Module::getPatternWaitAddr(int level) const {
     int args[]{level, GET_FLAG};
     return sendToDetector<int>(F_SET_PATTERN_WAIT_ADDR, args);
 }
@@ -2111,7 +2111,7 @@ void Module::setPatternWaitAddr(int level, int addr) {
     sendToDetector<int>(F_SET_PATTERN_WAIT_ADDR, args);
 }
 
-uint64_t Module::getPatternWaitTime(int level) {
+uint64_t Module::getPatternWaitTime(int level) const {
     uint64_t args[]{static_cast<uint64_t>(level),
                     static_cast<uint64_t>(GET_FLAG)};
     return sendToDetector<uint64_t>(F_SET_PATTERN_WAIT_TIME, args);
@@ -2122,7 +2122,7 @@ void Module::setPatternWaitTime(int level, uint64_t t) {
     sendToDetector<uint64_t>(F_SET_PATTERN_WAIT_TIME, args);
 }
 
-uint64_t Module::getPatternMask() {
+uint64_t Module::getPatternMask() const {
     return sendToDetector<uint64_t>(F_GET_PATTERN_MASK);
 }
 
@@ -2130,7 +2130,7 @@ void Module::setPatternMask(uint64_t mask) {
     sendToDetector(F_SET_PATTERN_MASK, mask, nullptr);
 }
 
-uint64_t Module::getPatternBitMask() {
+uint64_t Module::getPatternBitMask() const {
     return sendToDetector<uint64_t>(F_GET_PATTERN_BIT_MASK);
 }
 
@@ -2275,7 +2275,7 @@ void Module::rebootController() {
     LOG(logINFO) << "Controller rebooted successfully!";
 }
 
-uint32_t Module::readRegister(uint32_t addr) {
+uint32_t Module::readRegister(uint32_t addr) const {
     return sendToDetectorStop<uint32_t>(F_READ_REGISTER, addr);
 }
 
@@ -2311,7 +2311,7 @@ void Module::writeAdcRegister(uint32_t addr, uint32_t val) {
     sendToDetector(F_WRITE_ADC_REG, args, nullptr);
 }
 
-uint32_t Module::getADCInvert() {
+uint32_t Module::getADCInvert() const {
     return sendToDetector<uint32_t>(F_GET_ADC_INVERT);
 }
 
@@ -2347,7 +2347,7 @@ int Module::setStopPort(int port_number) {
     return shm()->stopPort;
 }
 
-bool Module::getLockDetector() {
+bool Module::getLockDetector() const {
     int arg = GET_FLAG;
     return static_cast<bool>(sendToDetector<int>(F_LOCK_SERVER, arg));
 }
@@ -2356,7 +2356,7 @@ void Module::setLockDetector(bool lock) {
     sendToDetector<int>(F_LOCK_SERVER, static_cast<int>(lock));
 }
 
-sls::IpAddr Module::getLastClientIP() {
+sls::IpAddr Module::getLastClientIP() const {
     return sendToDetector<sls::IpAddr>(F_GET_LAST_CLIENT_IP);
 }
 

--- a/slsDetectorSoftware/src/Module.h
+++ b/slsDetectorSoftware/src/Module.h
@@ -335,19 +335,19 @@ class Module : public virtual slsDetectorDefs {
      *    Jungfrau Specific                           *
      *                                                *
      * ************************************************/
-    int getThresholdTemperature();
+    int getThresholdTemperature() const;
     void setThresholdTemperature(int val);
-    bool getTemperatureControl();
+    bool getTemperatureControl() const;
     void setTemperatureControl(bool val);
-    int getTemperatureEvent();
+    int getTemperatureEvent() const;
     void resetTemperatureEvent();
-    bool getAutoComparatorDisableMode();
+    bool getAutoComparatorDisableMode() const;
     void setAutoComparatorDisableMode(bool val);
-    int getNumberOfAdditionalStorageCells();
+    int getNumberOfAdditionalStorageCells() const;
     void setNumberOfAdditionalStorageCells(int value);
-    int getStorageCellStart();
+    int getStorageCellStart() const;
     void setStorageCellStart(int pos);
-    int64_t getStorageCellDelay();
+    int64_t getStorageCellDelay() const;
     void setStorageCellDelay(int64_t value);
 
     /**************************************************
@@ -355,7 +355,7 @@ class Module : public virtual slsDetectorDefs {
      *    Gotthard Specific                           *
      *                                                *
      * ************************************************/
-    slsDetectorDefs::ROI getROI();
+    slsDetectorDefs::ROI getROI() const;
     void setROI(slsDetectorDefs::ROI arg);
     void clearROI();
     int64_t getExptimeLeft() const;
@@ -365,33 +365,33 @@ class Module : public virtual slsDetectorDefs {
      *    Gotthard2 Specific                          *
      *                                                *
      * ************************************************/
-    int64_t getNumberOfBursts();
+    int64_t getNumberOfBursts() const;
     void setNumberOfBursts(int64_t value);
-    int64_t getBurstPeriod();
+    int64_t getBurstPeriod() const;
     void setBurstPeriod(int64_t value);
-    std::array<int, 2> getInjectChannel();
+    std::array<int, 2> getInjectChannel() const;
     void setInjectChannel(const int offsetChannel, const int incrementChannel);
-    std::vector<int> getVetoPhoton(const int chipIndex);
+    std::vector<int> getVetoPhoton(const int chipIndex) const;
     void setVetoPhoton(const int chipIndex, const int numPhotons,
                        const int energy, const std::string &fname);
     void setVetoReference(const int gainIndex, const int value);
     void setVetoFile(const int chipIndex, const std::string &fname);
-    burstMode getBurstMode();
+    burstMode getBurstMode() const;
     void setBurstMode(burstMode value);
-    bool getCDSGain();
+    bool getCDSGain() const;
     void setCDSGain(bool value);
-    int getFilter();
+    int getFilter() const;
     void setFilter(int value);
-    bool getCurrentSource();
+    bool getCurrentSource() const;
     void setCurrentSource(bool value);
-    slsDetectorDefs::timingSourceType getTimingSource();
+    slsDetectorDefs::timingSourceType getTimingSource() const;
     void setTimingSource(slsDetectorDefs::timingSourceType value);
-    bool getVeto();
+    bool getVeto() const;
     void setVeto(bool enable);
-    int getADCConfiguration(const int chipIndex, const int adcIndex);
+    int getADCConfiguration(const int chipIndex, const int adcIndex) const;
     void setADCConfiguration(const int chipIndex, const int adcIndex,
                              int value);
-    void getBadChannels(const std::string &fname);
+    void getBadChannels(const std::string &fname) const;
     void setBadChannels(const std::string &fname);
 
     /**************************************************
@@ -399,27 +399,27 @@ class Module : public virtual slsDetectorDefs {
      *    Mythen3 Specific                            *
      *                                                *
      * ************************************************/
-    uint32_t getCounterMask();
+    uint32_t getCounterMask() const;
     void setCounterMask(uint32_t countermask);
-    int getNumberOfGates();
+    int getNumberOfGates() const;
     void setNumberOfGates(int value);
-    std::array<time::ns, 3> getExptimeForAllGates();
-    int64_t getGateDelay(int gateIndex);
+    std::array<time::ns, 3> getExptimeForAllGates() const;
+    int64_t getGateDelay(int gateIndex) const;
     void setGateDelay(int gateIndex, int64_t value);
-    std::array<time::ns, 3> getGateDelayForAllGates();
+    std::array<time::ns, 3> getGateDelayForAllGates() const;
 
     /**************************************************
      *                                                *
      *    CTB / Moench Specific                       *
      *                                                *
      * ************************************************/
-    int getNumberOfAnalogSamples();
+    int getNumberOfAnalogSamples() const;
     void setNumberOfAnalogSamples(int value);
-    int getPipeline(int clkIndex);
+    int getPipeline(int clkIndex) const;
     void setPipeline(int clkIndex, int value);
-    uint32_t getADCEnableMask();
+    uint32_t getADCEnableMask() const;
     void setADCEnableMask(uint32_t mask);
-    uint32_t getTenGigaADCEnableMask();
+    uint32_t getTenGigaADCEnableMask() const;
     void setTenGigaADCEnableMask(uint32_t mask);
 
     /**************************************************
@@ -427,20 +427,20 @@ class Module : public virtual slsDetectorDefs {
      *    CTB Specific                                *
      *                                                *
      * ************************************************/
-    int getNumberOfDigitalSamples();
+    int getNumberOfDigitalSamples() const;
     void setNumberOfDigitalSamples(int value);
-    readoutMode getReadoutMode();
+    readoutMode getReadoutMode() const;
     void setReadoutMode(const readoutMode mode);
     int getExternalSamplingSource();
     int setExternalSamplingSource(int value);
-    bool getExternalSampling();
+    bool getExternalSampling() const;
     void setExternalSampling(bool value);
     std::vector<int> getReceiverDbitList() const;
     void setReceiverDbitList(const std::vector<int> &list);
-    int getReceiverDbitOffset();
+    int getReceiverDbitOffset() const;
     void setReceiverDbitOffset(int value);
     void setDigitalIODelay(uint64_t pinMask, int delay);
-    bool getLEDEnable();
+    bool getLEDEnable() const;
     void setLEDEnable(bool enable);
 
     /**************************************************
@@ -449,21 +449,21 @@ class Module : public virtual slsDetectorDefs {
      *                                                *
      * ************************************************/
     void setPattern(const std::string &fname);
-    uint64_t getPatternIOControl();
+    uint64_t getPatternIOControl() const;
     void setPatternIOControl(uint64_t word);
-    uint64_t getPatternWord(int addr);
+    uint64_t getPatternWord(int addr) const;
     void setPatternWord(int addr, uint64_t word);
-    std::array<int, 2> getPatternLoopAddresses(int level);
+    std::array<int, 2> getPatternLoopAddresses(int level) const;
     void setPatternLoopAddresses(int level, int start, int stop);
-    int getPatternLoopCycles(int level);
+    int getPatternLoopCycles(int level) const;
     void setPatternLoopCycles(int level, int n);
-    int getPatternWaitAddr(int level);
+    int getPatternWaitAddr(int level) const;
     void setPatternWaitAddr(int level, int addr);
-    uint64_t getPatternWaitTime(int level);
+    uint64_t getPatternWaitTime(int level) const;
     void setPatternWaitTime(int level, uint64_t t);
-    uint64_t getPatternMask();
+    uint64_t getPatternMask() const;
     void setPatternMask(uint64_t mask);
-    uint64_t getPatternBitMask();
+    uint64_t getPatternBitMask() const;
     void setPatternBitMask(uint64_t mask);
     void startPattern();
 
@@ -489,14 +489,14 @@ class Module : public virtual slsDetectorDefs {
     void copyDetectorServer(const std::string &fname,
                             const std::string &hostname);
     void rebootController();
-    uint32_t readRegister(uint32_t addr);
+    uint32_t readRegister(uint32_t addr) const;
     uint32_t writeRegister(uint32_t addr, uint32_t val);
     uint32_t setBit(uint32_t addr, int n);
     uint32_t clearBit(uint32_t addr, int n);
     void executeFirmwareTest();
     void executeBusTest();
     void writeAdcRegister(uint32_t addr, uint32_t val);
-    uint32_t getADCInvert();
+    uint32_t getADCInvert() const;
     void setADCInvert(uint32_t value);
 
     /**************************************************
@@ -508,9 +508,9 @@ class Module : public virtual slsDetectorDefs {
     int setControlPort(int port_number);
     int getStopPort() const;
     int setStopPort(int port_number);
-    bool getLockDetector();
+    bool getLockDetector() const;
     void setLockDetector(bool lock);
-    sls::IpAddr getLastClientIP();
+    sls::IpAddr getLastClientIP() const;
     std::string execCommand(const std::string &cmd);
     int64_t getNumberOfFramesFromStart() const;
     int64_t getActualTime() const;

--- a/slsDetectorSoftware/src/Module.h
+++ b/slsDetectorSoftware/src/Module.h
@@ -78,7 +78,7 @@ class Module : public virtual slsDetectorDefs {
     Safe to call only if detector shm also deleted or its numberOfDetectors is
     updated */
     void freeSharedMemory();
-    bool isFixedPatternSharedMemoryCompatible();
+    bool isFixedPatternSharedMemoryCompatible() const;
     std::string getHostname() const;
 
     /** initialChecks is enable or disable initial compatibility checks and
@@ -86,9 +86,9 @@ class Module : public virtual slsDetectorDefs {
     users! */
     void setHostname(const std::string &hostname, const bool initialChecks);
 
-    int64_t getFirmwareVersion();
-    int64_t getDetectorServerVersion();
-    int64_t getSerialNumber();
+    int64_t getFirmwareVersion() const;
+    int64_t getDetectorServerVersion() const;
+    int64_t getSerialNumber() const;
     int64_t getReceiverSoftwareVersion() const;
     static detectorType getTypeFromDetector(const std::string &hostname,
                                             int cport = DEFAULT_PORTNO);
@@ -98,10 +98,10 @@ class Module : public virtual slsDetectorDefs {
     void updateNumberOfChannels();
     slsDetectorDefs::xy getNumberOfChannels() const;
     void updateNumberOfDetector(slsDetectorDefs::xy det);
-    detectorSettings getSettings();
+    detectorSettings getSettings() const;
     void setSettings(detectorSettings isettings);
     void loadSettingsFile(const std::string &fname);
-    int getAllTrimbits();
+    int getAllTrimbits() const;
     void setAllTrimbits(int val);
 
     /**************************************************
@@ -109,45 +109,45 @@ class Module : public virtual slsDetectorDefs {
      *    Acquisition Parameters                      *
      *                                                *
      * ************************************************/
-    int64_t getNumberOfFrames();
+    int64_t getNumberOfFrames() const;
     void setNumberOfFrames(int64_t value);
-    int64_t getNumberOfTriggers();
+    int64_t getNumberOfTriggers() const;
     void setNumberOfTriggers(int64_t value);
     /** [Mythen3] gatIndex: 0-2, [Others]: -1 always */
-    int64_t getExptime(int gateIndex);
+    int64_t getExptime(int gateIndex) const;
     /** [Mythen3] gatIndex: -1 for all, 0-2, [Others]: -1 always */
     void setExptime(int gateIndex, int64_t value);
-    int64_t getPeriod();
+    int64_t getPeriod() const;
     void setPeriod(int64_t value);
-    int64_t getDelayAfterTrigger();
+    int64_t getDelayAfterTrigger() const;
     void setDelayAfterTrigger(int64_t value);
     int64_t getNumberOfFramesLeft() const;
     int64_t getNumberOfTriggersLeft() const;
     int64_t getDelayAfterTriggerLeft() const;
     int64_t getPeriodLeft() const;
-    int getDynamicRange();
+    int getDynamicRange() const;
     void setDynamicRange(int n);
-    timingMode getTimingMode();
+    timingMode getTimingMode() const;
     void setTimingMode(timingMode value);
-    int getClockDivider(int clkIndex);
+    int getClockDivider(int clkIndex) const;
     void setClockDivider(int clkIndex, int value);
-    int getClockPhase(int clkIndex, bool inDegrees);
+    int getClockPhase(int clkIndex, bool inDegrees) const;
     void setClockPhase(int clkIndex, int value, bool inDegrees);
-    int getMaxClockPhaseShift(int clkIndex);
-    int getClockFrequency(int clkIndex);
+    int getMaxClockPhaseShift(int clkIndex) const;
+    int getClockFrequency(int clkIndex) const;
     void setClockFrequency(int clkIndex, int value);
-    int getDAC(dacIndex index, bool mV);
+    int getDAC(dacIndex index, bool mV) const;
     void setDAC(int val, dacIndex index, bool mV);
-    bool getPowerChip();
+    bool getPowerChip() const;
     void setPowerChip(bool on);
-    int getImageTestMode();
+    int getImageTestMode() const;
     void setImageTestMode(const int value);
     /* temperature in millidegrees */
-    int getADC(dacIndex index);
-    int getOnChipDAC(slsDetectorDefs::dacIndex index, int chipIndex);
+    int getADC(dacIndex index) const;
+    int getOnChipDAC(slsDetectorDefs::dacIndex index, int chipIndex) const;
     void setOnChipDAC(slsDetectorDefs::dacIndex index, int chipIndex,
                       int value);
-    externalSignalFlag getExternalSignalFlags(int signalIndex);
+    externalSignalFlag getExternalSignalFlags(int signalIndex) const;
     void setExternalSignalFlags(int signalIndex, externalSignalFlag type);
 
     /**************************************************
@@ -165,53 +165,53 @@ class Module : public virtual slsDetectorDefs {
     int getReceiverProgress() const;
     int64_t getFramesCaughtByReceiver() const;
     std::vector<uint64_t> getNumMissingPackets() const;
-    uint64_t getStartingFrameNumber();
+    uint64_t getStartingFrameNumber() const;
     void setStartingFrameNumber(uint64_t value);
     void sendSoftwareTrigger();
-    defs::scanParameters getScan();
+    defs::scanParameters getScan() const;
     void setScan(const defs::scanParameters t);
-    std::string getScanErrorMessage();
+    std::string getScanErrorMessage() const;
 
     /**************************************************
      *                                                 *
      *    Network Configuration (Detector<->Receiver)  *
      *                                                 *
      * ************************************************/
-    int getNumberofUDPInterfacesFromShm();
-    int getNumberofUDPInterfaces();
+    int getNumberofUDPInterfacesFromShm() const;
+    int getNumberofUDPInterfaces() const;
     void setNumberofUDPInterfaces(int n);
-    int getSelectedUDPInterface();
+    int getSelectedUDPInterface() const;
     void selectUDPInterface(int n);
-    sls::IpAddr getSourceUDPIP();
+    sls::IpAddr getSourceUDPIP() const;
     void setSourceUDPIP(const sls::IpAddr ip);
-    sls::IpAddr getSourceUDPIP2();
+    sls::IpAddr getSourceUDPIP2() const;
     void setSourceUDPIP2(const sls::IpAddr ip);
-    sls::MacAddr getSourceUDPMAC();
+    sls::MacAddr getSourceUDPMAC() const;
     void setSourceUDPMAC(const sls::MacAddr mac);
-    sls::MacAddr getSourceUDPMAC2();
+    sls::MacAddr getSourceUDPMAC2() const;
     void setSourceUDPMAC2(const sls::MacAddr mac);
-    sls::IpAddr getDestinationUDPIP();
+    sls::IpAddr getDestinationUDPIP() const;
     void setDestinationUDPIP(const sls::IpAddr ip);
-    sls::IpAddr getDestinationUDPIP2();
+    sls::IpAddr getDestinationUDPIP2() const;
     void setDestinationUDPIP2(const sls::IpAddr ip);
-    sls::MacAddr getDestinationUDPMAC();
+    sls::MacAddr getDestinationUDPMAC() const;
     void setDestinationUDPMAC(const sls::MacAddr mac);
-    sls::MacAddr getDestinationUDPMAC2();
+    sls::MacAddr getDestinationUDPMAC2() const;
     void setDestinationUDPMAC2(const sls::MacAddr mac);
-    int getDestinationUDPPort();
+    int getDestinationUDPPort() const;
     void setDestinationUDPPort(int udpport);
-    int getDestinationUDPPort2();
+    int getDestinationUDPPort2() const;
     void setDestinationUDPPort2(int udpport);
     std::string printReceiverConfiguration();
-    bool getTenGiga();
+    bool getTenGiga() const;
     void setTenGiga(bool value);
-    bool getTenGigaFlowControl();
+    bool getTenGigaFlowControl() const;
     void setTenGigaFlowControl(bool enable);
-    int getTransmissionDelayFrame();
+    int getTransmissionDelayFrame() const;
     void setTransmissionDelayFrame(int value);
-    int getTransmissionDelayLeft();
+    int getTransmissionDelayLeft() const;
     void setTransmissionDelayLeft(int value);
-    int getTransmissionDelayRight();
+    int getTransmissionDelayRight() const;
     void setTransmissionDelayRight(int value);
 
     /**************************************************
@@ -224,18 +224,18 @@ class Module : public virtual slsDetectorDefs {
     void setReceiverHostname(const std::string &receiver);
     int getReceiverPort() const;
     int setReceiverPort(int port_number);
-    int getReceiverFifoDepth();
+    int getReceiverFifoDepth() const;
     void setReceiverFifoDepth(int n_frames);
-    bool getReceiverSilentMode();
+    bool getReceiverSilentMode() const;
     void setReceiverSilentMode(bool enable);
-    frameDiscardPolicy getReceiverFramesDiscardPolicy();
+    frameDiscardPolicy getReceiverFramesDiscardPolicy() const;
     void setReceiverFramesDiscardPolicy(frameDiscardPolicy f);
-    bool getPartialFramesPadding();
+    bool getPartialFramesPadding() const;
     void setPartialFramesPadding(bool padding);
     int64_t getReceiverUDPSocketBufferSize() const;
     int64_t getReceiverRealUDPSocketBufferSize() const;
     void setReceiverUDPSocketBufferSize(int64_t udpsockbufsize);
-    bool getReceiverLock();
+    bool getReceiverLock() const;
     void setReceiverLock(bool lock);
     sls::IpAddr getReceiverLastClientIP() const;
     std::array<pid_t, NUM_RX_THREAD_IDS> getReceiverThreadIds() const;
@@ -245,22 +245,22 @@ class Module : public virtual slsDetectorDefs {
      *    File                                        *
      *                                                *
      * ************************************************/
-    fileFormat getFileFormat();
+    fileFormat getFileFormat() const;
     void setFileFormat(fileFormat f);
-    std::string getFilePath();
+    std::string getFilePath() const;
     void setFilePath(const std::string &path);
-    std::string getFileName();
+    std::string getFileName() const;
     void setFileName(const std::string &fname);
-    int64_t getFileIndex();
+    int64_t getFileIndex() const;
     void setFileIndex(int64_t file_index);
     void incrementFileIndex();
-    bool getFileWrite();
+    bool getFileWrite() const;
     void setFileWrite(bool value);
-    bool getMasterFileWrite();
+    bool getMasterFileWrite() const;
     void setMasterFileWrite(bool value);
-    bool getFileOverWrite();
+    bool getFileOverWrite() const;
     void setFileOverWrite(bool value);
-    int getFramesPerFile();
+    int getFramesPerFile() const;
     /** 0 will set frames per file to unlimited */
     void setFramesPerFile(int n_frames);
 
@@ -269,22 +269,22 @@ class Module : public virtual slsDetectorDefs {
      *    ZMQ Streaming Parameters (Receiver<->Client)*
      *                                                *
      * ************************************************/
-    bool getReceiverStreaming();
+    bool getReceiverStreaming() const;
     void setReceiverStreaming(bool enable);
-    int getReceiverStreamingFrequency();
+    int getReceiverStreamingFrequency() const;
     /** Option: nth frame streamed out, if 0, streamed out at a timer of 200 */
     void setReceiverStreamingFrequency(int freq);
-    int getReceiverStreamingTimer();
+    int getReceiverStreamingTimer() const;
     void setReceiverStreamingTimer(int time_in_ms = 200);
-    int getReceiverStreamingStartingFrame();
+    int getReceiverStreamingStartingFrame() const;
     void setReceiverStreamingStartingFrame(int fnum);
-    int getReceiverStreamingPort();
+    int getReceiverStreamingPort() const;
     void setReceiverStreamingPort(int port);
-    sls::IpAddr getReceiverStreamingIP();
+    sls::IpAddr getReceiverStreamingIP() const;
     void setReceiverStreamingIP(const sls::IpAddr ip);
-    int getClientStreamingPort();
+    int getClientStreamingPort() const;
     void setClientStreamingPort(int port);
-    sls::IpAddr getClientStreamingIP();
+    sls::IpAddr getClientStreamingIP() const;
     void setClientStreamingIP(const sls::IpAddr ip);
 
     /**************************************************
@@ -292,42 +292,42 @@ class Module : public virtual slsDetectorDefs {
      *    Eiger Specific                              *
      *                                                *
      * ************************************************/
-    int64_t getSubExptime();
+    int64_t getSubExptime() const;
     void setSubExptime(int64_t value);
-    int64_t getSubDeadTime();
+    int64_t getSubDeadTime() const;
     void setSubDeadTime(int64_t value);
-    int getThresholdEnergy();
+    int getThresholdEnergy() const;
     void setThresholdEnergy(int e_eV, detectorSettings isettings,
                             bool trimbits);
-    std::string getSettingsDir();
+    std::string getSettingsDir() const;
     std::string setSettingsDir(const std::string &dir);
-    bool getParallelMode();
+    bool getParallelMode() const;
     void setParallelMode(const bool enable);
-    bool getOverFlowMode();
+    bool getOverFlowMode() const;
     void setOverFlowMode(const bool enable);
-    bool getFlippedDataX();
+    bool getFlippedDataX() const;
     void setFlippedDataX(bool value);
-    std::vector<int> getTrimEn();
+    std::vector<int> getTrimEn() const;
     int setTrimEn(const std::vector<int> &energies = {});
-    int64_t getRateCorrection();
+    int64_t getRateCorrection() const;
     void setDefaultRateCorrection();
     void setRateCorrection(int64_t t = 0);
-    int getReadNLines();
+    int getReadNLines() const;
     void setReadNLines(const int value);
-    bool getInterruptSubframe();
+    bool getInterruptSubframe() const;
     void setInterruptSubframe(const bool enable);
     int64_t getMeasuredPeriod() const;
     int64_t getMeasuredSubFramePeriod() const;
-    bool getActivate();
+    bool getActivate() const;
     void setActivate(const bool enable);
-    bool getDeactivatedRxrPaddingMode();
+    bool getDeactivatedRxrPaddingMode() const;
     void setDeactivatedRxrPaddingMode(bool padding);
-    bool getCounterBit();
+    bool getCounterBit() const;
     void setCounterBit(bool cb);
     void pulsePixel(int n = 0, int x = 0, int y = 0);
     void pulsePixelNMove(int n = 0, int x = 0, int y = 0);
     void pulseChip(int n_pulses = 0);
-    bool getQuad();
+    bool getQuad() const;
     void setQuad(const bool enable);
 
     /**************************************************
@@ -472,10 +472,10 @@ class Module : public virtual slsDetectorDefs {
      *    Moench                                      *
      *                                                *
      * ************************************************/
-    std::map<std::string, std::string> getAdditionalJsonHeader();
+    std::map<std::string, std::string> getAdditionalJsonHeader() const;
     void setAdditionalJsonHeader(
         const std::map<std::string, std::string> &jsonHeader);
-    std::string getAdditionalJsonParameter(const std::string &key);
+    std::string getAdditionalJsonParameter(const std::string &key) const;
     void setAdditionalJsonParameter(const std::string &key,
                                     const std::string &value);
 

--- a/slsDetectorSoftware/src/Module.h
+++ b/slsDetectorSoftware/src/Module.h
@@ -518,7 +518,8 @@ class Module : public virtual slsDetectorDefs {
     uint64_t getReceiverCurrentFrameIndex() const;
 
   private:
-    void preSendArgsCheck(const void * args, size_t args_size, void * retval, size_t retval_size) const;
+    void preSendArgsCheck(const void *args, size_t args_size, void *retval,
+                          size_t retval_size) const;
 
     /**
      * Send function parameters to detector (control server)
@@ -536,16 +537,33 @@ class Module : public virtual slsDetectorDefs {
 
     template <typename Arg, typename Ret>
     void sendToDetector(int fnum, const Arg &args, Ret &retval);
+
+    template <typename Arg, typename Ret>
+    void sendToDetector(int fnum, const Arg &args, Ret &retval) const;
+
     template <typename Arg>
     void sendToDetector(int fnum, const Arg &args, std::nullptr_t);
+
+    template <typename Arg>
+    void sendToDetector(int fnum, const Arg &args, std::nullptr_t) const;
+
     template <typename Ret>
     void sendToDetector(int fnum, std::nullptr_t, Ret &retval);
+
+    template <typename Ret>
+    void sendToDetector(int fnum, std::nullptr_t, Ret &retval) const;
+
     void sendToDetector(int fnum);
+    void sendToDetector(int fnum) const;
 
     template <typename Ret> Ret sendToDetector(int fnum);
+    template <typename Ret> Ret sendToDetector(int fnum) const;
 
     template <typename Ret, typename Arg>
     Ret sendToDetector(int fnum, const Arg &args);
+
+    template <typename Ret, typename Arg>
+    Ret sendToDetector(int fnum, const Arg &args) const;
 
     /** Send function parameters to detector (stop server) */
     void sendToDetectorStop(int fnum, const void *args, size_t args_size,
@@ -582,6 +600,9 @@ class Module : public virtual slsDetectorDefs {
 
     template <typename Ret, typename Arg>
     Ret sendToDetectorStop(int fnum, const Arg &args);
+
+    template <typename Ret, typename Arg>
+    Ret sendToDetectorStop(int fnum, const Arg &args) const;
 
     /** Send function parameters to receiver */
     void sendToReceiver(int fnum, const void *args, size_t args_size,

--- a/slsDetectorSoftware/src/Module.h
+++ b/slsDetectorSoftware/src/Module.h
@@ -518,7 +518,7 @@ class Module : public virtual slsDetectorDefs {
     uint64_t getReceiverCurrentFrameIndex() const;
 
   private:
-    void preSendArgsCheck(const void *args, size_t args_size, void *retval,
+    void checkArgs(const void *args, size_t args_size, void *retval,
                           size_t retval_size) const;
 
     /**

--- a/slsDetectorSoftware/src/Module.h
+++ b/slsDetectorSoftware/src/Module.h
@@ -518,6 +518,8 @@ class Module : public virtual slsDetectorDefs {
     uint64_t getReceiverCurrentFrameIndex() const;
 
   private:
+    void preSendArgsCheck(const void * args, size_t args_size, void * retval, size_t retval_size) const;
+
     /**
      * Send function parameters to detector (control server)
      * @param fnum function enum
@@ -528,6 +530,9 @@ class Module : public virtual slsDetectorDefs {
      */
     void sendToDetector(int fnum, const void *args, size_t args_size,
                         void *retval, size_t retval_size);
+
+    void sendToDetector(int fnum, const void *args, size_t args_size,
+                        void *retval, size_t retval_size) const;
 
     template <typename Arg, typename Ret>
     void sendToDetector(int fnum, const Arg &args, Ret &retval);


### PR DESCRIPTION
- Reduced code duplication between const and non const sendToDetector/sendToReceiver
- Static asserts to prevent from passing in pointers to the templated functions
- Runtime check that the combination of size and nullptr is sane