### PR TITLE
Adding auto generated server default #define in documentation

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -65,6 +65,7 @@ configure_file(
 
 add_custom_target(docs
               gendoc
+              python gen_server_doc.py
               COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYGEN_OUT}
               COMMAND ${SPHINX_EXECUTABLE} -a -b html
               -Dbreathe_projects.slsDetectorPackage=${CMAKE_CURRENT_BINARY_DIR}/xml
@@ -80,6 +81,3 @@ add_custom_target(rst
               ${SPHINX_BUILD}/src 
               ${SPHINX_BUILD}/html
               COMMENT "Generating documentation with Sphinx")
-
-add_custom_target(hej
-                  python gen_server_doc.py) 

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -81,3 +81,5 @@ add_custom_target(rst
               ${SPHINX_BUILD}/src 
               ${SPHINX_BUILD}/html
               COMMENT "Generating documentation with Sphinx")
+
+add_custom_target(server_rst python gen_server_doc.py)

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -63,9 +63,12 @@ configure_file(
   "${SPHINX_BUILD}/gen_server_doc.py"
   @ONLY)
 
+
+add_custom_target(server_rst python gen_server_doc.py)  
+
 add_custom_target(docs
               gendoc
-              python gen_server_doc.py
+              COMMAND python gen_server_doc.py
               COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYGEN_OUT}
               COMMAND ${SPHINX_EXECUTABLE} -a -b html
               -Dbreathe_projects.slsDetectorPackage=${CMAKE_CURRENT_BINARY_DIR}/xml
@@ -82,4 +85,3 @@ add_custom_target(rst
               ${SPHINX_BUILD}/html
               COMMENT "Generating documentation with Sphinx")
 
-add_custom_target(server_rst python gen_server_doc.py)

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -63,6 +63,10 @@ configure_file(
   "${SPHINX_BUILD}/gen_server_doc.py"
   @ONLY)
 
+  configure_file(
+  "${CMAKE_CURRENT_SOURCE_DIR}/static/extra.css"
+  "${SPHINX_BUILD}/static/css/extra.css"
+  @ONLY)
 
 add_custom_target(server_rst python gen_server_doc.py)  
 

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -38,6 +38,7 @@ set(SPHINX_SOURCE_FILES
   src/pydetector.rst
   src/pyenums.rst
   src/pyexamples.rst
+  src/servers.rst
   src/receiver.rst
   src/result.rst
   src/type_traits.rst
@@ -57,6 +58,11 @@ configure_file(
   "${SPHINX_BUILD}/conf.py"
   @ONLY)
 
+configure_file(
+  "${CMAKE_CURRENT_SOURCE_DIR}/gen_server_doc.py.in"
+  "${SPHINX_BUILD}/gen_server_doc.py"
+  @ONLY)
+
 add_custom_target(docs
               gendoc
               COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYGEN_OUT}
@@ -74,3 +80,6 @@ add_custom_target(rst
               ${SPHINX_BUILD}/src 
               ${SPHINX_BUILD}/html
               COMMENT "Generating documentation with Sphinx")
+
+add_custom_target(hej
+                  python gen_server_doc.py) 

--- a/docs/conf.py.in
+++ b/docs/conf.py.in
@@ -59,4 +59,8 @@ html_theme = "sphinx_rtd_theme"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-#html_static_path = ['_static']
+html_static_path = ['static']
+
+
+def setup(app):
+    app.add_stylesheet('css/extra.css')  # may also be an URL

--- a/docs/gen_server_doc.py.in
+++ b/docs/gen_server_doc.py.in
@@ -2,15 +2,21 @@ import os
 import re
 from pathlib import Path
 
+
+
 # @CMAKE_CURRENT_BINARY_DIR@
 
-src = Path('@CMAKE_SOURCE_DIR@')/'slsDetectorServers/'
+print('\n\n\n\n SERVER CSV')
 
-detectors = ['Mythen3', 'Gotthard2', 'Eiger', 'Jungfrau', 'Moench', 'Gotthard', 'Ctb']
+src = Path('@CMAKE_SOURCE_DIR@')/'slsDetectorServers/'
+detectors = ['Mythen3', 'Gotthard2', 'Eiger', 
+            'Jungfrau', 'Moench', 'Gotthard', 'Ctb']
 
 
 for det in detectors:
-    with open(src/f'{det.lower()}DetectorServer/slsDetectorServer_defs.h') as f:
+    in_fname = src/f'{det.lower()}DetectorServer/slsDetectorServer_defs.h'
+    print(f'Reading: {in_fname}')
+    with open(in_fname) as f:
         lines = f.read().replace('\\\n', '')
         lines = lines.splitlines(keepends = True)
 
@@ -38,6 +44,10 @@ for det in detectors:
 
 
     rstpath = Path('@CMAKE_SOURCE_DIR@')/'docs/src/'
-    with open(f'src/{det.lower()}.csv', 'w') as f:
+
+    out_fname = Path.cwd()/f'src/{det.lower()}.csv'
+    print(f'Writing: {out_fname}')
+    with open(out_fname, 'w') as f:
         f.writelines(output)
 
+print('END\n\n\n\n')

--- a/docs/gen_server_doc.py.in
+++ b/docs/gen_server_doc.py.in
@@ -6,7 +6,7 @@ from pathlib import Path
 
 src = Path('@CMAKE_SOURCE_DIR@')/'slsDetectorServers/'
 
-detectors = ['Mythen3', 'Gotthard2', 'Eiger', 'Jungfrau', 'Moench', 'Gotthard']
+detectors = ['Mythen3', 'Gotthard2', 'Eiger', 'Jungfrau', 'Moench', 'Gotthard', 'Ctb']
 
 
 for det in detectors:

--- a/docs/gen_server_doc.py.in
+++ b/docs/gen_server_doc.py.in
@@ -1,0 +1,43 @@
+import os 
+import re
+from pathlib import Path
+
+# @CMAKE_CURRENT_BINARY_DIR@
+
+src = Path('@CMAKE_SOURCE_DIR@')/'slsDetectorServers/'
+
+detectors = ['Mythen3', 'Gotthard2', 'Eiger', 'Jungfrau', 'Moench', 'Gotthard']
+
+
+for det in detectors:
+    with open(src/f'{det.lower()}DetectorServer/slsDetectorServer_defs.h') as f:
+        lines = f.read().replace('\\\n', '')
+        lines = lines.splitlines(keepends = True)
+
+    lines = [l.strip('#define').strip(' ') for l in lines if l.startswith('#define')]
+    output = []
+    signals = []
+    fields = ['Name,', 'Value', 'Comment']
+    excluded = ['DAC_NAMES', 'DEFAULT_DAC_VALS', 'CLK_NAMES', 'ONCHIP_DAC_NAMES']
+    header = f'{fields[0]:35}{fields[1]:35}\n'
+    output.append(header)
+    signals.append(header)
+    for line in lines:
+        name, *parts = line.split()
+        arg = ' '.join(parts)
+        value, *comments = arg.split('//') 
+        value = value.strip('() ')
+        # value = value.replace(', ', ' ')
+        value = value.replace('\"', '')
+        if name not in excluded:
+            name += ','
+            if name.startswith('SIGNAL_'):
+                signals.append(f'{name:35}{value}\n')
+            else:
+                output.append(f'{name:35}\"{value}\"\n')
+
+
+    rstpath = Path('@CMAKE_SOURCE_DIR@')/'docs/src/'
+    with open(f'src/{det.lower()}.csv', 'w') as f:
+        f.writelines(output)
+

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -50,6 +50,11 @@ Welcome to slsDetectorPackage's documentation!
     type_traits
     ToString
 
+.. toctree::
+    :caption: Servers
+
+    servers
+
 .. Indices and tables
 .. ==================
 

--- a/docs/src/servers.rst
+++ b/docs/src/servers.rst
@@ -27,6 +27,14 @@ Moench
    :widths: 35, 35
    :header-rows: 1
 
+Ctb
+-------------
+
+.. csv-table:: Default values
+   :file: ctb.csv
+   :widths: 35, 35
+   :header-rows: 1
+
 Eiger
 -------------
 

--- a/docs/src/servers.rst
+++ b/docs/src/servers.rst
@@ -1,0 +1,52 @@
+Detector Servers
+==============================================
+
+Some general intro 
+
+Mythen3
+-------------
+
+.. csv-table:: Default values
+   :file: mythen3.csv
+   :widths: 35, 35
+   :header-rows: 1
+
+Gotthard2
+-------------
+
+.. csv-table:: Default values
+   :file: gotthard2.csv
+   :widths: 35, 35
+   :header-rows: 1
+
+Moench
+-------------
+
+.. csv-table:: Default values
+   :file: moech.csv
+   :widths: 35, 35
+   :header-rows: 1
+
+Eiger
+-------------
+
+.. csv-table:: Default values
+   :file: eiger.csv
+   :widths: 35, 35
+   :header-rows: 1
+
+Jungfrau
+-------------
+
+.. csv-table:: Default values
+   :file: jungfrau.csv
+   :widths: 35, 35
+   :header-rows: 1
+
+Gotthard
+-------------
+
+.. csv-table:: Default values
+   :file: gotthard.csv
+   :widths: 35, 35
+   :header-rows: 1

--- a/docs/src/servers.rst
+++ b/docs/src/servers.rst
@@ -23,7 +23,7 @@ Moench
 -------------
 
 .. csv-table:: Default values
-   :file: moech.csv
+   :file: moench.csv
    :widths: 35, 35
    :header-rows: 1
 

--- a/docs/src/servers.rst
+++ b/docs/src/servers.rst
@@ -1,4 +1,4 @@
-Detector Servers
+Default values
 ==============================================
 
 Some general intro 

--- a/docs/static/extra.css
+++ b/docs/static/extra.css
@@ -1,0 +1,4 @@
+/* override table no-wrap */
+.wy-table-responsive table td, .wy-table-responsive table th {
+    white-space: normal;
+}

--- a/slsDetectorServers/ctbDetectorServer/slsDetectorServer_defs.h
+++ b/slsDetectorServers/ctbDetectorServer/slsDetectorServer_defs.h
@@ -95,7 +95,7 @@ enum CLKINDEX { RUN_CLK, ADC_CLK, SYNC_CLK, DBIT_CLK, NUM_CLOCKS };
 #define NDAC_ONLY               (NDAC - NPWR)
 #define DYNAMIC_RANGE           (16)
 #define NUM_BYTES_PER_PIXEL     (DYNAMIC_RANGE / 8)
-#define CLK_FREQ                (156.25) /* MHz */
+#define CLK_FREQ                (156.25) // MHz
 #define I2C_POWER_VIO_DEVICE_ID (0x40)
 #define I2C_POWER_VA_DEVICE_ID  (0x41)
 #define I2C_POWER_VB_DEVICE_ID  (0x42)

--- a/slsDetectorServers/eigerDetectorServer/slsDetectorServer_defs.h
+++ b/slsDetectorServers/eigerDetectorServer/slsDetectorServer_defs.h
@@ -130,7 +130,7 @@ enum MASTERINDEX { MASTER_HARDWARE, OW_MASTER, OW_SLAVE };
 #define DAC_MAX_STEPS   (4096)
 
 #define MAX_SUBFRAME_EXPOSURE_VAL_IN_10NS                                      \
-    (0x1FFFFFFF) /** 29 bit register for max subframe exposure value */
+(0x1FFFFFFF) // 29 bit register for max subframe exposure value
 
 #define SLAVE_HIGH_VOLTAGE_READ_VAL (-999)
 #define HIGH_VOLTAGE_TOLERANCE      (5)

--- a/slsDetectorServers/gotthardDetectorServer/slsDetectorServer_defs.h
+++ b/slsDetectorServers/gotthardDetectorServer/slsDetectorServer_defs.h
@@ -41,7 +41,7 @@ enum CLKINDEX { ADC_CLK, NUM_CLOCKS };
 #define DYNAMIC_RANGE      (16)
 #define NUM_BITS_PER_PIXEL (DYNAMIC_RANGE / 8)
 #define DATA_BYTES         (NCHIP * NCHAN * NUM_BITS_PER_PIXEL)
-#define CLK_FREQ           (32007729) /* Hz */
+#define CLK_FREQ           (32007729) // Hz
 #define MAX_EXT_SIGNALS    (1)
 
 /** Firmware Definitions */

--- a/slsDetectorServers/jungfrauDetectorServer/slsDetectorServer_defs.h
+++ b/slsDetectorServers/jungfrauDetectorServer/slsDetectorServer_defs.h
@@ -69,8 +69,8 @@ enum CLKINDEX { RUN_CLK, ADC_CLK, DBIT_CLK, NUM_CLOCKS };
 #define DYNAMIC_RANGE       (16)
 #define NUM_BYTES_PER_PIXEL (DYNAMIC_RANGE / 8)
 #define DATA_BYTES          (NCHIP * NCHAN * NUM_BYTES_PER_PIXEL)
-#define CLK_RUN             (40) /* MHz */
-#define CLK_SYNC            (20) /* MHz */
+#define CLK_RUN             (40) // MHz
+#define CLK_SYNC            (20) // MHz
 #define ADC_CLK_INDEX       (1)
 #define DBIT_CLK_INDEX      (0)
 


### PR DESCRIPTION
For each detector parse slsDetectorServer_defs.h to extract the defines and write them to a CSV. 
Generate table from the CSV using sphinx. 
Now included in make docs