### PR TITLE
Jungfrau features: 11. update

### DIFF
--- a/python/scripts/test_virtual.py
+++ b/python/scripts/test_virtual.py
@@ -161,7 +161,7 @@ def test_gainmode(virtual_jf_detectors):
     assert d.gainMode == gainMode.NORMAL_GAIN_MODE
 
     gain_list = [
-        gainMode.DYNAMIC_GAIN,
+        gainMode.DYNAMIC_GAIN_MODE,
         gainMode.FORCE_SWITCH_G1,
         gainMode.FORCE_SWITCH_G2,
         gainMode.FIX_G1,
@@ -176,7 +176,7 @@ def test_gainmode(virtual_jf_detectors):
 
     d.setGainMode(gainMode.FORCE_SWITCH_G1, [1])
     assert d.gainMode == [
-        gainMode.DYNAMIC_GAIN,
+        gainMode.DYNAMIC_GAIN_MODE,
         gainMode.FORCE_SWITCH_G1,
         gainMode.FORCE_SWITCH_G2,
         gainMode.FIX_G1,

--- a/python/scripts/test_virtual.py
+++ b/python/scripts/test_virtual.py
@@ -101,11 +101,11 @@ def test_module_size(virtual_jf_detectors):
 
 def test_settings(virtual_jf_detectors):
     d = ExperimentalDetector()
-    assert d.settings == detectorSettings.DYNAMICGAIN
+    assert d.settings == detectorSettings.GAIN0
 
     gain_list = [
-        detectorSettings.DYNAMICHG0,
-        detectorSettings.DYNAMICGAIN,
+        detectorSettings.GAIN0,
+        detectorSettings.HIGHGAIN0,
     ]
 
     # Set all viable gain for Jungfrau to make sure nothing is crashing
@@ -113,14 +113,14 @@ def test_settings(virtual_jf_detectors):
         d.settings = gain
         assert d.settings == gain
 
-    d.setSettings(detectorSettings.DYNAMICGAIN, [1])
+    d.setSettings(detectorSettings.GAIN0, [1])
     assert d.settings == [
-        detectorSettings.DYNAMICHG0,
-        detectorSettings.DYNAMICGAIN,
+        detectorSettings.GAIN0,
+        detectorSettings.HIGHGAIN0,
     ]
 
-    d.settings = detectorSettings.DYNAMICGAIN
-    assert d.settings == detectorSettings.DYNAMICGAIN
+    d.settings = detectorSettings.GAIN0
+    assert d.settings == detectorSettings.GAIN0
 
 def test_frames(virtual_jf_detectors):
     d = ExperimentalDetector()
@@ -161,9 +161,12 @@ def test_gainmode(virtual_jf_detectors):
     assert d.gainMode == gainMode.NORMAL_GAIN_MODE
 
     gain_list = [
-        gainMode.NORMAL_GAIN_MODE,
+        gainMode.DYNAMIC_GAIN,
         gainMode.FORCE_SWITCH_G1,
         gainMode.FORCE_SWITCH_G2,
+        gainMode.FIX_G1,
+        gainMode.FIX_G2,
+        gainMode.FIX_G0
     ]
 
     # Set all viable gain for Jungfrau to make sure nothing is crashing
@@ -173,9 +176,12 @@ def test_gainmode(virtual_jf_detectors):
 
     d.setGainMode(gainMode.FORCE_SWITCH_G1, [1])
     assert d.gainMode == [
-        gainMode.NORMAL_GAIN_MODE,
+        gainMode.DYNAMIC_GAIN,
         gainMode.FORCE_SWITCH_G1,
         gainMode.FORCE_SWITCH_G2,
+        gainMode.FIX_G1,
+        gainMode.FIX_G2,
+        gainMode.FIX_G0
     ]
 
     d.gainMode = gainMode.FORCE_SWITCH_G1

--- a/python/slsdet/detector.py
+++ b/python/slsdet/detector.py
@@ -311,7 +311,7 @@ class Detector(CppDetectorApi):
         -----
         
         [Eiger] Use threshold command to load settings
-        [Jungfrau] DYNAMICGAIN, DYNAMICHG0 \n
+        [Jungfrau] GAIN0, HIGHGAIN0 \n
         [Gotthard] DYNAMICGAIN, HIGHGAIN, LOWGAIN, MEDIUMGAIN, VERYHIGHGAIN \n
         [Gotthard2] DYNAMICGAIN, FIXGAIN1, FIXGAIN2 \n
         [Moench] G1_HIGHGAIN, G1_LOWGAIN, G2_HIGHCAP_HIGHGAIN, G2_HIGHCAP_LOWGAIN, G2_LOWCAP_HIGHGAIN, G2_LOWCAP_LOWGAIN, G4_HIGHGAIN, G4_LOWGAIN \n
@@ -2201,8 +2201,8 @@ class Detector(CppDetectorApi):
         [Jungfrau] Detector gain mode. Enum: gainMode
         Note
         -----
-        [Jungfrau] NORMAL_GAIN_MODE, FORCE_SWITCH_G1, FORCE_SWITCH_G2, FIX_G1, FIX_G2, FIX_G0, FIX_HG0 \n
-        CAUTION: Do not use FIX_G0 and FIX_HG0 blindly, you can damage the detector!!!
+        [Jungfrau] DYNAMIC_GAIN, FORCE_SWITCH_G1, FORCE_SWITCH_G2, FIX_G1, FIX_G2, FIX_G0 \n
+        CAUTION: Do not use FIX_G0 blindly, you can damage the detector!!!
         """
         return element_if_equal(self.getGainMode())
 

--- a/python/slsdet/detector.py
+++ b/python/slsdet/detector.py
@@ -2202,7 +2202,7 @@ class Detector(CppDetectorApi):
         Note
         -----
         [Jungfrau] DYNAMIC_GAIN_MODE, FORCE_SWITCH_G1, FORCE_SWITCH_G2, FIX_G1, FIX_G2, FIX_G0 \n
-        CAUTION: Do not use FIX_G0 blindly, you can damage the detector!!!
+        CAUTION: Do not use FIX_G0 without caution, you can damage the detector!!!
         """
         return element_if_equal(self.getGainMode())
 

--- a/python/slsdet/detector.py
+++ b/python/slsdet/detector.py
@@ -2201,7 +2201,7 @@ class Detector(CppDetectorApi):
         [Jungfrau] Detector gain mode. Enum: gainMode
         Note
         -----
-        [Jungfrau] DYNAMIC_GAIN, FORCE_SWITCH_G1, FORCE_SWITCH_G2, FIX_G1, FIX_G2, FIX_G0 \n
+        [Jungfrau] DYNAMIC_GAIN_MODE, FORCE_SWITCH_G1, FORCE_SWITCH_G2, FIX_G1, FIX_G2, FIX_G0 \n
         CAUTION: Do not use FIX_G0 blindly, you can damage the detector!!!
         """
         return element_if_equal(self.getGainMode())

--- a/python/slsdet/detector.py
+++ b/python/slsdet/detector.py
@@ -2201,8 +2201,8 @@ class Detector(CppDetectorApi):
         [Jungfrau] Detector gain mode. Enum: gainMode
         Note
         -----
-        
-        [Jungfrau] NORMAL_GAIN_MODE, FORCE_SWITCH_G1, FORCE_SWITCH_G2 
+        [Jungfrau] NORMAL_GAIN_MODE, FORCE_SWITCH_G1, FORCE_SWITCH_G2, FIX_G1, FIX_G2, FIX_G0, FIX_HG0 \n
+        CAUTION: Do not use FIX_G0 and FIX_HG0 blindly, you can damage the detector!!!
         """
         return element_if_equal(self.getGainMode())
 

--- a/python/src/enums.cpp
+++ b/python/src/enums.cpp
@@ -308,7 +308,7 @@ void init_enums(py::module &m) {
         .export_values();
 
     py::enum_<slsDetectorDefs::gainMode>(Defs, "gainMode")
-        .value("DYNAMIC_GAIN", slsDetectorDefs::gainMode::DYNAMIC_GAIN)
+        .value("DYNAMIC_GAIN_MODE", slsDetectorDefs::gainMode::DYNAMIC_GAIN_MODE)
         .value("FORCE_SWITCH_G1", slsDetectorDefs::gainMode::FORCE_SWITCH_G1)
         .value("FORCE_SWITCH_G2", slsDetectorDefs::gainMode::FORCE_SWITCH_G2)
         .value("FIX_G1", slsDetectorDefs::gainMode::FIX_G1)

--- a/python/src/enums.cpp
+++ b/python/src/enums.cpp
@@ -210,7 +210,7 @@ void init_enums(py::module &m) {
         .value("LOWGAIN", slsDetectorDefs::detectorSettings::LOWGAIN)
         .value("MEDIUMGAIN", slsDetectorDefs::detectorSettings::MEDIUMGAIN)
         .value("VERYHIGHGAIN", slsDetectorDefs::detectorSettings::VERYHIGHGAIN)
-        .value("DYNAMICHG0", slsDetectorDefs::detectorSettings::DYNAMICHG0)
+        .value("HIGHGAIN0", slsDetectorDefs::detectorSettings::HIGHGAIN0)
         .value("FIXGAIN1", slsDetectorDefs::detectorSettings::FIXGAIN1)
         .value("FIXGAIN2", slsDetectorDefs::detectorSettings::FIXGAIN2)
         .value("VERYLOWGAIN", slsDetectorDefs::detectorSettings::VERYLOWGAIN)
@@ -226,6 +226,7 @@ void init_enums(py::module &m) {
                slsDetectorDefs::detectorSettings::G2_LOWCAP_LOWGAIN)
         .value("G4_HIGHGAIN", slsDetectorDefs::detectorSettings::G4_HIGHGAIN)
         .value("G4_LOWGAIN", slsDetectorDefs::detectorSettings::G4_LOWGAIN)
+        .value("GAIN0", slsDetectorDefs::detectorSettings::GAIN0)
         .value("UNDEFINED", slsDetectorDefs::detectorSettings::UNDEFINED)
         .value("UNINITIALIZED",
                slsDetectorDefs::detectorSettings::UNINITIALIZED)
@@ -307,8 +308,11 @@ void init_enums(py::module &m) {
         .export_values();
 
     py::enum_<slsDetectorDefs::gainMode>(Defs, "gainMode")
-        .value("NORMAL_GAIN_MODE", slsDetectorDefs::gainMode::NORMAL_GAIN_MODE)
+        .value("DYNAMIC_GAIN", slsDetectorDefs::gainMode::DYNAMIC_GAIN)
         .value("FORCE_SWITCH_G1", slsDetectorDefs::gainMode::FORCE_SWITCH_G1)
         .value("FORCE_SWITCH_G2", slsDetectorDefs::gainMode::FORCE_SWITCH_G2)
+        .value("FIX_G1", slsDetectorDefs::gainMode::FIX_G1)
+        .value("FIX_G2", slsDetectorDefs::gainMode::FIX_G2)
+        .value("FIX_G0", slsDetectorDefs::gainMode::FIX_G0)
         .export_values();
 }

--- a/slsDetectorGui/forms/form_tab_settings.ui
+++ b/slsDetectorGui/forms/form_tab_settings.ui
@@ -32,7 +32,7 @@
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
-   <item row="3" column="3">
+   <item row="4" column="3">
     <widget class="QCheckBox" name="chkCounter2">
      <property name="enabled">
       <bool>false</bool>
@@ -51,7 +51,7 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="4">
+   <item row="4" column="4">
     <widget class="QCheckBox" name="chkCounter3">
      <property name="enabled">
       <bool>false</bool>
@@ -70,7 +70,7 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="2" colspan="3">
+   <item row="3" column="2" colspan="3">
     <widget class="QComboBox" name="comboDynamicRange">
      <property name="enabled">
       <bool>false</bool>
@@ -109,7 +109,7 @@
      </item>
     </widget>
    </item>
-   <item row="1" column="2" colspan="3">
+   <item row="2" column="2" colspan="3">
     <widget class="QSpinBox" name="spinThreshold">
      <property name="enabled">
       <bool>false</bool>
@@ -146,7 +146,7 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="6">
+   <item row="2" column="6">
     <widget class="QSpinBox" name="spinThreshold3">
      <property name="enabled">
       <bool>false</bool>
@@ -183,7 +183,7 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
+   <item row="3" column="0">
     <widget class="QLabel" name="lblDynamicRange">
      <property name="enabled">
       <bool>false</bool>
@@ -205,7 +205,7 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="2">
+   <item row="5" column="2">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -221,7 +221,7 @@
      </property>
     </spacer>
    </item>
-   <item row="1" column="8">
+   <item row="2" column="8">
     <widget class="QPushButton" name="btnSetThreshold">
      <property name="enabled">
       <bool>true</bool>
@@ -334,7 +334,7 @@
      </property>
     </spacer>
    </item>
-   <item row="1" column="0">
+   <item row="2" column="0">
     <widget class="QLabel" name="lblThreshold">
      <property name="enabled">
       <bool>false</bool>
@@ -356,7 +356,7 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="5">
+   <item row="2" column="5">
     <widget class="QSpinBox" name="spinThreshold2">
      <property name="enabled">
       <bool>false</bool>
@@ -393,7 +393,7 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="9">
+   <item row="2" column="9">
     <spacer name="horizontalSpacer_2">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -409,7 +409,7 @@
      </property>
     </spacer>
    </item>
-   <item row="3" column="0">
+   <item row="4" column="0">
     <widget class="QLabel" name="lblCounter">
      <property name="enabled">
       <bool>false</bool>
@@ -431,7 +431,7 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="2">
+   <item row="4" column="2">
     <widget class="QCheckBox" name="chkCounter1">
      <property name="enabled">
       <bool>false</bool>
@@ -587,6 +587,57 @@
        <string>Uninitialized</string>
       </property>
      </item>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="lblGainMode">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>110</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>110</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>Gain Mode:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="2">
+    <widget class="QComboBox" name="comboGainMode">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>140</width>
+       <height>25</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>140</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string>Settings of the detector. 
+ #settings#</string>
+     </property>
     </widget>
    </item>
   </layout>

--- a/slsDetectorGui/forms/form_tab_settings.ui
+++ b/slsDetectorGui/forms/form_tab_settings.ui
@@ -514,7 +514,7 @@
      </item>
      <item>
       <property name="text">
-       <string>Dynamic HG0</string>
+       <string>High Gain 0</string>
       </property>
      </item>
      <item>
@@ -570,6 +570,11 @@
      <item>
       <property name="text">
        <string>G4_LG</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Gain 0</string>
       </property>
      </item>
      <item>

--- a/slsDetectorGui/forms/form_tab_settings.ui
+++ b/slsDetectorGui/forms/form_tab_settings.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>775</width>
-    <height>345</height>
+    <height>380</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -635,9 +635,38 @@
       </size>
      </property>
      <property name="toolTip">
-      <string>Settings of the detector. 
- #settings#</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Gain Mode of the detector&lt;/p&gt;&lt;p&gt; #gainmode#&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Fix G0 is to be used with utmost caution. Can damage the detector!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
+     <item>
+      <property name="text">
+       <string>Dynamic Gain</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Force Switch G1</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Force Switch G2</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Fix G1</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Fix G2</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Fix G0</string>
+      </property>
+     </item>
     </widget>
    </item>
   </layout>

--- a/slsDetectorGui/include/qTabSettings.h
+++ b/slsDetectorGui/include/qTabSettings.h
@@ -10,9 +10,12 @@ class qTabSettings : public QWidget, private Ui::TabSettingsObject {
     qTabSettings(QWidget *parent, sls::Detector *detector);
     ~qTabSettings();
     void Refresh();
+  public slots:
+    void SetExportMode(bool exportMode);
 
   private slots:
     void SetSettings(int index);
+    void SetGainMode(int index);
     void SetDynamicRange(int index);
     void SetThresholdEnergy(int index);
     void SetThresholdEnergies();
@@ -22,9 +25,11 @@ class qTabSettings : public QWidget, private Ui::TabSettingsObject {
     void SetupWidgetWindow();
     void SetupDetectorSettings();
     void SetupGainMode();
+    void ShowFixG0(bool expertMode);
     void Initialization();
 
     void GetSettings();
+    void GetGainMode();
     void GetDynamicRange();
     void GetThresholdEnergy();
     void GetThresholdEnergies();
@@ -58,5 +63,16 @@ class qTabSettings : public QWidget, private Ui::TabSettingsObject {
         UNINITIALIZED,
         NUMSETTINGS
     };
+
+    enum {
+        DYNAMIC_GAIN_MODE,
+        FORCE_SWITCH_G1,
+        FORCE_SWITCH_G2,
+        FIX_G1,
+        FIX_G2,
+        FIX_G0
+    };
+    bool isVisibleFixG0{false};
+
     enum { DYNAMICRANGE_32, DYNAMICRANGE_16, DYNAMICRANGE_8, DYNAMICRANGE_4 };
 };

--- a/slsDetectorGui/include/qTabSettings.h
+++ b/slsDetectorGui/include/qTabSettings.h
@@ -32,29 +32,5 @@ class qTabSettings : public QWidget, private Ui::TabSettingsObject {
     sls::Detector *det;
     std::vector<QCheckBox *> counters;
 
-    enum {
-        STANDARD,
-        FAST,
-        HIGHGAIN,
-        DYNAMICGAIN,
-        LOWGAIN,
-        MEDIUMGAIN,
-        VERYHIGHGAIN,
-        DYNAMICHG0,
-        FIXGAIN1,
-        FIXGAIN2,
-        VERLOWGAIN,
-        G1_HIGHGAIN,
-        G1_LOWGAIN,
-        G2_HIGHCAP_HIGHGAIN,
-        G2_HIGHCAP_LOWGAIN,
-        G2_LOWCAP_HIGHGAIN,
-        G2_LOWCAP_LOWGAIN,
-        G4_HIGHGAIN,
-        G4_LOWGAIN,
-        UNDEFINED,
-        UNINITIALIZED,
-        NUMSETTINGS
-    };
     enum { DYNAMICRANGE_32, DYNAMICRANGE_16, DYNAMICRANGE_8, DYNAMICRANGE_4 };
 };

--- a/slsDetectorGui/include/qTabSettings.h
+++ b/slsDetectorGui/include/qTabSettings.h
@@ -21,6 +21,7 @@ class qTabSettings : public QWidget, private Ui::TabSettingsObject {
   private:
     void SetupWidgetWindow();
     void SetupDetectorSettings();
+    void SetupGainMode();
     void Initialization();
 
     void GetSettings();

--- a/slsDetectorGui/include/qTabSettings.h
+++ b/slsDetectorGui/include/qTabSettings.h
@@ -32,5 +32,30 @@ class qTabSettings : public QWidget, private Ui::TabSettingsObject {
     sls::Detector *det;
     std::vector<QCheckBox *> counters;
 
+    enum {
+        STANDARD,
+        FAST,
+        HIGHGAIN,
+        DYNAMICGAIN,
+        LOWGAIN,
+        MEDIUMGAIN,
+        VERYHIGHGAIN,
+        HIGHGAIN0,
+        FIXGAIN1,
+        FIXGAIN2,
+        VERLOWGAIN,
+        G1_HIGHGAIN,
+        G1_LOWGAIN,
+        G2_HIGHCAP_HIGHGAIN,
+        G2_HIGHCAP_LOWGAIN,
+        G2_LOWCAP_HIGHGAIN,
+        G2_LOWCAP_LOWGAIN,
+        G4_HIGHGAIN,
+        G4_LOWGAIN,
+        GAIN0,
+        UNDEFINED,
+        UNINITIALIZED,
+        NUMSETTINGS
+    };
     enum { DYNAMICRANGE_32, DYNAMICRANGE_16, DYNAMICRANGE_8, DYNAMICRANGE_4 };
 };

--- a/slsDetectorGui/src/qDetectorMain.cpp
+++ b/slsDetectorGui/src/qDetectorMain.cpp
@@ -340,6 +340,7 @@ void qDetectorMain::EnableModes(QAction *action) {
         actionLoadTrimbits->setVisible(enable &&
                                        (detType == slsDetectorDefs::EIGER ||
                                         detType == slsDetectorDefs::MYTHEN3));
+        tabSettings->SetExportMode(enable);
         LOG(logINFO) << "Expert Mode: " << qDefs::stringEnable(enable);
     }
 

--- a/slsDetectorGui/src/qTabSettings.cpp
+++ b/slsDetectorGui/src/qTabSettings.cpp
@@ -92,10 +92,11 @@ void qTabSettings::SetupWidgetWindow() {
 void qTabSettings::SetupDetectorSettings() {
     QStandardItemModel *model =
         qobject_cast<QStandardItemModel *>(comboSettings->model());
+    const int numSettings = comboSettings->count();
     if (model) {
-        QModelIndex index[NUMSETTINGS];
-        QStandardItem *item[NUMSETTINGS];
-        for (int i = 0; i < NUMSETTINGS; ++i) {
+        QModelIndex index[numSettings];
+        QStandardItem *item[numSettings];
+        for (int i = 0; i < numSettings; ++i) {
             index[i] = model->index(i, comboSettings->modelColumn(),
                                     comboSettings->rootModelIndex());
             item[i] = model->itemFromIndex(index[i]);
@@ -160,7 +161,7 @@ void qTabSettings::GetSettings() {
             comboSettings->setCurrentIndex(UNINITIALIZED);
             break;
         default:
-            if ((int)retval < -1 || (int)retval >= NUMSETTINGS) {
+            if ((int)retval < -1 || (int)retval >= comboSettings->count()) {
                 throw sls::RuntimeError(std::string("Unknown settings: ") +
                                         std::to_string(retval));
             }

--- a/slsDetectorGui/src/qTabSettings.cpp
+++ b/slsDetectorGui/src/qTabSettings.cpp
@@ -71,6 +71,9 @@ void qTabSettings::SetupWidgetWindow() {
         comboDynamicRange->setEnabled(true);
         lblThreshold->setEnabled(true);
         spinThreshold->setEnabled(true);
+    } else if (detType == slsDetectorDefs::JUNGFRAU) {
+        lblGainMode->setEnabled(true);
+        comboGainMode->setEnabled(true);
     }
 
     // default settings for the disabled
@@ -83,6 +86,12 @@ void qTabSettings::SetupWidgetWindow() {
         spinThreshold2->setValue(-1);
         spinThreshold3->setValue(-1);
     }
+
+    // default for gain mode
+    if (comboGainMode->isEnabled()) {
+        SetupGainMode();
+    }
+
     Initialization();
     // default for the disabled
     GetDynamicRange();
@@ -111,6 +120,17 @@ void qTabSettings::SetupDetectorSettings() {
                 CATCH_DISPLAY(std::string("Could not setup settings"),
                               "qTabSettings::SetupDetectorSettings")
     }
+}
+
+void qTabSettings::SetupGainMode() {
+    try {
+        auto list = det->getGainModeList();
+        for (auto it : list) {
+            comboGainMode->addItem(sls::ToString(it).c_str());
+        }
+    }
+    CATCH_DISPLAY(std::string("Could not setup gain mode"),
+                  "qTabSettings::SetupGainMode")
 }
 
 void qTabSettings::Initialization() {

--- a/slsDetectorGui/src/qTabSettings.cpp
+++ b/slsDetectorGui/src/qTabSettings.cpp
@@ -94,9 +94,9 @@ void qTabSettings::SetupDetectorSettings() {
         qobject_cast<QStandardItemModel *>(comboSettings->model());
     const int numSettings = comboSettings->count();
     if (model) {
-        QModelIndex index[numSettings];
-        QStandardItem *item[numSettings];
-        for (int i = 0; i < numSettings; ++i) {
+        std::vector<QModelIndex> index(numSettings);
+        std::vector<QStandardItem *> item(numSettings);
+        for (size_t i = 0; i < index.size(); ++i) {
             index[i] = model->index(i, comboSettings->modelColumn(),
                                     comboSettings->rootModelIndex());
             item[i] = model->itemFromIndex(index[i]);

--- a/slsDetectorServers/jungfrauDetectorServer/RegisterDefs.h
+++ b/slsDetectorServers/jungfrauDetectorServer/RegisterDefs.h
@@ -351,6 +351,7 @@
 #define DAQ_CRRNT_SRC_CLMN_FIX_MSK          (0x00000001 << DAQ_CRRNT_SRC_CLMN_FIX_OFST)
 #define DAQ_CRRNT_SRC_CLMN_SLCT_OFST        (20)
 #define DAQ_CRRNT_SRC_CLMN_SLCT_MSK         (0x0000003F << DAQ_CRRNT_SRC_CLMN_SLCT_OFST)
+#define DAQ_GAIN_MODE_MASK                  (DAQ_FRCE_SWTCH_GAIN_MSK | DAQ_FIX_GAIN_MSK | DAQ_CMP_RST_MSK)
 
 /** Chip Power Register */
 #define CHIP_POWER_REG                      (0x5E << MEM_MAP_SHIFT)

--- a/slsDetectorServers/jungfrauDetectorServer/slsDetectorFunctionList.c
+++ b/slsDetectorServers/jungfrauDetectorServer/slsDetectorFunctionList.c
@@ -1098,7 +1098,7 @@ enum gainMode getGainMode() {
 
     switch (retval_force) {
     case DAQ_FRCE_GAIN_STG_0_VAL:
-        return NORMAL_GAIN_MODE;
+        return DYNAMICGAIN;
     case DAQ_FRCE_GAIN_STG_1_VAL:
         return FORCE_SWITCH_G1;
     case DAQ_FRCE_GAIN_STG_2_VAL:
@@ -1131,7 +1131,7 @@ void setGainMode(enum gainMode mode) {
     uint32_t value = bus_r(addr);
 
     switch (mode) {
-    case NORMAL_GAIN_MODE:
+    case DYNAMICGAIN:
         value &= ~(DAQ_FRCE_SWTCH_GAIN_MSK);
         bus_w(addr, value);
         LOG(logINFO, ("Set gain mode - Normal Gain  Mode [DAQ Reg:0x%x]\n",
@@ -1150,6 +1150,27 @@ void setGainMode(enum gainMode mode) {
         bus_w(addr, value);
         LOG(logINFO, ("Set gain mode - Force Switch G2 [DAQ Reg:0x%x]\n",
                       bus_r(DAQ_REG)));
+        break;
+    case FIX_G1:
+        value &= ~(DAQ_FIX_GAIN_MSK);
+        value |= DAQ_FIX_GAIN_STG_1_VAL;
+        bus_w(addr, value);
+        LOG(logINFO,
+            ("Set gain mode - Fix G1 [DAQ Reg:0x%x]\n", bus_r(DAQ_REG)));
+        break;
+    case FIX_G2:
+        value &= ~(DAQ_FIX_GAIN_MSK);
+        value |= DAQ_FIX_GAIN_STG_2_VAL;
+        bus_w(addr, value);
+        LOG(logINFO,
+            ("Set gain mode - Fix G2 [DAQ Reg:0x%x]\n", bus_r(DAQ_REG)));
+        break;
+    case FIX_G0: //????
+        value &= ~(DAQ_FIX_GAIN_MSK);
+        value |= DAQ_FIX_GAIN_STG_2_VAL;
+        bus_w(addr, value);
+        LOG(logINFO,
+            ("Set gain mode - Fix G2 [DAQ Reg:0x%x]\n", bus_r(DAQ_REG)));
         break;
     default:
         LOG(logERROR, ("This gain mode %d is not defined\n", (int)mode));

--- a/slsDetectorServers/jungfrauDetectorServer/slsDetectorFunctionList.c
+++ b/slsDetectorServers/jungfrauDetectorServer/slsDetectorFunctionList.c
@@ -1078,41 +1078,6 @@ enum detectorSettings setSettings(enum detectorSettings sett) {
     return thisSettings;
 }
 
-void validateSettings() {
-    // if any special dac value is changed individually => undefined
-    const int specialDacs[NSPECIALDACS] = SPECIALDACINDEX;
-    int *specialDacValues[] = {defaultDacValue_G0, defaultDacValue_HG0};
-    int settList[] = {DYNAMICGAIN, DYNAMICHG0};
-    enum detectorSettings sett = UNDEFINED;
-    for (int isett = 0; isett != NUMSETTINGS; ++isett) {
-
-        // assume it matches current setting in list
-        sett = settList[isett];
-        // if one value does not match, = undefined
-        for (int i = 0; i < NSPECIALDACS; ++i) {
-            if (getDAC(specialDacs[i], 0) != specialDacValues[isett][i]) {
-                sett = UNDEFINED;
-                break;
-            }
-        }
-
-        // all values matchd a setting
-        if (sett != UNDEFINED) {
-            break;
-        }
-    }
-    // update settings
-    if (thisSettings != sett) {
-        LOG(logINFOBLUE,
-            ("Validated settings to %s (%d)\n",
-             (sett == DYNAMICGAIN
-                  ? "dynamicgain"
-                  : (sett == DYNAMICHG0 ? "dynamichg0" : "undefined")),
-             sett));
-        thisSettings = sett;
-    }
-}
-
 enum detectorSettings getSettings() { return thisSettings; }
 
 enum gainMode getGainMode() {
@@ -1193,12 +1158,6 @@ void setDAC(enum DACINDEX ind, int val, int mV) {
         }
     }
 #endif
-    const int specialDacs[NSPECIALDACS] = SPECIALDACINDEX;
-    for (int i = 0; i < NSPECIALDACS; ++i) {
-        if ((int)ind == specialDacs[i]) {
-            validateSettings();
-        }
-    }
 }
 
 int getDAC(enum DACINDEX ind, int mV) {

--- a/slsDetectorServers/jungfrauDetectorServer/slsDetectorFunctionList.c
+++ b/slsDetectorServers/jungfrauDetectorServer/slsDetectorFunctionList.c
@@ -1101,9 +1101,12 @@ enum gainMode getGainMode() {
         LOG(logERROR, ("undefined gain mode. DAQ reg: 0x%x\n", regval));
     }
 
-    switch (retval_force) {
-    case DAQ_FRCE_GAIN_STG_0_VAL:
+    // dynamic gain, when nothing is set
+    if (retval_force == 0 && retval_fix == 0 && retval_cmp_rst == 0) {
         return DYNAMIC_GAIN_MODE;
+    }
+
+    switch (retval_force) {
     case DAQ_FRCE_GAIN_STG_1_VAL:
         return FORCE_SWITCH_G1;
     case DAQ_FRCE_GAIN_STG_2_VAL:
@@ -1124,6 +1127,7 @@ enum gainMode getGainMode() {
     if (retval_cmp_rst) {
         return FIX_G0;
     }
+
     LOG(logERROR, ("This gain mode is undefined [DAQ reg: %d]\n", regval));
     return -1;
 }

--- a/slsDetectorServers/jungfrauDetectorServer/slsDetectorFunctionList.c
+++ b/slsDetectorServers/jungfrauDetectorServer/slsDetectorFunctionList.c
@@ -793,6 +793,11 @@ int selectStoragecellStart(int pos) {
         LOG(logINFO, ("Setting storage cell start: %d\n", pos));
         bus_w(addr, bus_r(addr) & ~mask);
         bus_w(addr, bus_r(addr) | ((value << offset) & mask));
+        // should not do a get to verify (status register does not update
+        // immediately during acquisition)
+        if (getChipVersion() == 11) {
+            return pos;
+        }
     }
 
     // read value back
@@ -1098,7 +1103,7 @@ enum gainMode getGainMode() {
 
     switch (retval_force) {
     case DAQ_FRCE_GAIN_STG_0_VAL:
-        return DYNAMIC_GAIN;
+        return DYNAMIC_GAIN_MODE;
     case DAQ_FRCE_GAIN_STG_1_VAL:
         return FORCE_SWITCH_G1;
     case DAQ_FRCE_GAIN_STG_2_VAL:
@@ -1128,7 +1133,7 @@ void setGainMode(enum gainMode mode) {
     uint32_t value = bus_r(addr);
 
     switch (mode) {
-    case DYNAMIC_GAIN:
+    case DYNAMIC_GAIN_MODE:
         value &= ~(DAQ_GAIN_MODE_MASK);
         bus_w(addr, value);
         LOG(logINFO,

--- a/slsDetectorServers/jungfrauDetectorServer/slsDetectorFunctionList.c
+++ b/slsDetectorServers/jungfrauDetectorServer/slsDetectorFunctionList.c
@@ -1095,6 +1095,7 @@ enum gainMode getGainMode() {
         (retval_force && retval_cmp_rst)) {
         LOG(logERROR, ("undefined gain mode. DAQ reg: 0x%x\n", regval));
     }
+
     switch (retval_force) {
     case DAQ_FRCE_GAIN_STG_0_VAL:
         return NORMAL_GAIN_MODE;
@@ -1105,6 +1106,7 @@ enum gainMode getGainMode() {
     default:
         break;
     }
+
     switch (retval_fix) {
     case DAQ_FIX_GAIN_STG_1_VAL:
         return FIX_G1;

--- a/slsDetectorServers/jungfrauDetectorServer/slsDetectorServer_defs.h
+++ b/slsDetectorServers/jungfrauDetectorServer/slsDetectorServer_defs.h
@@ -98,7 +98,7 @@ enum CLKINDEX { RUN_CLK, ADC_CLK, DBIT_CLK, NUM_CLOCKS };
 #define DEFAULT_HIGH_VOLTAGE          (0)
 #define DEFAULT_TIMING_MODE           (AUTO_TIMING)
 #define DEFAULT_SETTINGS              (GAIN0)
-#define DEFAULT_GAINMODE              (DYNAMIC_GAIN)
+#define DEFAULT_GAINMODE              (DYNAMIC_GAIN_MODE)
 #define DEFAULT_TX_UDP_PORT           (0x7e9a)
 #define DEFAULT_TMP_THRSHLD           (65 * 1000) // milli degree Celsius
 #define DEFAULT_NUM_STRG_CLLS         (0)

--- a/slsDetectorServers/jungfrauDetectorServer/slsDetectorServer_defs.h
+++ b/slsDetectorServers/jungfrauDetectorServer/slsDetectorServer_defs.h
@@ -97,7 +97,8 @@ enum CLKINDEX { RUN_CLK, ADC_CLK, DBIT_CLK, NUM_CLOCKS };
 #define DEFAULT_DELAY                 (0)
 #define DEFAULT_HIGH_VOLTAGE          (0)
 #define DEFAULT_TIMING_MODE           (AUTO_TIMING)
-#define DEFAULT_SETTINGS              (DYNAMICGAIN)
+#define DEFAULT_SETTINGS              (GAIN0)
+#define DEFAULT_GAINMODE              (DYNAMIC_GAIN)
 #define DEFAULT_TX_UDP_PORT           (0x7e9a)
 #define DEFAULT_TMP_THRSHLD           (65 * 1000) // milli degree Celsius
 #define DEFAULT_NUM_STRG_CLLS         (0)

--- a/slsDetectorServers/slsDetectorServer/include/slsDetectorFunctionList.h
+++ b/slsDetectorServers/slsDetectorServer/include/slsDetectorFunctionList.h
@@ -297,9 +297,6 @@ int getAllTrimbits();
 #ifndef CHIPTESTBOARDD
 enum detectorSettings setSettings(enum detectorSettings sett);
 #endif
-#if defined(MYTHEN3D) || defined(JUNGFRAUD)
-void validateSettings();
-#endif
 enum detectorSettings getSettings();
 #ifdef JUNGFRAUD
 enum gainMode getGainMode();

--- a/slsDetectorServers/slsDetectorServer/src/slsDetectorServer_funcs.c
+++ b/slsDetectorServers/slsDetectorServer/src/slsDetectorServer_funcs.c
@@ -8560,7 +8560,7 @@ int set_default_dac(int file_des) {
 int get_gain_mode(int file_des) {
     ret = OK;
     memset(mess, 0, sizeof(mess));
-    enum gainMode retval = NORMAL_GAIN_MODE;
+    enum gainMode retval = DYNAMIC_GAIN_MODE;
     LOG(logDEBUG1, ("Getting gain mode\n"));
 
 #ifndef JUNGFRAUD
@@ -8593,7 +8593,7 @@ int set_gain_mode(int file_des) {
     // only set
     if (Server_VerifyLock() == OK) {
         switch (gainmode) {
-        case DYNAMIC_GAIN:
+        case DYNAMIC_GAIN_MODE:
         case FORCE_SWITCH_G1:
         case FORCE_SWITCH_G2:
         case FIX_G1:

--- a/slsDetectorServers/slsDetectorServer/src/slsDetectorServer_funcs.c
+++ b/slsDetectorServers/slsDetectorServer/src/slsDetectorServer_funcs.c
@@ -1561,8 +1561,8 @@ void validate_settings(enum detectorSettings sett) {
 #ifdef EIGERD
     case STANDARD:
 #elif JUNGFRAUD
-    case DYNAMICGAIN:
-    case DYNAMICHG0:
+    case GAIN0:
+    case HIGHGAIN0:
 #elif GOTTHARDD
         case DYNAMICGAIN:
         case HIGHGAIN:
@@ -8593,9 +8593,12 @@ int set_gain_mode(int file_des) {
     // only set
     if (Server_VerifyLock() == OK) {
         switch (gainmode) {
-        case NORMAL_GAIN_MODE:
+        case DYNAMIC_GAIN:
         case FORCE_SWITCH_G1:
         case FORCE_SWITCH_G2:
+        case FIX_G1:
+        case FIX_G2:
+        case FIX_G0:
             break;
         default:
             modeNotImplemented("Gain Mode Index", (int)gainmode);

--- a/slsDetectorSoftware/include/sls/Detector.h
+++ b/slsDetectorSoftware/include/sls/Detector.h
@@ -1180,8 +1180,8 @@ class Detector {
     Result<defs::gainMode> getGainMode(Positions pos = {}) const;
 
     /** [Jungfrau] Options: DYNAMIC_GAIN_MODE, FORCE_SWITCH_G1, FORCE_SWITCH_G2,
-     * FIX_G1, FIX_G2, FIX_G0 \n\CAUTION: Do not use FIX_G0 blindly, you can
-     * damage the detector!!!\n
+     * FIX_G1, FIX_G2, FIX_G0 \n\CAUTION: Do not use FIX_G0 without caution, you
+     * can damage the detector!!!\n
      */
     void setGainMode(const defs::gainMode mode, Positions pos = {});
 

--- a/slsDetectorSoftware/include/sls/Detector.h
+++ b/slsDetectorSoftware/include/sls/Detector.h
@@ -113,7 +113,7 @@ class Detector {
     /** [Jungfrau][Gotthard][Gotthard2][Mythen3] */
     Result<defs::detectorSettings> getSettings(Positions pos = {}) const;
 
-    /** [Jungfrau] DYNAMICGAIN, DYNAMICHG0 \n [Gotthard] DYNAMICGAIN, HIGHGAIN,
+    /** [Jungfrau] GAIN0, HIGHGAIN0 \n [Gotthard] DYNAMICGAIN, HIGHGAIN,
      * LOWGAIN, MEDIUMGAIN, VERYHIGHGAIN \n [Gotthard2] DYNAMICGAIN,
      * FIXGAIN1, FIXGAIN2 \n [Moench] G1_HIGHGAIN, G1_LOWGAIN,
      * G2_HIGHCAP_HIGHGAIN, G2_HIGHCAP_LOWGAIN, G2_LOWCAP_HIGHGAIN,
@@ -1179,9 +1179,9 @@ class Detector {
     /** [Jungfrau]*/
     Result<defs::gainMode> getGainMode(Positions pos = {}) const;
 
-    /** [Jungfrau] Options: DYNAMICGAIN, FORCE_SWITCH_G1, FORCE_SWITCH_G2,
-     * FIX_G1, FIX_G2, FIX_G0, FIX_HG0 \n\CAUTION: Do not use FIX_G0 and FIX_HG0
-     * blindly, you can damage the detector!!!\n
+    /** [Jungfrau] Options: DYNAMIC_GAIN, FORCE_SWITCH_G1, FORCE_SWITCH_G2,
+     * FIX_G1, FIX_G2, FIX_G0 \n\CAUTION: Do not use FIX_G0 blindly, you can
+     * damage the detector!!!\n
      */
     void setGainMode(const defs::gainMode mode, Positions pos = {});
 

--- a/slsDetectorSoftware/include/sls/Detector.h
+++ b/slsDetectorSoftware/include/sls/Detector.h
@@ -1179,7 +1179,9 @@ class Detector {
     /** [Jungfrau]*/
     Result<defs::gainMode> getGainMode(Positions pos = {}) const;
 
-    /** [Jungfrau] Options: NORMAL_GAIN_MODE, FORCE_SWITCH_G1, FORCE_SWITCH_G2\n
+    /** [Jungfrau] Options: NORMAL_GAIN_MODE, FORCE_SWITCH_G1, FORCE_SWITCH_G2,
+     * FIX_G1, FIX_G2, FIX_G0, FIX_HG0 \n\CAUTION: Do not use FIX_G0 and FIX_HG0
+     * blindly, you can damage the detector!!!\n
      */
     void setGainMode(const defs::gainMode mode, Positions pos = {});
 

--- a/slsDetectorSoftware/include/sls/Detector.h
+++ b/slsDetectorSoftware/include/sls/Detector.h
@@ -1179,7 +1179,7 @@ class Detector {
     /** [Jungfrau]*/
     Result<defs::gainMode> getGainMode(Positions pos = {}) const;
 
-    /** [Jungfrau] Options: DYNAMIC_GAIN, FORCE_SWITCH_G1, FORCE_SWITCH_G2,
+    /** [Jungfrau] Options: DYNAMIC_GAIN_MODE, FORCE_SWITCH_G1, FORCE_SWITCH_G2,
      * FIX_G1, FIX_G2, FIX_G0 \n\CAUTION: Do not use FIX_G0 blindly, you can
      * damage the detector!!!\n
      */

--- a/slsDetectorSoftware/include/sls/Detector.h
+++ b/slsDetectorSoftware/include/sls/Detector.h
@@ -1179,7 +1179,7 @@ class Detector {
     /** [Jungfrau]*/
     Result<defs::gainMode> getGainMode(Positions pos = {}) const;
 
-    /** [Jungfrau] Options: NORMAL_GAIN_MODE, FORCE_SWITCH_G1, FORCE_SWITCH_G2,
+    /** [Jungfrau] Options: DYNAMICGAIN, FORCE_SWITCH_G1, FORCE_SWITCH_G2,
      * FIX_G1, FIX_G2, FIX_G0, FIX_HG0 \n\CAUTION: Do not use FIX_G0 and FIX_HG0
      * blindly, you can damage the detector!!!\n
      */

--- a/slsDetectorSoftware/src/CmdProxy.h
+++ b/slsDetectorSoftware/src/CmdProxy.h
@@ -1877,7 +1877,9 @@ class CmdProxy {
     INTEGER_COMMAND_VEC_ID(
         gainmode, getGainMode, setGainMode,
         sls::StringTo<slsDetectorDefs::gainMode>,
-        "[forceswitchg1, forceswitchg2]\n\t[Jungfrau] Gain mode.");
+        "[forceswitchg1|forceswitchg2|fixgain1|fixgain2|fixgain0|"
+        "fixhighgain0]\n\t[Jungfrau] Gain mode.\n\tCAUTION: Do not use "
+        "fixgain0 and fixhighgain0 blindly, you can damage the detector!!!");
 
     /* Gotthard Specific */
     TIME_GET_COMMAND(exptimel, getExptimeLeft,

--- a/slsDetectorSoftware/src/CmdProxy.h
+++ b/slsDetectorSoftware/src/CmdProxy.h
@@ -1203,12 +1203,12 @@ class CmdProxy {
         settings, getSettings, setSettings,
         sls::StringTo<slsDetectorDefs::detectorSettings>,
         "[standard, fast, highgain, dynamicgain, lowgain, "
-        "mediumgain, veryhighgain, dynamichg0, "
+        "mediumgain, veryhighgain, highgain0, "
         "fixgain1, fixgain2, forceswitchg1, forceswitchg2, "
         "verylowgain, g1_hg, g1_lg, g2_hc_hg, g2_hc_lg, "
-        "g2_lc_hg, g2_lc_lg, g4_hg, g4_lg]"
+        "g2_lc_hg, g2_lc_lg, g4_hg, g4_lg, gain0]"
         "\n\t Detector Settings"
-        "\n\t[Jungfrau] - [dynamicgain | dynamichg0]"
+        "\n\t[Jungfrau] - [ gain0 | highgain0]"
         "\n\t[Gotthard] - [dynamicgain | highgain | lowgain | "
         "mediumgain | veryhighgain]"
         "\n\t[Gotthard2] - [dynamicgain | fixgain1 | fixgain2]"
@@ -1877,9 +1877,9 @@ class CmdProxy {
     INTEGER_COMMAND_VEC_ID(
         gainmode, getGainMode, setGainMode,
         sls::StringTo<slsDetectorDefs::gainMode>,
-        "[forceswitchg1|forceswitchg2|fixgain1|fixgain2|fixgain0|"
-        "fixhighgain0]\n\t[Jungfrau] Gain mode.\n\tCAUTION: Do not use "
-        "fixgain0 and fixhighgain0 blindly, you can damage the detector!!!");
+        "[dynamicgain|forceswitchg1|forceswitchg2|fixg1|fixg2|fixg0]\n\t["
+        "Jungfrau] Gain mode.\n\tCAUTION: Do not use fixg0 blindly, you can "
+        "damage the detector!!!");
 
     /* Gotthard Specific */
     TIME_GET_COMMAND(exptimel, getExptimeLeft,

--- a/slsDetectorSoftware/src/CmdProxy.h
+++ b/slsDetectorSoftware/src/CmdProxy.h
@@ -1878,7 +1878,8 @@ class CmdProxy {
         gainmode, getGainMode, setGainMode,
         sls::StringTo<slsDetectorDefs::gainMode>,
         "[dynamicgain|forceswitchg1|forceswitchg2|fixg1|fixg2|fixg0]\n\t["
-        "Jungfrau] Gain mode.\n\tCAUTION: Do not use fixg0 blindly, you can "
+        "Jungfrau] Gain mode.\n\tCAUTION: Do not use fixg0 without caution, "
+        "you can "
         "damage the detector!!!");
 
     /* Gotthard Specific */

--- a/slsDetectorSoftware/src/Detector.cpp
+++ b/slsDetectorSoftware/src/Detector.cpp
@@ -1494,9 +1494,12 @@ void Detector::setStorageCellDelay(ns value, Positions pos) {
 std::vector<defs::gainMode> Detector::getGainModeList() const {
     switch (getDetectorType().squash()) {
     case defs::JUNGFRAU:
-        return std::vector<defs::gainMode>{
-            defs::DYNAMIC_GAIN, defs::FORCE_SWITCH_G1, defs::FORCE_SWITCH_G2,
-            defs::FIX_G1,       defs::FIX_G2,          defs::FIX_G0};
+        return std::vector<defs::gainMode>{defs::DYNAMIC_GAIN_MODE,
+                                           defs::FORCE_SWITCH_G1,
+                                           defs::FORCE_SWITCH_G2,
+                                           defs::FIX_G1,
+                                           defs::FIX_G2,
+                                           defs::FIX_G0};
         break;
     default:
         throw RuntimeError("Gain mode is not implemented for this detector.");

--- a/slsDetectorSoftware/src/Detector.cpp
+++ b/slsDetectorSoftware/src/Detector.cpp
@@ -158,8 +158,8 @@ std::vector<defs::detectorSettings> Detector::getSettingsList() const {
             defs::HIGHGAIN, defs::DYNAMICGAIN, defs::LOWGAIN, defs::MEDIUMGAIN,
             defs::VERYHIGHGAIN};
     case defs::JUNGFRAU:
-        return std::vector<defs::detectorSettings>{defs::DYNAMICGAIN,
-                                                   defs::DYNAMICHG0};
+        return std::vector<defs::detectorSettings>{defs::GAIN0,
+                                                   defs::HIGHGAIN0};
     case defs::GOTTHARD2:
         return std::vector<defs::detectorSettings>{
             defs::DYNAMICGAIN, defs::DYNAMICHG0, defs::FIXGAIN1,
@@ -1495,9 +1495,8 @@ std::vector<defs::gainMode> Detector::getGainModeList() const {
     switch (getDetectorType().squash()) {
     case defs::JUNGFRAU:
         return std::vector<defs::gainMode>{
-            defs::DYNAMICGAIN, defs::FORCE_SWITCH_G1, defs::FORCE_SWITCH_G2,
-            defs::FIX_G1,      defs::FIX_G2,          defs::FIX_G0,
-            defs::FIX_HG0};
+            defs::DYNAMIC_GAIN, defs::FORCE_SWITCH_G1, defs::FORCE_SWITCH_G2,
+            defs::FIX_G1,       defs::FIX_G2,          defs::FIX_G0};
         break;
     default:
         throw RuntimeError("Gain mode is not implemented for this detector.");

--- a/slsDetectorSoftware/src/Detector.cpp
+++ b/slsDetectorSoftware/src/Detector.cpp
@@ -1494,9 +1494,10 @@ void Detector::setStorageCellDelay(ns value, Positions pos) {
 std::vector<defs::gainMode> Detector::getGainModeList() const {
     switch (getDetectorType().squash()) {
     case defs::JUNGFRAU:
-        return std::vector<defs::gainMode>{defs::NORMAL_GAIN_MODE,
-                                           defs::FORCE_SWITCH_G1,
-                                           defs::FORCE_SWITCH_G2};
+        return std::vector<defs::gainMode>{
+            defs::DYNAMICGAIN, defs::FORCE_SWITCH_G1, defs::FORCE_SWITCH_G2,
+            defs::FIX_G1,      defs::FIX_G2,          defs::FIX_G0,
+            defs::FIX_HG0};
         break;
     default:
         throw RuntimeError("Gain mode is not implemented for this detector.");

--- a/slsDetectorSoftware/src/Detector.cpp
+++ b/slsDetectorSoftware/src/Detector.cpp
@@ -162,8 +162,7 @@ std::vector<defs::detectorSettings> Detector::getSettingsList() const {
                                                    defs::HIGHGAIN0};
     case defs::GOTTHARD2:
         return std::vector<defs::detectorSettings>{
-            defs::DYNAMICGAIN, defs::DYNAMICHG0, defs::FIXGAIN1,
-            defs::FIXGAIN2};
+            defs::DYNAMICGAIN, defs::FIXGAIN1, defs::FIXGAIN2};
     case defs::MOENCH:
         return std::vector<defs::detectorSettings>{
             defs::G1_HIGHGAIN,         defs::G1_LOWGAIN,

--- a/slsDetectorSoftware/tests/test-CmdProxy-jungfrau.cpp
+++ b/slsDetectorSoftware/tests/test-CmdProxy-jungfrau.cpp
@@ -463,8 +463,18 @@ TEST_CASE("gainmode", "[.cmd]") {
         }
         {
             std::ostringstream oss;
-            proxy.Call("gainmode", {"normal"}, -1, PUT, oss);
-            REQUIRE(oss.str() == "gainmode normal\n");
+            proxy.Call("gainmode", {"fixg1"}, -1, PUT, oss);
+            REQUIRE(oss.str() == "gainmode fixg1\n");
+        }
+        {
+            std::ostringstream oss;
+            proxy.Call("gainmode", {"fixg2"}, -1, PUT, oss);
+            REQUIRE(oss.str() == "gainmode fixg2\n");
+        }
+        {
+            std::ostringstream oss;
+            proxy.Call("gainmode", {"dynamic"}, -1, PUT, oss);
+            REQUIRE(oss.str() == "gainmode dynamic\n");
         }
         for (int i = 0; i != det.size(); ++i) {
             det.setGainMode(prev_val[i], {i});

--- a/slsDetectorSoftware/tests/test-CmdProxy-jungfrau.cpp
+++ b/slsDetectorSoftware/tests/test-CmdProxy-jungfrau.cpp
@@ -458,6 +458,11 @@ TEST_CASE("gainmode", "[.cmd]") {
         }
         {
             std::ostringstream oss;
+            proxy.Call("gainmode", {"dynamicgain"}, -1, PUT, oss);
+            REQUIRE(oss.str() == "gainmode dynamicgain\n");
+        }
+        {
+            std::ostringstream oss;
             proxy.Call("gainmode", {"forceswitchg2"}, -1, PUT, oss);
             REQUIRE(oss.str() == "gainmode forceswitchg2\n");
         }
@@ -473,8 +478,8 @@ TEST_CASE("gainmode", "[.cmd]") {
         }
         {
             std::ostringstream oss;
-            proxy.Call("gainmode", {"dynamic"}, -1, PUT, oss);
-            REQUIRE(oss.str() == "gainmode dynamic\n");
+            proxy.Call("gainmode", {"fixg0"}, -1, PUT, oss);
+            REQUIRE(oss.str() == "gainmode fixg0\n");
         }
         for (int i = 0; i != det.size(); ++i) {
             det.setGainMode(prev_val[i], {i});

--- a/slsDetectorSoftware/tests/test-CmdProxy.cpp
+++ b/slsDetectorSoftware/tests/test-CmdProxy.cpp
@@ -150,7 +150,7 @@ TEST_CASE("settings", "[.cmd]") {
     allSett.push_back("lowgain");
     allSett.push_back("mediumgain");
     allSett.push_back("veryhighgain");
-    allSett.push_back("dynamichg0");
+    allSett.push_back("highgain0");
     allSett.push_back("fixgain1");
     allSett.push_back("fixgain2");
     allSett.push_back("verylowgain");
@@ -164,12 +164,13 @@ TEST_CASE("settings", "[.cmd]") {
     allSett.push_back("g4_lg");
     allSett.push_back("forceswitchg1");
     allSett.push_back("forceswitchg2");
+    allSett.push_back("gain0");
 
     std::vector<std::string> sett;
     switch (det_type) {
     case defs::JUNGFRAU:
-        sett.push_back("dynamicgain");
-        sett.push_back("dynamichg0");
+        sett.push_back("gain0");
+        sett.push_back("highgain0");
         break;
     case defs::GOTTHARD:
         sett.push_back("highgain");

--- a/slsSupportLib/include/sls/sls_detector_defs.h
+++ b/slsSupportLib/include/sls/sls_detector_defs.h
@@ -414,7 +414,15 @@ typedef struct {
 
     enum vetoAlgorithm { DEFAULT_ALGORITHM };
 
-    enum gainMode { NORMAL_GAIN_MODE, FORCE_SWITCH_G1, FORCE_SWITCH_G2 };
+    enum gainMode {
+        NORMAL_GAIN_MODE,
+        FORCE_SWITCH_G1,
+        FORCE_SWITCH_G2,
+        FIX_G1,
+        FIX_G2,
+        FIX_G0,
+        FIX_HG0
+    };
 
 #ifdef __cplusplus
 

--- a/slsSupportLib/include/sls/sls_detector_defs.h
+++ b/slsSupportLib/include/sls/sls_detector_defs.h
@@ -415,7 +415,7 @@ typedef struct {
     enum vetoAlgorithm { DEFAULT_ALGORITHM };
 
     enum gainMode {
-        NORMAL_GAIN_MODE,
+        DYNAMICGAIN,
         FORCE_SWITCH_G1,
         FORCE_SWITCH_G2,
         FIX_G1,

--- a/slsSupportLib/include/sls/sls_detector_defs.h
+++ b/slsSupportLib/include/sls/sls_detector_defs.h
@@ -416,12 +416,11 @@ typedef struct {
     enum vetoAlgorithm { DEFAULT_ALGORITHM };
 
     enum gainMode {
-        DYNAMIC_GAIN,
+        DYNAMIC_GAIN_MODE,
         FORCE_SWITCH_G1,
         FORCE_SWITCH_G2,
         FIX_G1,
         FIX_G2,
-        FIX_G0,
         FIX_G0
     };
 

--- a/slsSupportLib/include/sls/sls_detector_defs.h
+++ b/slsSupportLib/include/sls/sls_detector_defs.h
@@ -345,7 +345,7 @@ typedef struct {
         LOWGAIN,
         MEDIUMGAIN,
         VERYHIGHGAIN,
-        DYNAMICHG0,
+        HIGHGAIN0,
         FIXGAIN1,
         FIXGAIN2,
         VERYLOWGAIN,
@@ -357,6 +357,7 @@ typedef struct {
         G2_LOWCAP_LOWGAIN,
         G4_HIGHGAIN,
         G4_LOWGAIN,
+        GAIN0,
         UNDEFINED = 200,
         UNINITIALIZED
     };
@@ -415,13 +416,13 @@ typedef struct {
     enum vetoAlgorithm { DEFAULT_ALGORITHM };
 
     enum gainMode {
-        DYNAMICGAIN,
+        DYNAMIC_GAIN,
         FORCE_SWITCH_G1,
         FORCE_SWITCH_G2,
         FIX_G1,
         FIX_G2,
         FIX_G0,
-        FIX_HG0
+        FIX_G0
     };
 
 #ifdef __cplusplus

--- a/slsSupportLib/src/ToString.cpp
+++ b/slsSupportLib/src/ToString.cpp
@@ -170,8 +170,8 @@ std::string ToString(const defs::detectorSettings s) {
         return std::string("mediumgain");
     case defs::VERYHIGHGAIN:
         return std::string("veryhighgain");
-    case defs::DYNAMICHG0:
-        return std::string("dynamichg0");
+    case defs::HIGHGAIN0:
+        return std::string("highgain0");
     case defs::FIXGAIN1:
         return std::string("fixgain1");
     case defs::FIXGAIN2:
@@ -194,6 +194,8 @@ std::string ToString(const defs::detectorSettings s) {
         return std::string("g4_hg");
     case defs::G4_LOWGAIN:
         return std::string("g4_lg");
+    case defs::GAIN0:
+        return std::string("gain0");
     case defs::UNDEFINED:
         return std::string("undefined");
     case defs::UNINITIALIZED:
@@ -581,7 +583,7 @@ std::string ToString(const defs::vetoAlgorithm s) {
 
 std::string ToString(const defs::gainMode s) {
     switch (s) {
-    case defs::DYNAMICGAIN:
+    case defs::DYNAMIC_GAIN:
         return std::string("dynamicgain");
     case defs::FORCE_SWITCH_G1:
         return std::string("forceswitchg1");
@@ -593,8 +595,6 @@ std::string ToString(const defs::gainMode s) {
         return std::string("fixg2");
     case defs::FIX_G0:
         return std::string("fixg0");
-    case defs::FIX_HG0:
-        return std::string("fixhg0");
     default:
         return std::string("Unknown");
     }
@@ -635,8 +635,8 @@ template <> defs::detectorSettings StringTo(const std::string &s) {
         return defs::MEDIUMGAIN;
     if (s == "veryhighgain")
         return defs::VERYHIGHGAIN;
-    if (s == "dynamichg0")
-        return defs::DYNAMICHG0;
+    if (s == "highgain0")
+        return defs::HIGHGAIN0;
     if (s == "fixgain1")
         return defs::FIXGAIN1;
     if (s == "fixgain2")
@@ -657,6 +657,8 @@ template <> defs::detectorSettings StringTo(const std::string &s) {
         return defs::G2_LOWCAP_LOWGAIN;
     if (s == "g4_hg")
         return defs::G4_HIGHGAIN;
+    if (s == "gain0")
+        return defs::GAIN0;
     if (s == "g4_lg")
         return defs::G4_LOWGAIN;
     throw sls::RuntimeError("Unknown setting " + s);
@@ -985,7 +987,7 @@ template <> defs::vetoAlgorithm StringTo(const std::string &s) {
 
 template <> defs::gainMode StringTo(const std::string &s) {
     if (s == "dynamicgain")
-        return defs::DYNAMICGAIN;
+        return defs::DYNAMIC_GAIN;
     if (s == "forceswitchg1")
         return defs::FORCE_SWITCH_G1;
     if (s == "forceswitchg2")
@@ -996,8 +998,6 @@ template <> defs::gainMode StringTo(const std::string &s) {
         return defs::FIX_G2;
     if (s == "fixg0")
         return defs::FIX_G0;
-    if (s == "fixhg0")
-        return defs::FIX_HG0;
     throw sls::RuntimeError("Unknown gain mode " + s);
 }
 

--- a/slsSupportLib/src/ToString.cpp
+++ b/slsSupportLib/src/ToString.cpp
@@ -581,8 +581,8 @@ std::string ToString(const defs::vetoAlgorithm s) {
 
 std::string ToString(const defs::gainMode s) {
     switch (s) {
-    case defs::NORMAL_GAIN_MODE:
-        return std::string("normal");
+    case defs::DYNAMICGAIN:
+        return std::string("dynamicgain");
     case defs::FORCE_SWITCH_G1:
         return std::string("forceswitchg1");
     case defs::FORCE_SWITCH_G2:
@@ -984,8 +984,8 @@ template <> defs::vetoAlgorithm StringTo(const std::string &s) {
 }
 
 template <> defs::gainMode StringTo(const std::string &s) {
-    if (s == "normal")
-        return defs::NORMAL_GAIN_MODE;
+    if (s == "dynamicgain")
+        return defs::DYNAMICGAIN;
     if (s == "forceswitchg1")
         return defs::FORCE_SWITCH_G1;
     if (s == "forceswitchg2")

--- a/slsSupportLib/src/ToString.cpp
+++ b/slsSupportLib/src/ToString.cpp
@@ -583,7 +583,7 @@ std::string ToString(const defs::vetoAlgorithm s) {
 
 std::string ToString(const defs::gainMode s) {
     switch (s) {
-    case defs::DYNAMIC_GAIN:
+    case defs::DYNAMIC_GAIN_MODE:
         return std::string("dynamicgain");
     case defs::FORCE_SWITCH_G1:
         return std::string("forceswitchg1");
@@ -987,7 +987,7 @@ template <> defs::vetoAlgorithm StringTo(const std::string &s) {
 
 template <> defs::gainMode StringTo(const std::string &s) {
     if (s == "dynamicgain")
-        return defs::DYNAMIC_GAIN;
+        return defs::DYNAMIC_GAIN_MODE;
     if (s == "forceswitchg1")
         return defs::FORCE_SWITCH_G1;
     if (s == "forceswitchg2")

--- a/slsSupportLib/src/ToString.cpp
+++ b/slsSupportLib/src/ToString.cpp
@@ -587,6 +587,14 @@ std::string ToString(const defs::gainMode s) {
         return std::string("forceswitchg1");
     case defs::FORCE_SWITCH_G2:
         return std::string("forceswitchg2");
+    case defs::FIX_G1:
+        return std::string("fixg1");
+    case defs::FIX_G2:
+        return std::string("fixg2");
+    case defs::FIX_G0:
+        return std::string("fixg0");
+    case defs::FIX_HG0:
+        return std::string("fixhg0");
     default:
         return std::string("Unknown");
     }
@@ -982,6 +990,14 @@ template <> defs::gainMode StringTo(const std::string &s) {
         return defs::FORCE_SWITCH_G1;
     if (s == "forceswitchg2")
         return defs::FORCE_SWITCH_G2;
+    if (s == "fixg1")
+        return defs::FIX_G1;
+    if (s == "fixg2")
+        return defs::FIX_G2;
+    if (s == "fixg0")
+        return defs::FIX_G0;
+    if (s == "fixhg0")
+        return defs::FIX_HG0;
     throw sls::RuntimeError("Unknown gain mode " + s);
 }
 


### PR DESCRIPTION
- settings: remove check for special dacs, should not return undefined
 [g0, hg0]

- gain mode:
[dynamicgain, forceswitchg1, forceswitchg2, fixg1, fixg2, fixg0]
fixg0 and fixhg0 is combined to fixg0 as it depends on settings (g0 and hg0)

- fixg0 is cmp_reset bit and requires a warning in help that they can damage the detector when using this without caution
- also disabled unless in advanced mode in gui, warning when setting it

- any command touching the chip1.1 register will not check the status when setting. It will just set and assume that it has been set.
