### PR TITLE
num udp interfaces in shm

### DIFF
--- a/slsDetectorSoftware/src/Detector.cpp
+++ b/slsDetectorSoftware/src/Detector.cpp
@@ -871,7 +871,7 @@ Result<std::string> Detector::getScanErrorMessage(Positions pos) const {
 
 Result<int> Detector::getNumberofUDPInterfaces(Positions pos) const {
     // also called by vetostream (for gotthard2)
-    return pimpl->getNumberofUDPInterfaces(pos);
+    return pimpl->Parallel(&Module::getNumberofUDPInterfacesFromShm, pos);
 }
 
 void Detector::setNumberofUDPInterfaces(int n, Positions pos) {
@@ -1739,7 +1739,7 @@ Result<defs::streamingInterface> Detector::getVetoStream(Positions pos) const {
     // 3gbe
     auto r3 = pimpl->Parallel(&Module::getVetoStream, pos);
     // 10gbe (debugging interface) opens 2nd udp interface in receiver
-    auto r10 = pimpl->getNumberofUDPInterfaces(pos);
+    auto r10 = getNumberofUDPInterfaces(pos);
 
     Result<defs::streamingInterface> res(r3.size());
     for (unsigned int i = 0; i < res.size(); ++i) {
@@ -1761,7 +1761,7 @@ void Detector::setVetoStream(defs::streamingInterface interface,
     pimpl->Parallel(&Module::setVetoStream, pos, LOW_LATENCY_LINK);
 
     // 10gbe (debugging interface) opens 2nd udp interface in receiver
-    int old_numinterfaces = pimpl->getNumberofUDPInterfaces(pos).tsquash(
+    int old_numinterfaces = getNumberofUDPInterfaces(pos).tsquash(
         "retrieved inconsistent number of udp interfaces");
     int numinterfaces =
         (((interface & defs::streamingInterface::ETHERNET_10GB) ==
@@ -2355,7 +2355,7 @@ Result<uint64_t> Detector::getRxCurrentFrameIndex(Positions pos) const {
 }
 
 std::vector<int> Detector::getPortNumbers(int start_port) {
-    int num_sockets_per_detector = pimpl->getNumberofUDPInterfaces({}).tsquash(
+    int num_sockets_per_detector = getNumberofUDPInterfaces({}).tsquash(
         "Number of UDP Interfaces is not consistent among modules");
     std::vector<int> res;
     res.reserve(size());

--- a/slsDetectorSoftware/src/DetectorImpl.cpp
+++ b/slsDetectorSoftware/src/DetectorImpl.cpp
@@ -245,15 +245,6 @@ void DetectorImpl::setHostname(const std::vector<std::string> &name) {
         addModule(hostname);
     }
     updateDetectorSize();
-
-    // update zmq port (especially for eiger)
-    int numInterfaces = modules[0]->getNumberofUDPInterfaces();
-    if (numInterfaces == 2) {
-        for (size_t i = 0; i < modules.size(); ++i) {
-            modules[i]->setClientStreamingPort(DEFAULT_ZMQ_CL_PORTNO +
-                                               i * numInterfaces);
-        }
-    }
 }
 
 void DetectorImpl::addModule(const std::string &hostname) {
@@ -288,11 +279,20 @@ void DetectorImpl::addModule(const std::string &hostname) {
     modules[pos]->setControlPort(port);
     modules[pos]->setStopPort(port + 1);
     modules[pos]->setHostname(host, shm()->initialChecks);
+
     // module type updated by now
     shm()->detType = Parallel(&Module::getDetectorType, {})
                          .tsquash("Inconsistent detector types.");
     // for moench and ctb
     modules[pos]->updateNumberOfChannels();
+
+    // for eiger, jungfrau, gotthard2
+    modules[pos]->updateNumberofUDPInterfaces();
+
+    // update zmq port in case numudpinterfaces changed
+    int numInterfaces = modules[pos]->getNumberofUDPInterfacesFromShm();
+    modules[pos]->setClientStreamingPort(DEFAULT_ZMQ_CL_PORTNO +
+                                         pos * numInterfaces);
 }
 
 void DetectorImpl::updateDetectorSize() {
@@ -1359,10 +1359,6 @@ std::vector<char> DetectorImpl::readProgrammingFile(const std::string &fname) {
     // delete temporary
     unlink(destfname);
     return buffer;
-}
-
-sls::Result<int> DetectorImpl::getNumberofUDPInterfaces(Positions pos) const {
-    return Parallel(&Module::getNumberofUDPInterfaces, pos);
 }
 
 sls::Result<int> DetectorImpl::getDefaultDac(defs::dacIndex index,

--- a/slsDetectorSoftware/src/DetectorImpl.h
+++ b/slsDetectorSoftware/src/DetectorImpl.h
@@ -291,7 +291,6 @@ class DetectorImpl : public virtual slsDetectorDefs {
      */
     std::vector<char> readProgrammingFile(const std::string &fname);
 
-    sls::Result<int> getNumberofUDPInterfaces(Positions pos) const;
     void setNumberofUDPInterfaces(int n, Positions pos);
     sls::Result<int> getDefaultDac(defs::dacIndex index,
                                    defs::detectorSettings sett,

--- a/slsDetectorSoftware/src/Module.cpp
+++ b/slsDetectorSoftware/src/Module.cpp
@@ -936,9 +936,8 @@ int Module::getNumberofUDPInterfacesFromShm() const {
     return shm()->numUDPInterfaces;
 }
 
-int Module::getNumberofUDPInterfaces() const {
+void Module::updateNumberofUDPInterfaces() {
     shm()->numUDPInterfaces = sendToDetector<int>(F_GET_NUM_INTERFACES);
-    return shm()->numUDPInterfaces;
 }
 
 void Module::setNumberofUDPInterfaces(int n) {
@@ -1146,7 +1145,7 @@ std::string Module::printReceiverConfiguration() {
        << getReceiverHostname();
 
     if (shm()->detType == JUNGFRAU) {
-        os << "\nNumber of Interfaces:\t" << getNumberofUDPInterfaces()
+        os << "\nNumber of Interfaces:\t" << getNumberofUDPInterfacesFromShm()
            << "\nSelected Interface:\t" << getSelectedUDPInterface();
     }
 
@@ -3183,10 +3182,10 @@ void Module::initializeModuleStructure(detectorType type) {
     sls::strcpy_safe(shm()->rxHostname, "none");
     shm()->rxTCPPort = DEFAULT_PORTNO + 2;
     shm()->useReceiverFlag = false;
+    shm()->numUDPInterfaces = 1;
     shm()->zmqport =
         DEFAULT_ZMQ_CL_PORTNO + moduleIndex * shm()->numUDPInterfaces;
     shm()->zmqip = IpAddr{};
-    shm()->numUDPInterfaces = 1;
     shm()->stoppedFlag = false;
 
     // get the Module parameters based on type

--- a/slsDetectorSoftware/src/Module.h
+++ b/slsDetectorSoftware/src/Module.h
@@ -218,7 +218,7 @@ class Module : public virtual slsDetectorDefs {
      *                                                 *
      * ************************************************/
     int getNumberofUDPInterfacesFromShm() const;
-    int getNumberofUDPInterfaces() const;
+    void updateNumberofUDPInterfaces();
     void setNumberofUDPInterfaces(int n);
     int getSelectedUDPInterface() const;
     void selectUDPInterface(int n);


### PR DESCRIPTION
- moved shm numUdpInterfaces initialization up front
- moved updating this value in DetectorImpl::setHostname to DetectorImpl::addModule for more readability
- renamed getNumberofUdpInterfaces to an updateNumberofUdpInterfaces as the shm was being updated and is used only in setHostname
- everywhere else getNumberofUdpInterfaces is replaced by getNumberofUdpInterfacesFromShm
- @alejandrohomsp @erikfrojdh 