### PR TITLE
Configfree

### DIFF
--- a/slsDetectorSoftware/src/CmdLineApp.cpp
+++ b/slsDetectorSoftware/src/CmdLineApp.cpp
@@ -58,7 +58,10 @@ int main(int argc, char *argv[]) {
     // if we have an option for verify in the detector constructor
     // we could avoid this but clutter the code
     if (parser.command() == "free" && action != slsDetectorDefs::HELP_ACTION) {
-        sls::freeSharedMemory(parser.multi_id(), parser.detector_id());
+        if (parser.detector_id() != -1)
+            std::cout << "Cannot free shared memory of sub-detector\n";
+        else
+            sls::freeSharedMemory(parser.multi_id());
         return 0;
     }
 

--- a/slsDetectorSoftware/src/CmdLineApp.cpp
+++ b/slsDetectorSoftware/src/CmdLineApp.cpp
@@ -58,12 +58,14 @@ int main(int argc, char *argv[]) {
     // if we have an option for verify in the detector constructor
     // we could avoid this but clutter the code
     if (parser.command() == "free" && action != slsDetectorDefs::HELP_ACTION) {
-        if (parser.detector_id() != -1)
-            std::cout << "Cannot free shared memory of sub-detector\n";
-        else
-            sls::freeSharedMemory(parser.multi_id());
+        sls::freeSharedMemory(parser.multi_id(), parser.detector_id());
         return 0;
     }
+
+    // prevent mem size check
+    if (parser.command() == "config" && action == slsDetectorDefs::PUT_ACTION) {
+        sls::freeSharedMemory(parser.multi_id());
+    }    
 
     try {
         sls::Detector det(parser.multi_id());


### PR DESCRIPTION
prevent mem size check before Detector constructed (for loading config)