### PR TITLE
Suppress -Wdeprecated-declarations for gcc

### DIFF
--- a/slsSupportLib/include/sls/ZmqSocket.h
+++ b/slsSupportLib/include/sls/ZmqSocket.h
@@ -14,7 +14,10 @@
 
 #include <map>
 #include <memory>
+#pragma GCC diagnostic push 
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #include <rapidjson/document.h> //json header in zmq stream
+#pragma GCC diagnostic pop
 #include <zmq.h>
 
 namespace sls {

--- a/slsSupportLib/include/sls/ZmqSocket.h
+++ b/slsSupportLib/include/sls/ZmqSocket.h
@@ -14,10 +14,15 @@
 
 #include <map>
 #include <memory>
+
+// Selective suppression of  warning in gcc, 
+// showed up in gcc 12 and at the moment
+// no upgrade is available to rapidjson 
 #pragma GCC diagnostic push 
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #include <rapidjson/document.h> //json header in zmq stream
 #pragma GCC diagnostic pop
+
 #include <zmq.h>
 
 namespace sls {


### PR DESCRIPTION
With gcc 12 we started to see warnings from rapidjson. Since it is out of our control and could obscure other error messaged  the idea is to suppress this warning in the rapidjson include for now. 