### PR TITLE
Udpsocket

### DIFF
--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -85,6 +85,7 @@ This document describes the differences between v7.0.0 and v6.x.x
 - number of storage cells is not updated in teh receiver. done. and also allowing it to be modified in running status
 - refactored memory structure in receiver and listener code (maybe resolves stuck issue, need to check)
 - callback modified to have rx header and not rx header pointer
+- rx udp socket refactored (maybe resolves getting stuck?)
 
 2. Resolved Issues
 ==================

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -85,7 +85,7 @@ This document describes the differences between v7.0.0 and v6.x.x
 - number of storage cells is not updated in teh receiver. done. and also allowing it to be modified in running status
 - refactored memory structure in receiver and listener code (maybe resolves stuck issue, need to check)
 - callback modified to have rx header and not rx header pointer
-- rx udp socket refactored (maybe resolves getting stuck?)
+- rx udp socket refactored (maybe resolves getting stuck?)remove check for eiger header and isntead checks for malformed packets for every detector
 
 2. Resolved Issues
 ==================

--- a/slsReceiverSoftware/src/Listener.cpp
+++ b/slsReceiverSoftware/src/Listener.cpp
@@ -151,14 +151,13 @@ void Listener::CreateUDPSocket(int &actualSize) {
     if (disabledPort) {
         return;
     }
-    ShutDownUDPSocket();
-
     uint32_t packetSize = generalData->packetSize;
     if (generalData->detType == GOTTHARD2 && index != 0) {
         packetSize = generalData->vetoPacketSize;
     }
 
     try {
+        udpSocket = nullptr;
         udpSocket = make_unique<UdpRxSocket>(
             udpPortNumber, packetSize,
             (eth.length() ? InterfaceNameToIp(eth).str().c_str() : nullptr),

--- a/slsReceiverSoftware/src/Listener.cpp
+++ b/slsReceiverSoftware/src/Listener.cpp
@@ -340,18 +340,13 @@ uint32_t Listener::ListenToAnImage(sls_receiver_header &dstHeader,
     // never entering this loop)
     while (numpackets < pperFrame) {
         // listen to new packet
-        int rc = 0;
-        if (udpSocketAlive) {
-            rc = udpSocket->ReceiveDataOnly(&listeningPacket[0]);
-        }
-        // end of acquisition
-        if (rc <= 0) {
+        if (!udpSocketAlive || !udpSocket->ReceivePacket(&listeningPacket[0])) {
+            // end of acquisition
             if (numpackets == 0)
                 return 0;
             return HandleFuturePacket(true, numpackets, fnum, isHeaderEmpty,
                                       imageSize, dstHeader);
         }
-
         numPacketsCaught++;
         numPacketsStatistic++;
         GetPacketIndices(fnum, pnum, bnum, standardHeader,

--- a/slsSupportLib/include/sls/UdpRxSocket.h
+++ b/slsSupportLib/include/sls/UdpRxSocket.h
@@ -23,10 +23,6 @@ class UdpRxSocket {
     void setBufferSize(int size);
     ssize_t getPacketSize() const noexcept;
     void Shutdown();
-
-    // Only for backwards compatibility, this drops the EIGER small pkt, may be
-    // removed
-    ssize_t ReceiveDataOnly(char *dst) noexcept;
 };
 
 } // namespace sls

--- a/slsSupportLib/src/UdpRxSocket.cpp
+++ b/slsSupportLib/src/UdpRxSocket.cpp
@@ -18,13 +18,11 @@ namespace sls {
 UdpRxSocket::UdpRxSocket(int port, ssize_t packet_size, const char *hostname,
                          int kernel_buffer_size)
     : packet_size_(packet_size) {
-    struct addrinfo hints;
-    memset(&hints, 0, sizeof(hints));
+    struct addrinfo hints {};
     hints.ai_family = AF_UNSPEC;
     hints.ai_socktype = SOCK_DGRAM;
-    hints.ai_protocol = 0;
     hints.ai_flags = AI_PASSIVE | AI_ADDRCONFIG;
-    struct addrinfo *res = nullptr;
+    struct addrinfo *res{nullptr};
 
     const std::string portname = std::to_string(port);
     if (getaddrinfo(hostname, portname.c_str(), &hints, &res)) {
@@ -36,6 +34,7 @@ UdpRxSocket::UdpRxSocket(int port, ssize_t packet_size, const char *hostname,
         throw RuntimeError("Failed to create UDP RX socket");
     }
     if (bind(sockfd_, res->ai_addr, res->ai_addrlen) == -1) {
+        close(sockfd_);
         throw RuntimeError("Failed to bind UDP RX socket");
     }
     freeaddrinfo(res);
@@ -56,7 +55,13 @@ UdpRxSocket::UdpRxSocket(int port, ssize_t packet_size, const char *hostname,
     }
 }
 
-UdpRxSocket::~UdpRxSocket() { Shutdown(); }
+UdpRxSocket::~UdpRxSocket() {
+    Shutdown();
+    if (sockfd_ >= 0) {
+        close(sockfd_);
+        sockfd_ = -1;
+    }
+}
 ssize_t UdpRxSocket::getPacketSize() const noexcept { return packet_size_; }
 
 bool UdpRxSocket::ReceivePacket(char *dst) noexcept {
@@ -66,19 +71,7 @@ bool UdpRxSocket::ReceivePacket(char *dst) noexcept {
 }
 
 ssize_t UdpRxSocket::ReceiveDataOnly(char *dst) noexcept {
-    auto r = recvfrom(sockfd_, dst, packet_size_, 0, nullptr, nullptr);
-    constexpr ssize_t eiger_header_packet = 40; // only detector that has this
-    if (r == eiger_header_packet) {
-        LOG(logWARNING) << "Got header pkg";
-        r = recvfrom(sockfd_, dst, packet_size_, 0, nullptr, nullptr);
-    }
-    // temporary workaround for Eiger firmware (stop sends bad packets of size 8
-    // bytes)
-    if (r == 8) {
-        LOG(logWARNING) << "Ignoring bad packet of size 8 bytes";
-        r = recvfrom(sockfd_, dst, packet_size_, 0, nullptr, nullptr);
-    }
-    return r;
+    return recvfrom(sockfd_, dst, packet_size_, 0, nullptr, nullptr);
 }
 
 int UdpRxSocket::getBufferSize() const {
@@ -95,10 +88,7 @@ void UdpRxSocket::setBufferSize(int size) {
 }
 
 void UdpRxSocket::Shutdown() {
+    // not closing yet on purpose, but read gives -1
     shutdown(sockfd_, SHUT_RDWR);
-    if (sockfd_ >= 0) {
-        close(sockfd_);
-        sockfd_ = -1;
-    }
 }
 } // namespace sls

--- a/slsSupportLib/src/UdpRxSocket.cpp
+++ b/slsSupportLib/src/UdpRxSocket.cpp
@@ -67,11 +67,8 @@ ssize_t UdpRxSocket::getPacketSize() const noexcept { return packet_size_; }
 bool UdpRxSocket::ReceivePacket(char *dst) noexcept {
     auto bytes_received =
         recvfrom(sockfd_, dst, packet_size_, 0, nullptr, nullptr);
-    return bytes_received == packet_size_;
-}
 
-ssize_t UdpRxSocket::ReceiveDataOnly(char *dst) noexcept {
-    return recvfrom(sockfd_, dst, packet_size_, 0, nullptr, nullptr);
+    return bytes_received == packet_size_;
 }
 
 int UdpRxSocket::getBufferSize() const {

--- a/slsSupportLib/src/UdpRxSocket.cpp
+++ b/slsSupportLib/src/UdpRxSocket.cpp
@@ -57,11 +57,10 @@ UdpRxSocket::UdpRxSocket(int port, ssize_t packet_size, const char *hostname,
 
 UdpRxSocket::~UdpRxSocket() {
     Shutdown();
-    if (sockfd_ >= 0) {
-        close(sockfd_);
-        sockfd_ = -1;
-    }
+    close(sockfd_);
+    sockfd_ = -1;
 }
+
 ssize_t UdpRxSocket::getPacketSize() const noexcept { return packet_size_; }
 
 bool UdpRxSocket::ReceivePacket(char *dst) noexcept {


### PR DESCRIPTION
udp socket refactor from reuss: 
- closing socket before throwing for bind error in constructor
- closing socket at destructor and not at shutdown to allow other thread to read with a -1, so the object can still be accessed 
- setting unique ptr of udp socket obj to null to call its destructor (instead of calling shutdown earlier)
- check for size of packet for every detector
- remove obsolete checks for Eiger firmware packet size