### PR TITLE
added missing equality operator for DurationWrapper in Python

### DIFF
--- a/python/src/duration.cpp
+++ b/python/src/duration.cpp
@@ -12,6 +12,7 @@ void init_duration(py::module &m) {
         .def("total_seconds", &DurationWrapper::total_seconds)
         .def("count", &DurationWrapper::count)
         .def("set_count", &DurationWrapper::set_count)
+        .def("__eq__", &DurationWrapper::operator==)
         .def("__repr__", [](const DurationWrapper &self) {
             std::stringstream ss;
             ss << "sls::DurationWrapper(total_seconds: " << self.total_seconds()

--- a/python/tests/test_utils.py
+++ b/python/tests/test_utils.py
@@ -8,7 +8,7 @@ Testing functions from utils.py
 
 import pytest
 from slsdet.utils import *
-from slsdet import IpAddr, MacAddr
+from slsdet import IpAddr, MacAddr, DurationWrapper
 import datetime as dt
 import pathlib
 from pathlib import Path
@@ -22,7 +22,11 @@ def test_iterable():
 
 
 def test_reduce_time_to_single_value_from_list():
-    t = 3 * [dt.timedelta(seconds=1)]
+    t = [dt.timedelta(seconds=1) for i in range(3)]
+    assert reduce_time(t) == 1
+
+def test_reduce_time_to_single_value_from_list_DurationWrapper():
+    t = [DurationWrapper(1) for i in range(3)]
     assert reduce_time(t) == 1
 
 
@@ -82,6 +86,12 @@ def test_all_equal_str():
 def test_all_equal_str_fails():
     assert all_equal('aaab') == False
 
+
+def test_all_equal_DurationWrapper():
+    assert all_equal([DurationWrapper(1), DurationWrapper(1)])
+
+def test_all_equal_DurationWrapper_fail():
+    assert not all_equal([DurationWrapper(1), DurationWrapper(2)])
 
 def test_element_if_equal_int():
     assert element_if_equal([5, 5]) == 5


### PR DESCRIPTION
This restores the behavior for Mythen3 exposure times. Meaning as long as all the exposure times are the same the python interface returns a single value. 

The regression happened when moving form the python datetime.timedelta to our sls::DurationWrapper. 