### PR TITLE
check shm size

### DIFF
--- a/slsDetectorSoftware/src/Detector.cpp
+++ b/slsDetectorSoftware/src/Detector.cpp
@@ -37,7 +37,7 @@ void freeSharedMemory(int detectorIndex, int moduleIndex) {
     int numDetectors = 0;
 
     if (detectorShm.exists()) {
-        detectorShm.openSharedMemory();
+        detectorShm.openSharedMemory(false);
         numDetectors = detectorShm()->numberOfModules;
         detectorShm.removeSharedMemory();
     }

--- a/slsDetectorSoftware/src/DetectorImpl.cpp
+++ b/slsDetectorSoftware/src/DetectorImpl.cpp
@@ -47,7 +47,7 @@ void DetectorImpl::setupDetector(bool verify, bool update) {
     }
 
     if (ctb_shm.exists())
-        ctb_shm.openSharedMemory();
+        ctb_shm.openSharedMemory(verify);
 }
 
 void DetectorImpl::setAcquiringFlag(bool flag) { shm()->acquiringFlag = flag; }
@@ -69,7 +69,7 @@ void DetectorImpl::freeSharedMemory(int detectorIndex, int detPos) {
     int numModules = 0;
 
     if (detectorShm.exists()) {
-        detectorShm.openSharedMemory();
+        detectorShm.openSharedMemory(false);
         numModules = detectorShm()->numberOfModules;
         detectorShm.removeSharedMemory();
     }
@@ -144,7 +144,7 @@ void DetectorImpl::initSharedMemory(bool verify) {
         shm.createSharedMemory();
         initializeDetectorStructure();
     } else {
-        shm.openSharedMemory();
+        shm.openSharedMemory(verify);
         if (verify && shm()->shmversion != DETECTOR_SHMVERSION) {
             LOG(logERROR) << "Detector shared memory (" << detectorIndex
                           << ") version mismatch "
@@ -264,7 +264,7 @@ void DetectorImpl::setHostname(const std::vector<std::string> &name) {
 
     if (shm()->detType == defs::CHIPTESTBOARD) {
         if (ctb_shm.exists())
-            ctb_shm.openSharedMemory();
+            ctb_shm.openSharedMemory(true);
         else
             ctb_shm.createSharedMemory();
     }

--- a/slsDetectorSoftware/src/Module.cpp
+++ b/slsDetectorSoftware/src/Module.cpp
@@ -3196,7 +3196,7 @@ slsDetectorDefs::detectorType Module::getDetectorTypeFromShm(int det_id,
                                 "memory. Please free shared memory.");
     }
 
-    shm.openSharedMemory();
+    shm.openSharedMemory(verify);
     if (verify && shm()->shmversion != MODULE_SHMVERSION) {
         std::ostringstream ss;
         ss << "Single shared memory (" << det_id << "-" << moduleIndex
@@ -3215,7 +3215,7 @@ void Module::initSharedMemory(detectorType type, int det_id, bool verify) {
         shm.createSharedMemory();
         initializeModuleStructure(type);
     } else {
-        shm.openSharedMemory();
+        shm.openSharedMemory(verify);
         if (verify && shm()->shmversion != MODULE_SHMVERSION) {
             std::ostringstream ss;
             ss << "Single shared memory (" << det_id << "-" << moduleIndex

--- a/slsDetectorSoftware/src/SharedMemory.h
+++ b/slsDetectorSoftware/src/SharedMemory.h
@@ -101,14 +101,15 @@ template <typename T> class SharedMemory {
         LOG(logINFO) << "Shared memory created " << name;
     }
 
-    void openSharedMemory() {
+    void openSharedMemory(bool verifySize) {
         int fd = shm_open(name.c_str(), O_RDWR, 0);
         if (fd < 0) {
             std::string msg = "Open existing shared memory " + name +
                               " failed: " + strerror(errno);
             throw SharedMemoryError(msg);
         }
-        checkSize(fd);
+        if (verifySize)
+            checkSize(fd);
         shared_struct = mapSharedMemory(fd);
     }
 

--- a/slsDetectorSoftware/tests/test-Module.cpp
+++ b/slsDetectorSoftware/tests/test-Module.cpp
@@ -33,7 +33,7 @@ TEST_CASE("Is shm fixed pattern shm compatible") {
     // Set shm version to 0
     sls::SharedMemory<sls::sharedModule> shm(0, 0);
     REQUIRE(shm.exists() == true);
-    shm.openSharedMemory();
+    shm.openSharedMemory(true);
     shm()->shmversion = 0;
 
     // Should fail since version is set to 0

--- a/slsDetectorSoftware/tests/test-SharedMemory.cpp
+++ b/slsDetectorSoftware/tests/test-SharedMemory.cpp
@@ -47,7 +47,7 @@ TEST_CASE("Open existing SharedMemory and read", "[detector]") {
     }
 
     SharedMemory<double> shm2(shm_id, -1);
-    shm2.openSharedMemory();
+    shm2.openSharedMemory(true);
     CHECK(*shm2() == 5.3);
 
     shm2.removeSharedMemory();
@@ -74,7 +74,7 @@ TEST_CASE("Open two shared memories to the same place", "[detector]") {
 
     // Open the second shared memory with the same name
     SharedMemory<Data> shm2(shm_id, -1);
-    shm2.openSharedMemory();
+    shm2.openSharedMemory(true);
     CHECK(shm2()->x == 5);
     CHECK(shm.getName() == shm2.getName());
 
@@ -165,7 +165,7 @@ TEST_CASE("map int64 to int32 throws"){
     *shm() = 7;
 
     SharedMemory<int64_t> shm2(shm_id, -1);
-    REQUIRE_THROWS(shm2.openSharedMemory());
+    REQUIRE_THROWS(shm2.openSharedMemory(true));
 
     shm.removeSharedMemory();
     


### PR DESCRIPTION
- size of shm needs to be only sometimes checked when opening shared memory (when freeing shm, do not check size)
- free throws when size does not match (fixed)