### PR TITLE
slsReceiver: avoid potential memory leak: Implementation::generalData

### DIFF
--- a/slsReceiverSoftware/src/Implementation.cpp
+++ b/slsReceiverSoftware/src/Implementation.cpp
@@ -121,6 +121,9 @@ void Implementation::setDetectorType(const detectorType d) {
                                 std::to_string(static_cast<int>(d)));
     }
 
+    delete generalData;
+    generalData = nullptr;
+
     // set detector specific variables
     switch (myDetectorType) {
     case GOTTHARD:

--- a/slsReceiverSoftware/src/Implementation.h
+++ b/slsReceiverSoftware/src/Implementation.h
@@ -368,7 +368,7 @@ class Implementation : private virtual slsDetectorDefs {
     void *pRawDataReady{nullptr};
 
     // class objects
-    GeneralData *generalData;
+    GeneralData *generalData{nullptr};
     std::vector<std::unique_ptr<Listener>> listener;
     std::vector<std::unique_ptr<DataProcessor>> dataProcessor;
     std::vector<std::unique_ptr<DataStreamer>> dataStreamer;


### PR DESCRIPTION
Hi,

There might be a memory leak in Implementation::setDetectorType around generalData. The current code should not suffer from it because the method is only called from the class constructor. However, it is a public member and can potentially be called outside the constructor context.

What do you think?

Best regards

Alejandro