### PR TITLE
fixed hostname not split (+) in python

### DIFF
--- a/python/slsdet/detector.py
+++ b/python/slsdet/detector.py
@@ -780,7 +780,8 @@ class Detector(CppDetectorApi):
 
     @rx_hostname.setter
     def rx_hostname(self, hostname):
-        self.setRxHostname(hostname)
+        args = hostname_list(hostname)
+        self.setRxHostname(args)
 
     @property
     @element

--- a/python/slsdet/detector.py
+++ b/python/slsdet/detector.py
@@ -14,7 +14,7 @@ streamingInterface = slsDetectorDefs.streamingInterface
 defs = slsDetectorDefs
 
 from .utils import element_if_equal, all_equal, get_set_bits, list_to_bitmask
-from .utils import Geometry, to_geo, element, reduce_time, is_iterable
+from .utils import Geometry, to_geo, element, reduce_time, is_iterable, hostname_list
 from _slsdet import xy
 from . import utils as ut
 from .proxy import JsonProxy, SlowAdcProxy, ClkDivProxy, MaxPhaseProxy, ClkFreqProxy, PatLoopProxy, PatNLoopProxy, PatWaitProxy, PatWaitTimeProxy 
@@ -162,12 +162,8 @@ class Detector(CppDetectorApi):
 
     @hostname.setter
     def hostname(self, hostnames):
-        if isinstance(hostnames, str):
-            hostnames = [hostnames]
-        if isinstance(hostnames, list):
-            self.setHostname(hostnames)
-        else:
-            raise ValueError("hostname needs to be string or list of strings")
+        args = hostname_list(hostnames)
+        self.setHostname(args)
 
 
     @property

--- a/python/slsdet/utils.py
+++ b/python/slsdet/utils.py
@@ -261,3 +261,20 @@ def merge_args(*args):
 
     else:
         raise ValueError("Multiple dictionaries passes cannot merge args")
+
+
+def hostname_list(args):
+    """
+    Generates a list from a hostname string
+    * Lists are passed through
+    * as are tuples (conversion in pybind11 to vector)
+    * if + is found it splits the string
+    """
+    if isinstance(args, (list, tuple)):
+        return args
+    elif(isinstance(args, str)):
+        hosts = args.split('+')
+        hosts = [it for it in hosts if len(it)]
+        return hosts
+    else:
+        raise ValueError("hostname needs to be string or list of strings")

--- a/python/tests/test_utils.py
+++ b/python/tests/test_utils.py
@@ -342,3 +342,32 @@ def test_merge_args_tuple():
 
 def test_merge_args_dict_with_tuple():
     assert merge_args({0: (1,2)}, 3) == ({0: (1,2,3)},)
+
+
+def test_hostname_to_list():
+    s = "localhost"
+    r = hostname_list(s)
+    assert r == [s]
+
+def test_hostname_to_list_passthrough():
+    args = ["localhost"]
+    ret = hostname_list(args)
+    assert ret == args
+
+    args = ("localhost",)
+    ret = hostname_list(args)
+    assert ret == args
+
+def test_splitting_hostname():
+    args = 'apple+banana+pear+'
+    ret = hostname_list(args)
+    assert ret == ['apple', 'banana', 'pear']
+
+    #not sensitive to trailing +
+    args = 'apple+banana+pear'
+    ret = hostname_list(args)
+    assert ret == ['apple', 'banana', 'pear']
+
+def test_hostame_throws_on_wrong_args():
+    with pytest.raises(Exception) as e:
+        hostname_list(5)


### PR DESCRIPTION
Since we do the splitting from string to vector of string in the CmdProxy it got omitted from the python code. This PR adds a fix to the python API. 

The parsing function is also factored out to allow for unit testing. 