### PR TITLE
Include depreciated commands in documentation

### DIFF
--- a/docs/src/commandline.rst
+++ b/docs/src/commandline.rst
@@ -35,7 +35,13 @@ Commands
 Depreciated commands
 ------------------------
 
+.. note ::
+	All dac commands are preceded with the **dac** command. Use command **daclist** to get correct list of dac command arguments for current detector.
+
 .. csv-table:: Depreciated commands
    :file: ../depreciated.csv
    :widths: 35, 35
    :header-rows: 1
+
+
+

--- a/docs/src/commandline.rst
+++ b/docs/src/commandline.rst
@@ -30,3 +30,12 @@ Commands
 -----------
 
 .. include:: ../commands.rst
+
+
+Depreciated commands
+------------------------
+
+.. csv-table:: Depreciated commands
+   :file: ../depreciated.csv
+   :widths: 35, 35
+   :header-rows: 1

--- a/docs/src/gendoc.cpp
+++ b/docs/src/gendoc.cpp
@@ -52,7 +52,8 @@ int main() {
         fs << '\t' << cmd << usage << help << "\n";
     }
 
-    std::ofstream fs2("depreciated.txt");
+    std::ofstream fs2("depreciated.csv");
+    fs2 << "Old, New\n"; 
     auto cmds = proxy.GetDepreciatedCommands();
     for (auto it : cmds){
         fs2 << it.first << ", " << it.second << '\n';

--- a/docs/src/gendoc.cpp
+++ b/docs/src/gendoc.cpp
@@ -51,4 +51,10 @@ int main() {
         auto help = replace_all(tmp, "\n\t", "\n\t\t| ");
         fs << '\t' << cmd << usage << help << "\n";
     }
+
+    std::ofstream fs2("depreciated.txt");
+    auto cmds = proxy.GetDepreciatedCommands();
+    for (auto it : cmds){
+        fs2 << it.first << ", " << it.second << '\n';
+    }
 }

--- a/slsDetectorSoftware/src/CmdProxy.cpp
+++ b/slsDetectorSoftware/src/CmdProxy.cpp
@@ -74,6 +74,10 @@ std::vector<std::string> CmdProxy::GetProxyCommands() {
     return commands;
 }
 
+std::map<std::string, std::string> CmdProxy::GetDepreciatedCommands(){
+    return depreciated_functions;
+}
+
 void CmdProxy::WrongNumberOfParameters(size_t expected) {
     throw RuntimeError(
         "Command " + cmd + " expected <=" + std::to_string(expected) +

--- a/slsDetectorSoftware/src/CmdProxy.h
+++ b/slsDetectorSoftware/src/CmdProxy.h
@@ -534,6 +534,7 @@ class CmdProxy {
     bool ReplaceIfDepreciated(std::string &command);
     size_t GetFunctionMapSize() const noexcept { return functions.size(); };
     std::vector<std::string> GetProxyCommands();
+    std::map<std::string, std::string> GetDepreciatedCommands();
 
   private:
     Detector *det;


### PR DESCRIPTION
Added a function to read out the depreciated commands. Using gendoc to write the csv file that then is included. 