### PR TITLE
M3: master starts twice (non blocking)

### DIFF
--- a/slsDetectorSoftware/src/Detector.cpp
+++ b/slsDetectorSoftware/src/Detector.cpp
@@ -781,24 +781,7 @@ void Detector::startReceiver() { pimpl->Parallel(&Module::startReceiver, {}); }
 void Detector::stopReceiver() { pimpl->Parallel(&Module::stopReceiver, {}); }
 
 void Detector::startDetector(Positions pos) {
-    auto detector_type = getDetectorType(pos).squash();
-    if (detector_type == defs::MYTHEN3 && size() > 1) {
-        std::vector<int> slaves(pos);
-        auto is_master = getMaster(pos);
-        int masterPosition = -1;
-        for (unsigned int i = 0; i < is_master.size(); ++i) {
-            if (is_master[i]) {
-                masterPosition = i;
-                slaves.erase(slaves.begin() + i);
-            }
-        }
-        pimpl->Parallel(&Module::startAcquisition, pos);
-        if (masterPosition != -1) {
-            pimpl->Parallel(&Module::startAcquisition, {masterPosition});
-        }
-    } else {
-        pimpl->Parallel(&Module::startAcquisition, pos);
-    }
+    pimpl->startAcquisition(false, pos);
 }
 
 void Detector::startDetectorReadout() {

--- a/slsDetectorSoftware/src/DetectorImpl.cpp
+++ b/slsDetectorSoftware/src/DetectorImpl.cpp
@@ -1124,25 +1124,7 @@ int DetectorImpl::acquire() {
 
         // start and read all
         try {
-            if (detector_type == defs::MYTHEN3 && modules.size() > 1) {
-                // Multi module mythen
-                std::vector<int> master;
-                std::vector<int> slaves;
-                auto is_master = Parallel(&Module::isMaster, {});
-                slaves.reserve(modules.size() - 1); // check this one!!
-                for (size_t i = 0; i < modules.size(); ++i) {
-                    if (is_master[i])
-                        master.push_back(i);
-                    else
-                        slaves.push_back(i);
-                }
-                Parallel(&Module::startAcquisition, slaves);
-                Parallel(&Module::startAndReadAll, master);
-            } else {
-                // Normal acquire
-                Parallel(&Module::startAndReadAll, {});
-            }
-
+            startAcquisition(true, {});
         } catch (...) {
             if (receiver)
                 Parallel(&Module::stopReceiver, {});
@@ -1189,6 +1171,34 @@ int DetectorImpl::acquire() {
     }
     setAcquiringFlag(false);
     return OK;
+}
+
+void DetectorImpl::startAcquisition(bool blocking, Positions pos) {
+    if (shm()->detType == defs::MYTHEN3 && size() > 1) {
+        std::vector<int> master;
+        std::vector<int> slaves;
+        auto is_master = Parallel(&Module::isMaster, pos);
+        // could be all slaves in pos
+        slaves.reserve(pos.size()); 
+        for (size_t i = 0; i != pos.size(); ++i) {
+            if (is_master[i]) 
+                master.push_back(i);
+            else
+                slaves.push_back(i);
+        }
+        if (master.size() > 1) {
+            throw RuntimeError("Could not start acquisitoin. There cannot be more than one master.");
+        }
+
+        Parallel(&Module::startAcquisition, slaves);
+        if (blocking) {
+            Parallel(&Module::startAndReadAll, master);
+        } else {
+            Parallel(&Module::startAcquisition, master);
+        }
+    } else {
+        Parallel(&Module::startAcquisition, pos);
+    }
 }
 
 void DetectorImpl::printProgress(double progress) {

--- a/slsDetectorSoftware/src/DetectorImpl.cpp
+++ b/slsDetectorSoftware/src/DetectorImpl.cpp
@@ -1194,7 +1194,11 @@ void DetectorImpl::startAcquisition(bool blocking, Positions pos) {
             Parallel(&Module::startAcquisition, master);
         }
     } else {
-        Parallel(&Module::startAcquisition, pos);
+        if (blocking) {
+            Parallel(&Module::startAndReadAll, pos);
+        } else {
+            Parallel(&Module::startAcquisition, pos);
+        }
     }
 }
 

--- a/slsDetectorSoftware/src/DetectorImpl.cpp
+++ b/slsDetectorSoftware/src/DetectorImpl.cpp
@@ -1186,9 +1186,6 @@ void DetectorImpl::startAcquisition(bool blocking, Positions pos) {
             else
                 slaves.push_back(i);
         }
-        if (master.size() > 1) {
-            throw RuntimeError("Could not start acquisitoin. There cannot be more than one master.");
-        }
 
         Parallel(&Module::startAcquisition, slaves);
         if (blocking) {

--- a/slsDetectorSoftware/src/DetectorImpl.h
+++ b/slsDetectorSoftware/src/DetectorImpl.h
@@ -278,6 +278,9 @@ class DetectorImpl : public virtual slsDetectorDefs {
      */
     int acquire();
 
+    /** also takes care of master and slave for multi module mythen */
+    void startAcquisition(bool blocking, Positions pos);
+
     /**
      * Combines data from all readouts and gives it to the gui
      * or just gives progress of acquisition by polling receivers


### PR DESCRIPTION
- bug fix: start acq for master m3 was sent twice (non blocking)
- merged redundant code
- position not handled properly for non blocking start acquisition (previously selection of positions wasnt possible for startAcquisition non blocking)