### PR TITLE
udp_cleardst in fpga

### DIFF
--- a/slsDetectorServers/slsDetectorServer/src/slsDetectorServer_funcs.c
+++ b/slsDetectorServers/slsDetectorServer/src/slsDetectorServer_funcs.c
@@ -9249,8 +9249,21 @@ int clear_all_udp_dst(int file_des) {
         if (check_detector_idle("clear all udp destinations") == OK) {
             memset(udpDetails, 0, sizeof(udpDetails));
             // minimum 1 destination in fpga
-            numUdpDestinations = 1;
-            configure_mac();
+            int numdest = 1;
+            // set number of destinations
+#if defined(JUNGFRAUD) || defined(EIGERD)
+            if (setNumberofDestinations(numdest) == FAIL) {
+                ret = FAIL;
+                strcpy(mess, "Could not clear udp destinations to 1 entry.\n");
+                LOG(logERROR, (mess));
+            } else
+#endif
+            {
+                numUdpDestinations = numdest;
+                LOG(logINFOBLUE, ("Number of UDP Destinations: %d\n",
+                                    numUdpDestinations));
+                configure_mac();
+            }
         }
     }
     return Server_SendResult(file_des, INT32, NULL, 0);


### PR DESCRIPTION
- set number of destination in fpga as well when using udp_cleardst
- ensures fpga destinations are all cleared up in the fpga as well