### PR TITLE
m3 rxr:  inconsistent generaldata default

### DIFF
--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -66,6 +66,8 @@ This document describes the differences between v7.0.0 and v6.x.x
 - registerCallBackRawDataReady and registerCallBackRawDataModifyReady now gives a sls_receiver_header* instead of a char*, and uint32_t to size_t
 - registerCallBackStartAcquisition gave incorrect imagesize (+120 bytes). corrected.
 - registerCallBackStartAcquisition parameter is a const string reference
+- m3 (runnig config second time with tengiga 0, dr !=32, counters !=0x7) calculated incorrect image size expected
+
 
 2. Resolved Issues
 ==================

--- a/slsReceiverSoftware/src/Implementation.cpp
+++ b/slsReceiverSoftware/src/Implementation.cpp
@@ -153,10 +153,20 @@ void Implementation::setDetectorType(const detectorType d) {
     default:
         break;
     }
-    numUDPInterfaces = generalData->numUDPInterfaces;
-    fifoDepth = generalData->defaultFifoDepth;
-    udpSocketBufferSize = generalData->defaultUdpSocketBufferSize;
+
     framesPerFile = generalData->maxFramesPerFile;
+    fifoDepth = generalData->defaultFifoDepth;
+    numUDPInterfaces = generalData->numUDPInterfaces;
+    udpSocketBufferSize = generalData->defaultUdpSocketBufferSize;
+    dynamicRange = generalData->dynamicRange;
+    // tengigaEnable = generalData->tengigaEnable;
+    numberOfAnalogSamples = generalData->nAnalogSamples;
+    numberOfDigitalSamples = generalData->nDigitalSamples;
+    readoutType = generalData->readoutType;
+    adcEnableMaskOneGiga = generalData->adcEnableMaskOneGiga;
+    adcEnableMaskTenGiga = generalData->adcEnableMaskTenGiga;
+    roi = generalData->roi;
+    counterMask = generalData->counterMask;
 
     SetLocalNetworkParameters();
     SetupFifoStructure();
@@ -1395,14 +1405,8 @@ uint32_t Implementation::getCounterMask() const { return counterMask; }
 
 void Implementation::setCounterMask(const uint32_t i) {
     if (counterMask != i) {
-        int ncounters = __builtin_popcount(i);
-        if (ncounters < 1 || ncounters > 3) {
-            throw sls::RuntimeError("Invalid number of counters " +
-                                    std::to_string(ncounters) +
-                                    ". Expected 1-3.");
-        }
+        generalData->SetCounterMask(i);
         counterMask = i;
-        generalData->SetNumberofCounters(ncounters);
         SetupFifoStructure();
     }
     LOG(logINFO) << "Counter mask: " << sls::ToStringHex(counterMask);
@@ -1445,6 +1449,8 @@ void Implementation::setROI(slsDetectorDefs::ROI arg) {
 bool Implementation::getTenGigaEnable() const { return tengigaEnable; }
 
 void Implementation::setTenGigaEnable(const bool b) {
+    LOG(logINFORED) << "setting tengiga  old:" << tengigaEnable << " new:" << b
+                    << " gene:" << generalData->tengigaEnable;
     if (tengigaEnable != b) {
         tengigaEnable = b;
 

--- a/slsReceiverSoftware/src/Implementation.cpp
+++ b/slsReceiverSoftware/src/Implementation.cpp
@@ -159,7 +159,7 @@ void Implementation::setDetectorType(const detectorType d) {
     numUDPInterfaces = generalData->numUDPInterfaces;
     udpSocketBufferSize = generalData->defaultUdpSocketBufferSize;
     dynamicRange = generalData->dynamicRange;
-    // tengigaEnable = generalData->tengigaEnable;
+    tengigaEnable = generalData->tengigaEnable;
     numberOfAnalogSamples = generalData->nAnalogSamples;
     numberOfDigitalSamples = generalData->nDigitalSamples;
     readoutType = generalData->readoutType;
@@ -533,10 +533,10 @@ void Implementation::startReceiver() {
     // callbacks
     if (startAcquisitionCallBack) {
         try {
-            std::size_t imageSize = static_cast<uint32_t>(generalData->imageSize);
-            startAcquisitionCallBack(
-                filePath, fileName, fileIndex, imageSize,
-                pStartAcquisition);
+            std::size_t imageSize =
+                static_cast<uint32_t>(generalData->imageSize);
+            startAcquisitionCallBack(filePath, fileName, fileIndex, imageSize,
+                                     pStartAcquisition);
         } catch (const std::exception &e) {
             throw sls::RuntimeError("Start Acquisition Callback Error: " +
                                     std::string(e.what()));
@@ -1449,8 +1449,6 @@ void Implementation::setROI(slsDetectorDefs::ROI arg) {
 bool Implementation::getTenGigaEnable() const { return tengigaEnable; }
 
 void Implementation::setTenGigaEnable(const bool b) {
-    LOG(logINFORED) << "setting tengiga  old:" << tengigaEnable << " new:" << b
-                    << " gene:" << generalData->tengigaEnable;
     if (tengigaEnable != b) {
         tengigaEnable = b;
 
@@ -1633,7 +1631,8 @@ void Implementation::setDbitOffset(const int s) { ctbDbitOffset = s; }
  *                                                *
  * ************************************************/
 void Implementation::registerCallBackStartAcquisition(
-    int (*func)(const std::string &, const std::string &, uint64_t, size_t, void *),
+    int (*func)(const std::string &, const std::string &, uint64_t, size_t,
+                void *),
     void *arg) {
     startAcquisitionCallBack = func;
     pStartAcquisition = arg;


### PR DESCRIPTION
inconsistent copy with generalData and implementation members, especially for m3 (non default rxr generic values), issue caught on second configure with non m3 default values, eg tengiga 0