### PR TITLE
Exposing vector of strings for loading parameters

### DIFF
--- a/python/slsdet/detector.py
+++ b/python/slsdet/detector.py
@@ -119,9 +119,10 @@ class Detector(CppDetectorApi):
         return NotImplementedError("parameters is set only")
 
     @parameters.setter
-    def parameters(self, fname):
-        fname = ut.make_string_path(fname)
-        self.loadParameters(fname)
+    def parameters(self, value):
+        if isinstance(value, str):
+            value = ut.make_string_path(value)
+        self.loadParameters(value)
 
     @property
     def hostname(self):

--- a/python/src/detector.cpp
+++ b/python/src/detector.cpp
@@ -36,6 +36,10 @@ void init_det(py::module &m) {
              (void (Detector::*)(const std::string &)) &
                  Detector::loadParameters,
              py::arg())
+        .def("loadParameters",
+             (void (Detector::*)(const std::vector<std::string> &)) &
+                 Detector::loadParameters,
+             py::arg())
         .def("getHostname",
              (Result<std::string>(Detector::*)(sls::Positions) const) &
                  Detector::getHostname,

--- a/slsDetectorSoftware/include/Detector.h
+++ b/slsDetectorSoftware/include/Detector.h
@@ -53,6 +53,8 @@ class Detector {
     /** Shared memory not freed prior. Set up per measurement. */
     void loadParameters(const std::string &fname);
 
+    void loadParameters(const std::vector<std::string>& parameters);
+
     Result<std::string> getHostname(Positions pos = {}) const;
 
     /* Frees shared memory, adds detectors to the list */


### PR DESCRIPTION
Parameters can now be loaded either from file or from a vector of strings:

```cpp

Detector d;

//Load from file
std::string fname = "some/file/name.par";
d.loadParameters(fname);

// Load from vector of strings
std::vector<std::string> par{"exptime 1ms", "period 2ms", "frames 10"};
d.loadParameters(par);

```

A similar syntax also works from python

```python

from slsdet import Detector
d = Detector()

#load from file
d.parameters = "~/some/file.par"

#load from list of strings
d.parameters = ["exptime 1ms", "frames 3"]
```

Closes #144