### PR TITLE
jungfrau features: 9. auto comp disable time

### DIFF
--- a/slsDetectorSoftware/src/CmdProxy.cpp
+++ b/slsDetectorSoftware/src/CmdProxy.cpp
@@ -1729,6 +1729,37 @@ std::string CmdProxy::TemperatureEvent(int action) {
     return os.str();
 }
 
+std::string AutoComparatorDisable(const int action) {
+    std::ostringstream os;
+    os << cmd << ' ';
+    if (action == slsDetectorDefs::HELP_ACTION)
+        os << "[0, 1]\n\t[Jungfrau] Auto comparator disable mode. By default, "
+              "the on-chip gain switching is active during the entire "
+              "exposure.This mode disables the on - chip gain switching "
+              "comparator automatically after 93.75% of exposure time (only "
+              "for longer than 100us). \n\tDefault is 0 or this mode "
+              "disabled(comparator enabled throughout). 1 enables mode. 0 "
+              "disables mode."
+           << '\n';
+    else if (action == slsDetectorDefs::GET_ACTION) {
+        if (!args.empty()) {
+            WrongNumberOfParameters(0);
+        }
+        auto t = det->GETFCN(std::vector<int>{det_id});
+        os << OutString(t) << '\n';
+    } else if (action == slsDetectorDefs::PUT_ACTION) {
+        if (args.size() != 1) {
+            WrongNumberOfParameters(1);
+        }
+        auto val = CONV(args[0]);
+        det->SETFCN(val, std::vector<int>{det_id});
+        os << args.front() << '\n';
+    } else {
+        throw sls::RuntimeError("Unknown action");
+    }
+    return os.str();
+}
+
 /* Gotthard Specific */
 
 std::string CmdProxy::ROI(int action) {

--- a/slsDetectorSoftware/src/CmdProxy.h
+++ b/slsDetectorSoftware/src/CmdProxy.h
@@ -925,7 +925,7 @@ class CmdProxy {
         {"temp_threshold", &CmdProxy::temp_threshold},
         {"temp_control", &CmdProxy::temp_control},
         {"temp_event", &CmdProxy::TemperatureEvent},
-        {"auto_comp_disable", &CmdProxy::auto_comp_disable},
+        {"auto_comp_disable", &CmdProxy::AutoComparatorDisable},
         {"storagecells", &CmdProxy::storagecells},
         {"storagecell_start", &CmdProxy::storagecell_start},
         {"storagecell_delay", &CmdProxy::storagecell_delay},
@@ -1123,6 +1123,7 @@ class CmdProxy {
     std::string DataStream(int action);
     /* Jungfrau Specific */
     std::string TemperatureEvent(int action);
+    std::string AutoComparatorDisable(int action);
     /* Gotthard Specific */
     std::string ROI(int action);
     std::string ClearROI(int action);
@@ -1835,16 +1836,6 @@ class CmdProxy {
         "and temperature event occurs. To power on chip again, temperature has "
         "to be less than threshold temperature and temperature event has to be "
         "cleared.");
-
-    INTEGER_COMMAND_VEC_ID(
-        auto_comp_disable, getAutoCompDisable, setAutoCompDisable,
-        StringTo<int>,
-        "[0, 1]\n\t[Jungfrau] Auto comparator disable mode. By default, the "
-        "on-chip gain switching is active during the entire exposure.This mode "
-        "disables the on - chip gain switching comparator automatically after "
-        "93.75% of exposure time (only for longer than 100us). \n\tDefault is "
-        "0 or this mode disabled(comparator enabled throughout). 1 enables "
-        "mode. 0 disables mode. ");
 
     INTEGER_COMMAND_SET_NOID_GET_ID(
         storagecells, getNumberOfAdditionalStorageCells,


### PR DESCRIPTION
    • less % and not restrictive about long exptime, register to set how long comparator needs to be enabled.

- (ony for v1.1) new register to custom the period in ns. (chipv1.0,  it was 93 or so %)
- put it along with command line argument