### PR TITLE
Cleaning up the find zmq

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,8 @@ include(cmake/project_version.cmake)
 #functions to add compiler flags
 include(cmake/SlsAddFlag.cmake)
 
+include(cmake/SlsFindZeroMQ.cmake)
+
 # Include additional modules that are used unconditionally
 include(GNUInstallDirs)
 
@@ -186,42 +188,11 @@ install(TARGETS slsProjectOptions slsProjectWarnings rapidjson
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_INSTALL_RPATH $ORIGIN)
-# set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
 set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
 
 
-set(ZeroMQ_HINT "" CACHE STRING "Hint where ZeroMQ could be found")
-#Adapted from: https://github.com/zeromq/cppzmq/
-if (NOT TARGET libzmq)
-    if(ZeroMQ_HINT)
-        message(STATUS "Looking for ZeroMQ in: ${ZeroMQ_HINT}")
-        find_package(ZeroMQ 4 
-            NO_DEFAULT_PATH
-            HINTS ${ZeroMQ_DIR}
-        )
-    else()
-        find_package(ZeroMQ 4 QUIET)
-    endif()
-    
-  # libzmq autotools install: fallback to pkg-config
-  if(NOT ZeroMQ_FOUND)
-    message(STATUS "CMake libzmq package not found, trying again with pkg-config (normal install of zeromq)")
-    list (APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/libzmq-pkg-config)
-    find_package(ZeroMQ 4 REQUIRED)
-  endif()
+custom_find_zmq()
 
-  # TODO "REQUIRED" above should already cause a fatal failure if not found, but this doesn't seem to work
-  if(NOT ZeroMQ_FOUND)
-    message(FATAL_ERROR "ZeroMQ was not found, neither as a CMake package nor via pkg-config")
-  endif()
-
-  if (ZeroMQ_FOUND AND NOT TARGET libzmq)
-    message(FATAL_ERROR "ZeroMQ version not supported!")
-  endif()
-endif()
-
-get_target_property(VAR libzmq INTERFACE_INCLUDE_DIRECTORIES)
-message(STATUS "zmq: ${VAR}")
 
 if (SLS_USE_TESTS)
     enable_testing()

--- a/cmake/SlsFindZeroMQ.cmake
+++ b/cmake/SlsFindZeroMQ.cmake
@@ -13,7 +13,9 @@ function(custom_find_zmq)
         endif()
         
     # libzmq autotools install: fallback to pkg-config
-    if(NOT ZeroMQ_FOUND)
+    if(ZeroMQ_FOUND)
+        message(STATUS "Found libzmq using find_package")
+    else()
         message(STATUS "CMake libzmq package not found, trying again with pkg-config (normal install of zeromq)")
         list (APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake/libzmq-pkg-config)
         find_package(ZeroMQ 4 REQUIRED)
@@ -30,7 +32,7 @@ function(custom_find_zmq)
     endif()
 
     get_target_property(VAR libzmq IMPORTED_LOCATION)
-    message(STATUS "Using zmqlib: ${VAR}")
+    message(STATUS "Using libzmq: ${VAR}")
 
 
 endfunction()

--- a/cmake/SlsFindZeroMQ.cmake
+++ b/cmake/SlsFindZeroMQ.cmake
@@ -1,0 +1,36 @@
+function(custom_find_zmq)
+    set(ZeroMQ_HINT "" CACHE STRING "Hint where ZeroMQ could be found")
+    #Adapted from: https://github.com/zeromq/cppzmq/
+    if (NOT TARGET libzmq)
+        if(ZeroMQ_HINT)
+            message(STATUS "Looking for ZeroMQ in: ${ZeroMQ_HINT}")
+            find_package(ZeroMQ 4 
+                NO_DEFAULT_PATH
+                HINTS ${ZeroMQ_DIR}
+            )
+        else()
+            find_package(ZeroMQ 4 QUIET)
+        endif()
+        
+    # libzmq autotools install: fallback to pkg-config
+    if(NOT ZeroMQ_FOUND)
+        message(STATUS "CMake libzmq package not found, trying again with pkg-config (normal install of zeromq)")
+        list (APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake/libzmq-pkg-config)
+        find_package(ZeroMQ 4 REQUIRED)
+    endif()
+
+    # TODO "REQUIRED" above should already cause a fatal failure if not found, but this doesn't seem to work
+    if(NOT ZeroMQ_FOUND)
+        message(FATAL_ERROR "ZeroMQ was not found, neither as a CMake package nor via pkg-config")
+    endif()
+
+    if (ZeroMQ_FOUND AND NOT TARGET libzmq)
+        message(FATAL_ERROR "ZeroMQ version not supported!")
+    endif()
+    endif()
+
+    get_target_property(VAR libzmq IMPORTED_LOCATION)
+    message(STATUS "Using zmqlib: ${VAR}")
+
+
+endfunction()

--- a/cmake/libzmq-pkg-config/FindZeroMQ.cmake
+++ b/cmake/libzmq-pkg-config/FindZeroMQ.cmake
@@ -11,6 +11,7 @@ find_library(ZeroMQ_STATIC_LIBRARY NAMES libzmq-static.a libzmq.a libzmq.dll.a
 
 if(ZeroMQ_LIBRARY OR ZeroMQ_STATIC_LIBRARY)
     set(ZeroMQ_FOUND ON)
+    message(STATUS "Found libzmq using PkgConfig")
 endif()
 
 if (TARGET libzmq)


### PR DESCRIPTION

In case libzmq is installed without the  FindZeroMQ.cmake

```
-- CMake libzmq package not found, trying again with pkg-config (normal install of zeromq)
-- Found PkgConfig: /usr/bin/pkg-config (found version "0.27.1") 
-- Found libzmq using PkgConfig
-- Using zmqlib: /usr/lib64/libzmq.so
```

If libzmq is found using FindZeroMQ.cmake (for example by the conda installation) but could also be a custom installation or a Linux distro that ships with FindPackageZeroMQ

```
-- Found libzmq using find_package
-- Using zmqlib: /afs/psi.ch/project/sls_det_software/conda/envs/erik/lib/libzmq.so
```

Setting a custom location to look for ZeroMQ, which in this example fails and falls back to PkgConfig. 

```
-- Looking for ZeroMQ in: /usr/lib64
-- Could NOT find ZeroMQ (missing: ZeroMQ_DIR)
-- CMake libzmq package not found, trying again with pkg-config (normal install of zeromq)
-- Found PkgConfig: /usr/bin/pkg-config (found version "1.8.0") 
-- Found libzmq using PkgConfig
-- Using libzmq: /usr/lib64/libzmq.so
```
