### PR TITLE
Support external builds of python bindings, gui, ctbgui and moench stuff

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,7 @@ if(SLS_BUILD_ONLY_MOENCH)
 endif()
 
 
+
 set(ClangFormat_EXCLUDE_PATTERNS    "build/" 
                                     "libs/" 
                                     "slsDetectorCalibration/" 
@@ -100,6 +101,7 @@ if((CMAKE_BUILD_TYPE STREQUAL "Release") AND SLS_LTO_AVAILABLE)
 else()
     message(STATUS "Building without link time optimization")
 endif()
+
 
 
 #Add two fake libraries to manage options
@@ -224,8 +226,8 @@ if (SLS_USE_INTEGRATION_TESTS)
 endif (SLS_USE_INTEGRATION_TESTS)
 
 if (SLS_USE_PYTHON)
-    find_package (Python 3.6 COMPONENTS Interpreter Development)
-    add_subdirectory(libs/pybind11)
+    # find_package (Python 3.6 COMPONENTS Interpreter Development)
+    # add_subdirectory(libs/pybind11)
     add_subdirectory(python)
 endif(SLS_USE_PYTHON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,21 +109,6 @@ else()
     message(STATUS "Building without link time optimization")
 endif()
 
-#Testing for minimum version for compilers
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.2)
-        message(FATAL_ERROR "Clang version must be at least 3.2!")
-    endif()
-elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.8)
-            message(FATAL_ERROR "GCC version must be at least 4.8!")
-    endif()
-    if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5)
-            target_compile_options(slsProjectWarnings INTERFACE 
-                                             -Wno-missing-field-initializers)
-    endif()
-endif()
-
 
 if(SLS_EXT_BUILD)
     # Find ourself in case of external build
@@ -161,6 +146,13 @@ if (NOT TARGET slsProjectWarnings)
     sls_enable_cxx_warning("-Wnull-dereference")
     sls_enable_cxx_warning("-Wduplicated-cond")
     sls_disable_cxx_warning("-Wclass-memaccess")
+
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5 AND "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+            target_compile_options(slsProjectWarnings INTERFACE 
+                                                -Wno-missing-field-initializers)
+endif()
+
+
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,13 +8,8 @@ set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG")
 
 cmake_policy(SET CMP0074 NEW)
 include(cmake/project_version.cmake)
-
-#functions to add compiler flags
 include(cmake/SlsAddFlag.cmake)
-
 include(cmake/SlsFindZeroMQ.cmake)
-
-# Include additional modules that are used unconditionally
 include(GNUInstallDirs)
 
 # If conda build, always set lib dir to 'lib'
@@ -28,7 +23,7 @@ string(TOLOWER "${PROJECT_NAME}" PROJECT_NAME_LOWER)
 
 # Set targets export name (used by slsDetectorPackage and dependencies)
 set(TARGETS_EXPORT_NAME "${PROJECT_NAME_LOWER}-targets")
-#set(namespace "${PROJECT_NAME}::")
+set(namespace "sls::")
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 
@@ -38,6 +33,8 @@ set(SLS_MASTER_PROJECT OFF)
 if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     set(SLS_MASTER_PROJECT ON)
 endif()
+
+
 
 option(SLS_USE_HDF5 "HDF5 File format" OFF)
 option(SLS_BUILD_SHARED_LIBRARIES "Build shared libaries" ON)
@@ -71,6 +68,19 @@ if(SLS_BUILD_ONLY_MOENCH)
 endif()
 
 
+option(SLS_EXT_BUILD "external build of part of the project" OFF)
+if(SLS_EXT_BUILD)
+    message(STATUS "External build using already installed libraries")
+    set(SLS_BUILD_SHARED_LIBRARIES OFF CACHE BOOL "Should already exist" FORCE)
+    set(SLS_USE_TEXTCLIENT OFF CACHE BOOL "Should already exist" FORCE)
+    set(SLS_USE_DETECTOR OFF CACHE BOOL "Should already exist" FORCE)
+    set(SLS_USE_RECEIVER OFF CACHE BOOL "Should already exist" FORCE)
+    set(SLS_USE_RECEIVER_BINARIES OFF CACHE BOOL "Should already exist" FORCE)
+    set(SLS_MASTER_PROJECT OFF CACHE BOOL "No master proj in case of extbuild" FORCE) 
+endif()
+
+#Maybe have an option guarding this?
+set(SLS_INTERNAL_RAPIDJSON_DIR ${CMAKE_CURRENT_SOURCE_DIR}/libs/rapidjson)
 
 set(ClangFormat_EXCLUDE_PATTERNS    "build/" 
                                     "libs/" 
@@ -81,9 +91,6 @@ set(ClangFormat_EXCLUDE_PATTERNS    "build/"
                                     "sample/"
                                     ${CMAKE_BINARY_DIR})
 find_package(ClangFormat)
-
-
-
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
@@ -102,43 +109,6 @@ else()
     message(STATUS "Building without link time optimization")
 endif()
 
-
-
-#Add two fake libraries to manage options
-add_library(slsProjectOptions INTERFACE)
-add_library(slsProjectWarnings INTERFACE)
-target_compile_features(slsProjectOptions INTERFACE cxx_std_11)
-target_compile_options(slsProjectWarnings INTERFACE 
-                                            -Wall
-                                            -Wextra
-                                            -Wno-unused-parameter
-                                            # -Wold-style-cast
-                                            -Wnon-virtual-dtor
-                                            -Woverloaded-virtual
-                                            -Wdouble-promotion
-                                            -Wformat=2
-                                            -Wredundant-decls
-                                            # -Wconversion
-                                            -Wvla
-                                            -Wdouble-promotion
-                                            -Werror=return-type
-                                 )
-
-#Settings for C code
-add_library(slsProjectCSettings INTERFACE)
-target_compile_options(slsProjectCSettings INTERFACE 
-                                            -std=gnu99 #fixed
-                                            -Wall
-                                            -Wextra
-                                            -Wno-unused-parameter
-                                            -Wdouble-promotion
-                                            -Wformat=2
-                                            -Wredundant-decls
-                                            -Wdouble-promotion
-                                            -Werror=return-type
-                                )
-
-
 #Testing for minimum version for compilers
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.2)
@@ -154,12 +124,62 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     endif()
 endif()
 
-# Add or disable warnings depending on if the compiler supports them 
-# The function checks internally and sets HAS_warning-name
-sls_enable_cxx_warning("-Wnull-dereference")
-sls_enable_cxx_warning("-Wduplicated-cond")
-sls_disable_cxx_warning("-Wclass-memaccess")
-sls_disable_c_warning("-Wstringop-truncation")
+
+if(SLS_EXT_BUILD)
+    # Find ourself in case of external build
+    find_package(slsDetectorPackage 6 REQUIRED)
+endif()
+
+
+
+# slsProjectOptions and slsProjectWarnings are used
+# to control options for the libraries
+if(NOT TARGET slsProjectOptions)
+    add_library(slsProjectOptions INTERFACE)
+    target_compile_features(slsProjectOptions INTERFACE cxx_std_11)
+endif()
+
+if (NOT TARGET slsProjectWarnings)
+    add_library(slsProjectWarnings INTERFACE)
+    target_compile_options(slsProjectWarnings INTERFACE 
+        -Wall
+        -Wextra
+        -Wno-unused-parameter
+        # -Wold-style-cast
+        -Wnon-virtual-dtor
+        -Woverloaded-virtual
+        -Wdouble-promotion
+        -Wformat=2
+        -Wredundant-decls
+        # -Wconversion
+        -Wvla
+        -Wdouble-promotion
+        -Werror=return-type
+    )
+    # Add or disable warnings depending on if the compiler supports them 
+    # The function checks internally and sets HAS_warning-name
+    sls_enable_cxx_warning("-Wnull-dereference")
+    sls_enable_cxx_warning("-Wduplicated-cond")
+    sls_disable_cxx_warning("-Wclass-memaccess")
+endif()
+
+
+if (NOT TARGET slsProjectCSettings)
+    #Settings for C code
+    add_library(slsProjectCSettings INTERFACE)
+    target_compile_options(slsProjectCSettings INTERFACE 
+                                                -std=gnu99 #fixed
+                                                -Wall
+                                                -Wextra
+                                                -Wno-unused-parameter
+                                                -Wdouble-promotion
+                                                -Wformat=2
+                                                -Wredundant-decls
+                                                -Wdouble-promotion
+                                                -Werror=return-type
+                                    )
+    sls_disable_c_warning("-Wstringop-truncation")
+endif()
 
 
 if(SLS_USE_SANITIZER)
@@ -174,19 +194,14 @@ if(SLS_TUNE_LOCAL)
 endif()
 
 
-#rapidjson
-add_library(rapidjson INTERFACE)
-target_include_directories(rapidjson INTERFACE
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/libs/rapidjson>  
-)
-
-# Install fake the libraries
-install(TARGETS slsProjectOptions slsProjectWarnings rapidjson
+if(SLS_MASTER_PROJECT)
+install(TARGETS slsProjectOptions slsProjectWarnings 
     EXPORT "${TARGETS_EXPORT_NAME}"
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
+endif()
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_INSTALL_RPATH $ORIGIN)
@@ -202,8 +217,9 @@ if (SLS_USE_TESTS)
 endif(SLS_USE_TESTS)
 
 
-# Common functionallity to detector and receiver
-add_subdirectory(slsSupportLib)
+if(NOT SLS_EXT_BUILD)
+    add_subdirectory(slsSupportLib)
+endif()
 
 if (SLS_USE_DETECTOR OR SLS_USE_TEXTCLIENT)
     add_subdirectory(slsDetectorSoftware)
@@ -226,6 +242,8 @@ if (SLS_USE_INTEGRATION_TESTS)
 endif (SLS_USE_INTEGRATION_TESTS)
 
 if (SLS_USE_PYTHON)
+    find_package (Python 3.6 COMPONENTS Interpreter Development)
+    add_subdirectory(libs/pybind11  ${CMAKE_BINARY_DIR}/bin/)
     add_subdirectory(python)
 endif(SLS_USE_PYTHON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -226,8 +226,6 @@ if (SLS_USE_INTEGRATION_TESTS)
 endif (SLS_USE_INTEGRATION_TESTS)
 
 if (SLS_USE_PYTHON)
-    # find_package (Python 3.6 COMPONENTS Interpreter Development)
-    # add_subdirectory(libs/pybind11)
     add_subdirectory(python)
 endif(SLS_USE_PYTHON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,7 +127,7 @@ endif()
 
 if(SLS_EXT_BUILD)
     # Find ourself in case of external build
-    find_package(slsDetectorPackage 6 REQUIRED)
+    find_package(slsDetectorPackage ${PROJECT_VERSION} REQUIRED)
 endif()
 
 

--- a/conda-recepie/copy_lib.sh
+++ b/conda-recepie/copy_lib.sh
@@ -19,4 +19,4 @@ cp build/install/bin/slsMultiReceiver $PREFIX/bin/.
 
 
 cp build/install/include/sls/* $PREFIX/include/sls
-cp -r build/install/share/ $PREFIX/share
+cp -rv build/install/share $PREFIX

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,6 +1,17 @@
 # SPDX-License-Identifier: LGPL-3.0-or-other
 # Copyright (C) 2021 Contributors to the SLS Detector Package
 
+if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+    #if we are only building the python extension
+    cmake_minimum_required(VERSION 3.12)    
+    project(slsdet)
+    find_package(slsDetectorPackage 6 REQUIRED)
+endif()
+
+
+find_package (Python 3.6 COMPONENTS Interpreter Development)
+add_subdirectory(../libs/pybind11  ${CMAKE_BINARY_DIR}/bin/)
+
 pybind11_add_module(_slsdet 
     src/main.cpp 
     src/enums.cpp

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,17 +1,6 @@
 # SPDX-License-Identifier: LGPL-3.0-or-other
 # Copyright (C) 2021 Contributors to the SLS Detector Package
 
-if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
-    #if we are only building the python extension
-    cmake_minimum_required(VERSION 3.12)    
-    project(slsdet)
-    find_package(slsDetectorPackage 6 REQUIRED)
-endif()
-
-
-find_package (Python 3.6 COMPONENTS Interpreter Development)
-add_subdirectory(../libs/pybind11  ${CMAKE_BINARY_DIR}/bin/)
-
 pybind11_add_module(_slsdet 
     src/main.cpp 
     src/enums.cpp

--- a/slsDetectorCalibration/moenchExecutables/CMakeLists.txt
+++ b/slsDetectorCalibration/moenchExecutables/CMakeLists.txt
@@ -56,7 +56,8 @@ foreach(exe ${MOENCH_EXECUTABLES})
         ../dataStructures 
         ../interpolations
         ../../slsReceiverSoftware/include/
-	../../slsSupportLib/include/
+	    ../../slsSupportLib/include/
+        ${SLS_INTERNAL_RAPIDJSON_DIR}
     )
 
     target_link_libraries(${exe} 

--- a/slsDetectorSoftware/CMakeLists.txt
+++ b/slsDetectorSoftware/CMakeLists.txt
@@ -17,6 +17,8 @@ add_library(slsDetectorObject OBJECT
 target_include_directories(slsDetectorObject PUBLIC
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
+    PRIVATE
+    ${SLS_INTERNAL_RAPIDJSON_DIR}
 )
 
 target_link_libraries(slsDetectorObject 

--- a/slsReceiverSoftware/CMakeLists.txt
+++ b/slsReceiverSoftware/CMakeLists.txt
@@ -40,6 +40,8 @@ add_library(slsReceiverObject OBJECT
 target_include_directories(slsReceiverObject PUBLIC
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
+    PRIVATE
+    ${SLS_INTERNAL_RAPIDJSON_DIR}
 )
 
 target_link_libraries(slsReceiverObject 

--- a/slsSupportLib/CMakeLists.txt
+++ b/slsSupportLib/CMakeLists.txt
@@ -34,6 +34,8 @@ set(PUBLICHEADERS
 if(SLS_DEVEL_HEADERS)
     set(PUBLICHEADERS
         ${PUBLICHEADERS}
+        include/sls/ansi.h
+        include/sls/logger.h
         include/sls/file_utils.h
         include/sls/sls_detector_funcs.h
         include/sls/ClientSocket.h
@@ -46,7 +48,7 @@ if(SLS_DEVEL_HEADERS)
         include/sls/versionAPI.h
         include/sls/ZmqSocket.h
         include/sls/bit_utils.h
-        include/sls/mdf5.h
+        include/sls/md5.h
         include/sls/md5_helper.h
     )
 endif()
@@ -75,13 +77,16 @@ target_include_directories(slsSupportObject
   PUBLIC
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
+    PRIVATE
+    ${SLS_INTERNAL_RAPIDJSON_DIR}
 )
+
+message(STATUS "RAPID: ${SLS_INTERNAL_RAPIDJSON_DIR}")
 
 target_link_libraries(slsSupportObject 
   PUBLIC
     slsProjectOptions 
     libzmq
-    rapidjson
   PRIVATE
     slsProjectWarnings
     md5sls     


### PR DESCRIPTION
Use already installed version of the slsDetectorPackage. Assumes that the library has already been built and installed either on a system wide location or pointed to by CMAKE_PREFIX_PATH

The sub projects can then be built using the following option:
```
cmake ~/sls/slsDetectorPackage/ -DSLS_EXT_BUILD=ON #enable some feature
```

Working example on RH7
```
mkdir build && cd build
cmake3 ../slsDetectorPackage/ -DSLS_DEVEL_HEADERS=ON -DCMAKE_INSTALL_PREFIX=~/erik/inst
make -j8
make install

cd ..
mkdir partial_build && cd partial_build
cmake3 ../slsDetectorPackage/ -DCMAKE_PREFIX_PATH=~/erik/inst -DSLS_USE_PYTHON=ON -DSLS_EXT_BUILD=ON
make -j8
```