### PR TITLE
rxMemsize

### DIFF
--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -79,6 +79,7 @@ This document describes the differences between v7.0.0 and v6.x.x
 - g2 and m3 clkdiv 2 (system clock) change should affect time settings (g2: exptime, period, delayaftertrigger, burstperiod, m3: exptime, gatedelay, gateperiod, period, delayaftertrigger)
 - g2 system frequency is the same irrespective of timing source
 - (apparently) rxr doesnt get stuck anymore from 6.1.1
+- rxr mem size changed (fifo header size from 8 to 16) due to sls rxr header = 112.. 112+ 16=128 (reduces packet losss especially for g2)
 
 2. Resolved Issues
 ==================

--- a/slsReceiverSoftware/src/receiver_defs.h
+++ b/slsReceiverSoftware/src/receiver_defs.h
@@ -37,7 +37,7 @@ namespace sls {
 #define FILE_BUFFER_SIZE (16 * 1024 * 1024) // 16mb
 
 // fifo
-#define FIFO_HEADER_NUMBYTES   (8)
+#define FIFO_HEADER_NUMBYTES   (16)
 #define FIFO_DATASIZE_NUMBYTES (4)
 #define FIFO_PADDING_NUMBYTES                                                  \
     (4) // for 8 byte alignment due to sls_receiver_header structure


### PR DESCRIPTION
changing fifo header size to 16 to fix the rxr header (112) to be a power of 2 to make it more efficient and reduce packet loss