### PR TITLE
frames in file hdf5

### DIFF
--- a/slsReceiverSoftware/src/BinaryDataFile.cpp
+++ b/slsReceiverSoftware/src/BinaryDataFile.cpp
@@ -72,7 +72,7 @@ void BinaryDataFile::WriteToFile(char *buffer, const int buffersize,
         ++subFileIndex_;
         CreateFile();
     }
-    numFramesInFile_++;
+    ++numFramesInFile_;
 
     // write to file
     int ret = 0;

--- a/slsReceiverSoftware/src/HDF5DataFile.cpp
+++ b/slsReceiverSoftware/src/HDF5DataFile.cpp
@@ -128,7 +128,7 @@ void HDF5DataFile::CreateFirstHDF5DataFile(
 }
 
 void HDF5DataFile::CreateFile() {
-
+    numFramesInFile_ = 0;
     numFilesInAcquisition_++;
 
     std::ostringstream os;
@@ -237,7 +237,7 @@ void HDF5DataFile::WriteToFile(char *buffer, const int buffersize,
         ++subFileIndex_;
         CreateFile();
     }
-    numFramesInFile_++;
+    ++numFramesInFile_;
 
     // extend dataset (when receiver start followed by many status starts
     // (jungfrau)))


### PR DESCRIPTION
- reset num frames per file when creating a new hdf5 file  (fixes the problem of creating one file per frame after the first 20k frames)