### PR TITLE
removed c++14 only overload_cast from pybind enum interface

### DIFF
--- a/python/scripts/generate_enums.py
+++ b/python/scripts/generate_enums.py
@@ -16,8 +16,10 @@ from parse import remove_comments
 allow_bitwise_op = ["M3_GainCaps"]
 allow_bitwise_op = ["streamingInterface"]
 
-op_key = {"operator|": "__or__", 
-          "operator&" : "__and__"}
+# op_key = {"operator|": "__or__", 
+#           "operator&" : "__and__"}
+op_key = {"operator|": "|", 
+          "operator&" : "&"}
 
 def single_line_enum(line):
     sub = line[line.find('{')+1:line.find('}')]
@@ -92,8 +94,7 @@ def generate_enum_string(enums):
 
         #Here add the operators 
         for op in operators:
-            data.append(f"\n\t.def(\"{op_key[op]}\", py::overload_cast< const slsDetectorDefs::streamingInterface&,  const slsDetectorDefs::streamingInterface&>(&{op}))")
-
+            data.append(f"\n\t.def(py::self {op_key[op]} slsDetectorDefs::{key}())")
 
         data.append(';\n\n')
     return ''.join(data)

--- a/python/scripts/generate_enums.py
+++ b/python/scripts/generate_enums.py
@@ -16,8 +16,6 @@ from parse import remove_comments
 allow_bitwise_op = ["M3_GainCaps"]
 allow_bitwise_op = ["streamingInterface"]
 
-# op_key = {"operator|": "__or__", 
-#           "operator&" : "__and__"}
 op_key = {"operator|": "|", 
           "operator&" : "&"}
 

--- a/python/src/enums.cpp
+++ b/python/src/enums.cpp
@@ -1,4 +1,5 @@
-/* WARINING This file is auto generated any edits might be overwritten without warning */
+/* WARINING This file is auto generated any edits might be overwritten without
+ * warning */
 
 // SPDX-License-Identifier: LGPL-3.0-or-other
 // Copyright (C) 2021 Contributors to the SLS Detector Package
@@ -42,15 +43,19 @@ void init_enums(py::module &m) {
 
     py::enum_<slsDetectorDefs::frameDiscardPolicy>(Defs, "frameDiscardPolicy")
         .value("NO_DISCARD", slsDetectorDefs::frameDiscardPolicy::NO_DISCARD)
-        .value("DISCARD_EMPTY_FRAMES", slsDetectorDefs::frameDiscardPolicy::DISCARD_EMPTY_FRAMES)
-        .value("DISCARD_PARTIAL_FRAMES", slsDetectorDefs::frameDiscardPolicy::DISCARD_PARTIAL_FRAMES)
-        .value("NUM_DISCARD_POLICIES", slsDetectorDefs::frameDiscardPolicy::NUM_DISCARD_POLICIES)
+        .value("DISCARD_EMPTY_FRAMES",
+               slsDetectorDefs::frameDiscardPolicy::DISCARD_EMPTY_FRAMES)
+        .value("DISCARD_PARTIAL_FRAMES",
+               slsDetectorDefs::frameDiscardPolicy::DISCARD_PARTIAL_FRAMES)
+        .value("NUM_DISCARD_POLICIES",
+               slsDetectorDefs::frameDiscardPolicy::NUM_DISCARD_POLICIES)
         .export_values();
 
     py::enum_<slsDetectorDefs::fileFormat>(Defs, "fileFormat")
         .value("BINARY", slsDetectorDefs::fileFormat::BINARY)
         .value("HDF5", slsDetectorDefs::fileFormat::HDF5)
-        .value("NUM_FILE_FORMATS", slsDetectorDefs::fileFormat::NUM_FILE_FORMATS)
+        .value("NUM_FILE_FORMATS",
+               slsDetectorDefs::fileFormat::NUM_FILE_FORMATS)
         .export_values();
 
     py::enum_<slsDetectorDefs::dimension>(Defs, "dimension")
@@ -59,19 +64,25 @@ void init_enums(py::module &m) {
         .export_values();
 
     py::enum_<slsDetectorDefs::externalSignalFlag>(Defs, "externalSignalFlag")
-        .value("TRIGGER_IN_RISING_EDGE", slsDetectorDefs::externalSignalFlag::TRIGGER_IN_RISING_EDGE)
-        .value("TRIGGER_IN_FALLING_EDGE", slsDetectorDefs::externalSignalFlag::TRIGGER_IN_FALLING_EDGE)
-        .value("INVERSION_ON", slsDetectorDefs::externalSignalFlag::INVERSION_ON)
-        .value("INVERSION_OFF", slsDetectorDefs::externalSignalFlag::INVERSION_OFF)
+        .value("TRIGGER_IN_RISING_EDGE",
+               slsDetectorDefs::externalSignalFlag::TRIGGER_IN_RISING_EDGE)
+        .value("TRIGGER_IN_FALLING_EDGE",
+               slsDetectorDefs::externalSignalFlag::TRIGGER_IN_FALLING_EDGE)
+        .value("INVERSION_ON",
+               slsDetectorDefs::externalSignalFlag::INVERSION_ON)
+        .value("INVERSION_OFF",
+               slsDetectorDefs::externalSignalFlag::INVERSION_OFF)
         .export_values();
 
     py::enum_<slsDetectorDefs::timingMode>(Defs, "timingMode")
         .value("AUTO_TIMING", slsDetectorDefs::timingMode::AUTO_TIMING)
-        .value("TRIGGER_EXPOSURE", slsDetectorDefs::timingMode::TRIGGER_EXPOSURE)
+        .value("TRIGGER_EXPOSURE",
+               slsDetectorDefs::timingMode::TRIGGER_EXPOSURE)
         .value("GATED", slsDetectorDefs::timingMode::GATED)
         .value("BURST_TRIGGER", slsDetectorDefs::timingMode::BURST_TRIGGER)
         .value("TRIGGER_GATED", slsDetectorDefs::timingMode::TRIGGER_GATED)
-        .value("NUM_TIMING_MODES", slsDetectorDefs::timingMode::NUM_TIMING_MODES)
+        .value("NUM_TIMING_MODES",
+               slsDetectorDefs::timingMode::NUM_TIMING_MODES)
         .export_values();
 
     py::enum_<slsDetectorDefs::dacIndex>(Defs, "dacIndex")
@@ -159,13 +170,16 @@ void init_enums(py::module &m) {
         .value("HIGH_VOLTAGE", slsDetectorDefs::dacIndex::HIGH_VOLTAGE)
         .value("TEMPERATURE_ADC", slsDetectorDefs::dacIndex::TEMPERATURE_ADC)
         .value("TEMPERATURE_FPGA", slsDetectorDefs::dacIndex::TEMPERATURE_FPGA)
-        .value("TEMPERATURE_FPGAEXT", slsDetectorDefs::dacIndex::TEMPERATURE_FPGAEXT)
+        .value("TEMPERATURE_FPGAEXT",
+               slsDetectorDefs::dacIndex::TEMPERATURE_FPGAEXT)
         .value("TEMPERATURE_10GE", slsDetectorDefs::dacIndex::TEMPERATURE_10GE)
         .value("TEMPERATURE_DCDC", slsDetectorDefs::dacIndex::TEMPERATURE_DCDC)
         .value("TEMPERATURE_SODL", slsDetectorDefs::dacIndex::TEMPERATURE_SODL)
         .value("TEMPERATURE_SODR", slsDetectorDefs::dacIndex::TEMPERATURE_SODR)
-        .value("TEMPERATURE_FPGA2", slsDetectorDefs::dacIndex::TEMPERATURE_FPGA2)
-        .value("TEMPERATURE_FPGA3", slsDetectorDefs::dacIndex::TEMPERATURE_FPGA3)
+        .value("TEMPERATURE_FPGA2",
+               slsDetectorDefs::dacIndex::TEMPERATURE_FPGA2)
+        .value("TEMPERATURE_FPGA3",
+               slsDetectorDefs::dacIndex::TEMPERATURE_FPGA3)
         .value("TRIMBIT_SCAN", slsDetectorDefs::dacIndex::TRIMBIT_SCAN)
         .value("V_POWER_A", slsDetectorDefs::dacIndex::V_POWER_A)
         .value("V_POWER_B", slsDetectorDefs::dacIndex::V_POWER_B)
@@ -204,15 +218,20 @@ void init_enums(py::module &m) {
         .value("VERYLOWGAIN", slsDetectorDefs::detectorSettings::VERYLOWGAIN)
         .value("G1_HIGHGAIN", slsDetectorDefs::detectorSettings::G1_HIGHGAIN)
         .value("G1_LOWGAIN", slsDetectorDefs::detectorSettings::G1_LOWGAIN)
-        .value("G2_HIGHCAP_HIGHGAIN", slsDetectorDefs::detectorSettings::G2_HIGHCAP_HIGHGAIN)
-        .value("G2_HIGHCAP_LOWGAIN", slsDetectorDefs::detectorSettings::G2_HIGHCAP_LOWGAIN)
-        .value("G2_LOWCAP_HIGHGAIN", slsDetectorDefs::detectorSettings::G2_LOWCAP_HIGHGAIN)
-        .value("G2_LOWCAP_LOWGAIN", slsDetectorDefs::detectorSettings::G2_LOWCAP_LOWGAIN)
+        .value("G2_HIGHCAP_HIGHGAIN",
+               slsDetectorDefs::detectorSettings::G2_HIGHCAP_HIGHGAIN)
+        .value("G2_HIGHCAP_LOWGAIN",
+               slsDetectorDefs::detectorSettings::G2_HIGHCAP_LOWGAIN)
+        .value("G2_LOWCAP_HIGHGAIN",
+               slsDetectorDefs::detectorSettings::G2_LOWCAP_HIGHGAIN)
+        .value("G2_LOWCAP_LOWGAIN",
+               slsDetectorDefs::detectorSettings::G2_LOWCAP_LOWGAIN)
         .value("G4_HIGHGAIN", slsDetectorDefs::detectorSettings::G4_HIGHGAIN)
         .value("G4_LOWGAIN", slsDetectorDefs::detectorSettings::G4_LOWGAIN)
         .value("GAIN0", slsDetectorDefs::detectorSettings::GAIN0)
         .value("UNDEFINED", slsDetectorDefs::detectorSettings::UNDEFINED)
-        .value("UNINITIALIZED", slsDetectorDefs::detectorSettings::UNINITIALIZED)
+        .value("UNINITIALIZED",
+               slsDetectorDefs::detectorSettings::UNINITIALIZED)
         .export_values();
 
     py::enum_<slsDetectorDefs::clockIndex>(Defs, "clockIndex")
@@ -225,7 +244,8 @@ void init_enums(py::module &m) {
     py::enum_<slsDetectorDefs::readoutMode>(Defs, "readoutMode")
         .value("ANALOG_ONLY", slsDetectorDefs::readoutMode::ANALOG_ONLY)
         .value("DIGITAL_ONLY", slsDetectorDefs::readoutMode::DIGITAL_ONLY)
-        .value("ANALOG_AND_DIGITAL", slsDetectorDefs::readoutMode::ANALOG_AND_DIGITAL)
+        .value("ANALOG_AND_DIGITAL",
+               slsDetectorDefs::readoutMode::ANALOG_AND_DIGITAL)
         .export_values();
 
     py::enum_<slsDetectorDefs::speedLevel>(Defs, "speedLevel")
@@ -239,14 +259,18 @@ void init_enums(py::module &m) {
     py::enum_<slsDetectorDefs::burstMode>(Defs, "burstMode")
         .value("BURST_INTERNAL", slsDetectorDefs::burstMode::BURST_INTERNAL)
         .value("BURST_EXTERNAL", slsDetectorDefs::burstMode::BURST_EXTERNAL)
-        .value("CONTINUOUS_INTERNAL", slsDetectorDefs::burstMode::CONTINUOUS_INTERNAL)
-        .value("CONTINUOUS_EXTERNAL", slsDetectorDefs::burstMode::CONTINUOUS_EXTERNAL)
+        .value("CONTINUOUS_INTERNAL",
+               slsDetectorDefs::burstMode::CONTINUOUS_INTERNAL)
+        .value("CONTINUOUS_EXTERNAL",
+               slsDetectorDefs::burstMode::CONTINUOUS_EXTERNAL)
         .value("NUM_BURST_MODES", slsDetectorDefs::burstMode::NUM_BURST_MODES)
         .export_values();
 
     py::enum_<slsDetectorDefs::timingSourceType>(Defs, "timingSourceType")
-        .value("TIMING_INTERNAL", slsDetectorDefs::timingSourceType::TIMING_INTERNAL)
-        .value("TIMING_EXTERNAL", slsDetectorDefs::timingSourceType::TIMING_EXTERNAL)
+        .value("TIMING_INTERNAL",
+               slsDetectorDefs::timingSourceType::TIMING_INTERNAL)
+        .value("TIMING_EXTERNAL",
+               slsDetectorDefs::timingSourceType::TIMING_EXTERNAL)
         .export_values();
 
     py::enum_<slsDetectorDefs::M3_GainCaps>(Defs, "M3_GainCaps")
@@ -265,14 +289,17 @@ void init_enums(py::module &m) {
         .value("BOTTOM", slsDetectorDefs::portPosition::BOTTOM)
         .export_values();
 
-    py::enum_<slsDetectorDefs::streamingInterface>(Defs, "streamingInterface", py::arithmetic())
+    py::enum_<slsDetectorDefs::streamingInterface>(Defs, "streamingInterface",
+                                                   py::arithmetic())
         .value("NONE", slsDetectorDefs::streamingInterface::NONE)
-        .value("LOW_LATENCY_LINK", slsDetectorDefs::streamingInterface::LOW_LATENCY_LINK)
-        .value("ETHERNET_10GB", slsDetectorDefs::streamingInterface::ETHERNET_10GB)
+        .value("LOW_LATENCY_LINK",
+               slsDetectorDefs::streamingInterface::LOW_LATENCY_LINK)
+        .value("ETHERNET_10GB",
+               slsDetectorDefs::streamingInterface::ETHERNET_10GB)
         .value("ALL", slsDetectorDefs::streamingInterface::ALL)
         .export_values()
-        .def("__or__", py::overload_cast<const slsDetectorDefs::streamingInterface &, const slsDetectorDefs::streamingInterface &>(&operator|))
-        .def("__and__", py::overload_cast<const slsDetectorDefs::streamingInterface &, const slsDetectorDefs::streamingInterface &>(&operator&));
+        .def(py::self | slsDetectorDefs::streamingInterface())
+        .def(py::self & slsDetectorDefs::streamingInterface());
 
     py::enum_<slsDetectorDefs::vetoAlgorithm>(Defs, "vetoAlgorithm")
         .value("ALG_HITS", slsDetectorDefs::vetoAlgorithm::ALG_HITS)

--- a/python/tests/test_enums.py
+++ b/python/tests/test_enums.py
@@ -1,0 +1,23 @@
+from slsdet.enums import streamingInterface
+import pytest
+def test_streamingInterface_bitwise():
+    """Bitwise operations on streaming interfaces are allowed"""
+
+    sif_none = streamingInterface.NONE
+    sif_low = streamingInterface.LOW_LATENCY_LINK
+    sif_10g = streamingInterface.ETHERNET_10GB
+    sif_all = streamingInterface.ALL
+
+    assert sif_low | sif_none == sif_low
+    assert sif_10g | sif_none == sif_10g
+    assert sif_low | sif_10g == sif_all
+    assert sif_10g | sif_all == sif_all
+
+    assert sif_10g & sif_low == sif_none
+    assert sif_low & sif_low == sif_low
+    assert sif_all & sif_all == sif_all
+
+def test_streamingInterface_bitwise_only_allowed_on_same_type():
+    with pytest.raises(Exception):
+        assert streamingInterface.LOW_LATENCY_LINK & 5 == 7
+


### PR DESCRIPTION
Removed a C++14 only feature of pybind11 that had was used by mistake. 

Lines 301 and 302 in enums.cpp show the difference in the generated code. All other edits in the same file is noise from clang-format. 

