### PR TITLE
Fixed crash on gendoc

### DIFF
--- a/docs/src/gendoc.cpp
+++ b/docs/src/gendoc.cpp
@@ -45,6 +45,7 @@ int main() {
 
     for (const auto &cmd : commands) {
         std::ostringstream os;
+        std::cout << cmd << '\n';
         proxy.Call(cmd, {}, -1, slsDetectorDefs::HELP_ACTION, os);
 
         auto tmp = os.str().erase(0, cmd.size());

--- a/slsDetectorSoftware/src/CmdProxy.cpp
+++ b/slsDetectorSoftware/src/CmdProxy.cpp
@@ -1056,7 +1056,18 @@ std::string CmdProxy::TemperatureValues(int action) {
 std::string CmdProxy::Dac(int action) {
     std::ostringstream os;
     os << cmd << ' ';
+    
+    if (action == defs::HELP_ACTION) {
+        if (args.size() == 0) {
+            os << GetHelpDac(std::to_string(0)) << '\n';
+        } else {
+            os << args[0] << ' ' << GetHelpDac(args[0]) << '\n';
+        }
+        return os.str();
+    }
+
     auto type = det->getDetectorType().squash();
+
     // dac indices only for ctb
     if (args.size() > 0 && action != defs::HELP_ACTION) {
         if (is_int(args[0]) && type != defs::CHIPTESTBOARD) {
@@ -1066,13 +1077,7 @@ std::string CmdProxy::Dac(int action) {
         }
     }
 
-    if (action == defs::HELP_ACTION) {
-        if (args.size() == 0) {
-            os << GetHelpDac(std::to_string(0)) << '\n';
-        } else {
-            os << args[0] << ' ' << GetHelpDac(args[0]) << '\n';
-        }
-    } else if (action == defs::GET_ACTION) {
+    if (action == defs::GET_ACTION) {
         if (args.empty())
             WrongNumberOfParameters(1); // This prints slightly wrong
 

--- a/slsDetectorSoftware/tests/test-CmdProxy.cpp
+++ b/slsDetectorSoftware/tests/test-CmdProxy.cpp
@@ -16,6 +16,17 @@ using sls::Detector;
 using test::GET;
 using test::PUT;
 
+TEST_CASE("Calling help doesn't throw or cause segfault"){
+    //Dont add [.cmd] tag this should run with normal tests
+    CmdProxy proxy(nullptr);
+    auto commands = proxy.GetProxyCommands();
+    std::ostringstream os;
+    for (const auto &cmd : commands)
+        REQUIRE_NOTHROW(proxy.Call(cmd, {}, -1, slsDetectorDefs::HELP_ACTION, os));
+    
+    
+}
+
 TEST_CASE("Unknown command", "[.cmd]") {
 
     Detector det;

--- a/slsSupportLib/tests/test-Timer.cpp
+++ b/slsSupportLib/tests/test-Timer.cpp
@@ -6,7 +6,7 @@
 #include <chrono>
 #include <thread>
 
-TEST_CASE("Time 1s restart then time 2s") {
+TEST_CASE("Time 1s restart then time 2s", "[.timer]") {
     auto sleep_duration = std::chrono::seconds(1);
     auto t = sls::Timer();
     std::this_thread::sleep_for(sleep_duration);
@@ -17,7 +17,7 @@ TEST_CASE("Time 1s restart then time 2s") {
     REQUIRE(t.elapsed_s() == Approx(2).epsilon(0.01));
 }
 
-TEST_CASE("Return ms") {
+TEST_CASE("Return ms", "[.timer]") {
     auto sleep_duration = std::chrono::milliseconds(1300);
     auto t = sls::Timer();
     std::this_thread::sleep_for(sleep_duration);


### PR DESCRIPTION
Generating documentation was crashing because of a nullptr dereference in calling help for the "dac" command. 

- Fixed by checking for help action before using the detector 
- added test that checks that for all helps this doesn't crash
- Disabled Timer tests by default since they take ~2s


**For the future always create Detector object when calling help?** 
Would create an extra shm in case of using prefix det id. Could even throw in case shm can't be opened due to some other user creating it. So not 100% convinced. 