### PR TITLE
ctb gui: calibration: moench getGain: aoff not declared

### DIFF
--- a/slsDetectorCalibration/dataStructures/moench04CtbZmq10GbData.h
+++ b/slsDetectorCalibration/dataStructures/moench04CtbZmq10GbData.h
@@ -107,7 +107,7 @@ class moench04CtbZmq10GbData : public slsDetectorData<uint16_t> {
    
 
         int getGain(char *data, int x, int y) {
-            // int aoff=aSamples*2*32;
+            int aoff=aSamples*2*32;
             int irow;
             int isc = x / sc_width;
             int icol = x % sc_width;


### PR DESCRIPTION
fix compiler warning for ctb gui for moench getGain: aoff not declared