### PR TITLE
Pattern.h as a public header files

### DIFF
--- a/slsDetectorSoftware/CMakeLists.txt
+++ b/slsDetectorSoftware/CMakeLists.txt
@@ -31,6 +31,7 @@ set(PUBLICHEADERS
     include/sls/detectorData.h
     include/sls/Detector.h
     include/sls/Result.h
+    include/sls/Pattern.h
 )
 
 #Shared library


### PR DESCRIPTION
It is used in Detector.h.