### PR TITLE
Jf zeromq display

### DIFF
--- a/slsDetectorCalibration/dataStructures/jungfrauModuleData.h
+++ b/slsDetectorCalibration/dataStructures/jungfrauModuleData.h
@@ -40,19 +40,30 @@ class jungfrauModuleData : public slsDetectorData<uint16_t> {
        out by a module i.e. using the slsReceiver (160x160 pixels, 40 packets
        1286 large etc.) \param c crosstalk parameter for the output buffer
 
-    */
+   */
+#ifndef ZMQ
+#define off sizeof(jf_header)
+#endif
+#ifdef ZMQ
+#define off 0
+#endif
+
+
     jungfrauModuleData()
         : slsDetectorData<uint16_t>(1024, 512,
-                                    1024* 512 * 2 + sizeof(jf_header)) {
-
+                                    1024* 512 * 2 + off) {
+  
         for (int ix = 0; ix < 1024; ix++) {
             for (int iy = 0; iy < 512; iy++) {
-                dataMap[iy][ix] = sizeof(jf_header) + (1024 * iy + ix) * 2;
+                dataMap[iy][ix] = off + (1024 * iy + ix) * 2;
 #ifdef HIGHZ
                 dataMask[iy][ix] = 0x3fff;
 #endif
             }
         }
+
+
+
 
         iframe = 0;
         //  cout << "data struct created" << endl;

--- a/slsDetectorCalibration/jungfrauExecutables/Makefile.rawdataprocess
+++ b/slsDetectorCalibration/jungfrauExecutables/Makefile.rawdataprocess
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: LGPL-3.0-or-other
+# Copyright (C) 2021 Contributors to the SLS Detector Package
+#module add CBFlib/0.9.5
+INCDIR=-I. -I../ -I../interpolations  -I../interpolations/etaVEL  -I../dataStructures  -I../../slsSupportLib/include/ -I../../slsReceiverSoftware/include/ -I../tiffio/include
+
+LDFLAG= ../tiffio/src/tiffIO.cpp -L/usr/lib64/ -lpthread -lm  -lstdc++   -pthread -lrt    -ltiff -O3  -std=c++11
+
+MAIN=jungfrauClusterFinder.cpp
+
+
+all: jungfrauRawDataProcess
+
+jungfrauRawDataProcess:  jungfrauRawDataProcess.cpp  $(INCS) clean
+			 g++ -o jungfrauRawDataProcess  jungfrauRawDataProcess.cpp $(LDFLAG) $(INCDIR) $(LIBHDF5) $(LIBRARYCBF) -DSAVE_ALL  -DMODULE
+
+jungfrauRawDataProcessStrx:  jungfrauRawDataProcess.cpp  $(INCS) clean
+			 g++ -o jungfrauRawDataProcessStrx  jungfrauRawDataProcess.cpp $(LDFLAG) $(INCDIR) $(LIBHDF5) $(LIBRARYCBF) -DSAVE_ALL -DJFSTRX 
+
+jungfrauRawDataProcessStrxAldo:  jungfrauRawDataProcess.cpp  $(INCS) clean
+			 g++ -o jungfrauRawDataProcessStrxAldo  jungfrauRawDataProcess.cpp $(LDFLAG) $(INCDIR) $(LIBHDF5) $(LIBRARYCBF) -DSAVE_ALL -DJFSTRX -DALDO
+
+jungfrauRawDataProcessStrxOld:  jungfrauRawDataProcess.cpp  $(INCS) clean
+			 g++ -o jungfrauRawDataProcessStrxOld  jungfrauRawDataProcess.cpp $(LDFLAG) $(INCDIR) $(LIBHDF5) $(LIBRARYCBF) -DSAVE_ALL -DJFSTRXOLD 
+
+jungfrauRawDataProcessStrxOldAldo:  jungfrauRawDataProcess.cpp  $(INCS) clean
+			 g++ -o jungfrauRawDataProcessStrxOldAldo  jungfrauRawDataProcess.cpp $(LDFLAG) $(INCDIR) $(LIBHDF5) $(LIBRARYCBF) -DSAVE_ALL -DJFSTRXOLD -DALDO
+
+
+
+jungfrauClusterFinder:  jungfrauClusterFinder.cpp  $(INCS) clean
+			 g++ -o jungfrauClusterFinder  jungfrauClusterFinder.cpp $(LDFLAG) $(INCDIR) $(LIBHDF5) $(LIBRARYCBF) -DSAVE_ALL  
+
+
+jungfrauClusterFinderHighZ:  jungfrauClusterFinder.cpp  $(INCS) clean
+			 g++ -o jungfrauClusterFinderHighZ  jungfrauClusterFinder.cpp $(LDFLAG) $(INCDIR) $(LIBHDF5) $(LIBRARYCBF) -DSAVE_ALL  -DHIGHZ 
+
+
+
+
+jungfrauMakeEta:  jungfrauInterpolation.cpp  $(INCS) clean
+			 g++ -o jungfrauMakeEta jungfrauInterpolation.cpp    $(LDFLAG) $(INCDIR) $(LIBHDF5) $(LIBRARYCBF) -DFF
+
+jungfrauInterpolation:  jungfrauInterpolation.cpp  $(INCS) clean
+			 g++ -o jungfrauInterpolation jungfrauInterpolation.cpp    $(LDFLAG) $(INCDIR) $(LIBHDF5) $(LIBRARYCBF)  
+
+jungfrauNoInterpolation:  jungfrauNoInterpolation.cpp  $(INCS) clean
+			 g++ -o jungfrauNoInterpolation jungfrauNoInterpolation.cpp    $(LDFLAG) $(INCDIR) $(LIBHDF5) $(LIBRARYCBF) 
+
+jungfrauPhotonCounter: jungfrauPhotonCounter.cpp   $(INCS) clean
+			 g++ -o jungfrauPhotonCounter  jungfrauPhotonCounter.cpp  $(LDFLAG) $(INCDIR) $(LIBHDF5) $(LIBRARYCBF)  -DNEWRECEIVER
+
+jungfrauAnalog: jungfrauPhotonCounter.cpp  $(INCS) clean
+			 g++ -o jungfrauAnalog  jungfrauPhotonCounter.cpp  $(LDFLAG) $(INCDIR) $(LIBHDF5) $(LIBRARYCBF)  -DNEWRECEIVER -DANALOG
+
+jungfrauPhotonCounterHighZ: jungfrauPhotonCounter.cpp   $(INCS) clean
+			 g++ -o jungfrauPhotonCounterHighZ  jungfrauPhotonCounter.cpp  $(LDFLAG) $(INCDIR) $(LIBHDF5) $(LIBRARYCBF)  -DNEWRECEIVER -DHIGHZ
+
+jungfrauAnalogHighZ: jungfrauPhotonCounter.cpp  $(INCS) clean
+			 g++ -o jungfrauAnalogHighZ  jungfrauPhotonCounter.cpp  $(LDFLAG) $(INCDIR) $(LIBHDF5) $(LIBRARYCBF)  -DNEWRECEIVER -DANALOG -DHIGHZ
+
+clean: 	
+	rm -f  jungfrauClusterFinder jungfrauMakeEta jungfrauInterpolation jungfrauNoInterpolation jungfrauPhotonCounter jungfrauAnalog
+
+

--- a/slsDetectorCalibration/jungfrauExecutables/Makefile.zmq
+++ b/slsDetectorCalibration/jungfrauExecutables/Makefile.zmq
@@ -1,25 +1,19 @@
 # SPDX-License-Identifier: LGPL-3.0-or-other
 # Copyright (C) 2021 Contributors to the SLS Detector Package
 
-INCDIR=   -I. -I../dataStructures ../tiffIO.cpp -I../ -I../interpolations/ -I../../slsSupportLib/include/ -I../../slsReceiverSoftware/include/ -I../../libs/rapidjson/
+INCDIR=   -I. -I../dataStructures ../tiffio/src/tiffIO.cpp -I../ -I../interpolations/ -I../../slsSupportLib/include/ -I../../slsReceiverSoftware/include/ -I../../libs/rapidjson/ -I../tiffio/include
 LDFLAG= -L/usr/lib64/ -lpthread -lm  -lstdc++  -lzmq -pthread -lrt -ltiff   -O3  -std=c++11 -Wall -L../../build/bin/ -lSlsSupport
 #-L../../bin -lhdf5  -L.
 
 #DESTDIR?=../bin
 
-all:  moenchZmqProcess moenchZmq04Process
- #moenchZmqProcessCtbGui
+all:  jungfrauZmqProcess 
+ #jungfrauZmqProcessCtbGui
 
-moenchZmqProcess:  moenchZmqProcess.cpp   clean
-		      g++ -o moenchZmqProcess  moenchZmqProcess.cpp  $(LDFLAG) $(INCDIR) $(LIBHDF5) $(LIBRARYCBF)  -DNEWZMQ -DINTERP 
-
-moenchZmq04Process:  moenchZmqProcess.cpp   clean
-		      g++ -o moench04ZmqProcess  moenchZmqProcess.cpp  $(LDFLAG) $(INCDIR) $(LIBHDF5) $(LIBRARYCBF)  -DNEWZMQ -DINTERP -DMOENCH04 
-
-#moenchZmqProcessCtbGui:  moenchZmqProcess.cpp   clean
-#		      g++ -o moenchZmqProcessCtbGui  moenchZmqProcess.cpp  $(LDFLAG) $(INCDIR) $(LIBHDF5) $(LIBRARYCBF)  -DNEWZMQ -DINTERP -DCTBGUI
+jungfrauZmqProcess:  jungfrauZmqProcess.cpp   clean
+		      g++ -o jungfrauZmqProcess  jungfrauZmqProcess.cpp  $(LDFLAG) $(INCDIR) $(LIBHDF5) $(LIBRARYCBF)  -DNEWZMQ -DINTERP
 
 clean: 	
-	rm -f  moenchZmqProcess  
+	rm -f   jungfrauZmqProcess  
 
 

--- a/slsDetectorCalibration/jungfrauExecutables/Makefile.zmqrootdisp
+++ b/slsDetectorCalibration/jungfrauExecutables/Makefile.zmqrootdisp
@@ -1,0 +1,26 @@
+ROOTSYS=/opt/cern/v6/root
+#/afs/psi.ch/project/sls_det_sof/roottware/root_v5.34.23_sl6_64bit
+
+
+
+LIBZMQDIR = $(PWD)
+LIBZMQ =  -L$(LIBZMQDIR) -lzmq
+SHLIB_PATH=/opt/cern/v6/root/lib
+CMAKE_PREFIX_PATH=/opt/cern/v6/root
+DYLD_LIBRARY_PATH=/opt/cern/v6/root/lib
+
+
+INCDIR=   -I. -I../dataStructures ../tiffio/src/tiffIO.cpp -I../ -I../interpolations/ -I../../slsSupportLib/include/ -I../../slsReceiverSoftware/include/ -I../../libs/rapidjson/ -I../tiffio/include
+LDFLAG= -L/usr/lib64/ -lpthread -lm  -lstdc++  -lzmq -pthread -lrt -ltiff   -O3  -std=c++11 -Wall -L../../build/bin/ -lSlsSupport
+#-L../../bin -lhdf5  -L.
+
+
+
+default: onlinedisp_zmq
+
+onlinedisp_zmq: onlinedisp_zmq.cpp onlinedisp_zmq.h 
+# flags from root-config --cflags --glibs
+	g++ -o onlinedisp_zmq onlinedisp_zmq.cpp  -I. -I$(ROOTSYS)/include -Wall -g -lm  -L. -lzmq -pthread -lrt -L$(ROOTSYS)/lib -lGui -lCore  -lRIO -lNet -lHist -lGraf -lGraf3d -lGpad -lTree -lRint -lPostscript -lMatrix  -lPhysics -lMathCore -lThread -m64 $(LDFLAG) $(INCDIR) $(LIBHDF5) $(LIBRARYCBF) 
+
+#-lCint
+

--- a/slsDetectorCalibration/jungfrauExecutables/examples.txt
+++ b/slsDetectorCalibration/jungfrauExecutables/examples.txt
@@ -1,0 +1,10 @@
+
+
+ sls_detector_put rx_jsonpara detectorMode counting 
+ sls_detector_put rx_jsonpara frameMode newPedestal 
+ sls_detector_put rx_jsonpara frameMode frame 
+ sls_detector_put rx_jsonpara detectorMode analog 
+ sls_detector_put rx_jsonpara threshold 150
+ sls_detector_put rx_jsonpara threshold 0
+ sls_detector_put rx_jsonpara threshold 300
+ sls_detector_put rx_zmqhwm 50

--- a/slsDetectorCalibration/jungfrauExecutables/jungfrauRawDataProcess.cpp
+++ b/slsDetectorCalibration/jungfrauExecutables/jungfrauRawDataProcess.cpp
@@ -1,0 +1,418 @@
+// SPDX-License-Identifier: LGPL-3.0-or-other
+// Copyright (C) 2021 Contributors to the SLS Detector Package
+//#include "sls/ansi.h"
+#include <iostream>
+#undef CORR
+
+#define C_GHOST 0.0004
+
+#define CM_ROWS 50
+
+#define RAWDATA
+
+#ifndef JFSTRX
+#ifndef JFSTRXOLD
+#ifndef MODULE
+#include "jungfrauHighZSingleChipData.h"
+#endif
+#ifdef MODULE
+#include "jungfrauModuleData.h"
+#endif
+#endif
+#endif
+#ifdef JFSTRX
+#include "jungfrauLGADStrixelsData.h"
+#endif
+#ifdef JFSTRXOLD
+#include "jungfrauStrixelsHalfModuleOldDesign.h"
+#endif
+
+#include "multiThreadedCountingDetector.h"
+#include "singlePhotonDetector.h"
+
+#include <fstream>
+#include <map>
+#include <stdio.h>
+#include <sys/stat.h>
+
+#include <ctime>
+using namespace std;
+
+int main(int argc, char *argv[]) {
+
+    if (argc < 5) {
+        cout << "Usage is " << argv[0]
+             << "indir outdir fname(no extension) fextension [runmin] [runmax] [pedfile (raw or tiff)] [threshold] "
+                "[nframes] [xmin xmax ymin ymax] [gainmap]"
+             << endl;
+        cout << "threshold <0 means analog; threshold=0 means cluster finder; "
+                "threshold>0 means photon counting"
+             << endl;
+        cout << "nframes <0 means sum everything; nframes=0 means one file per "
+                "run; nframes>0 means one file every nframes"
+             << endl;
+        return 1;
+    }
+
+    int fifosize = 1000;
+    int nthreads = 10;
+    int csize = 3;
+    int nsigma = 5;
+    int nped = 10000;
+
+    int cf = 0;
+
+
+#ifndef JFSTRX
+#ifndef JFSTRXOLD
+#ifndef MODULE
+    jungfrauHighZSingleChipData *decoder = new jungfrauHighZSingleChipData();
+    int nx = 256, ny = 256;
+#endif
+#ifdef MODULE
+    jungfrauModuleData *decoder = new jungfrauModuleData();
+    int nx = 1024, ny = 512;
+
+#endif
+#endif
+#endif
+#ifdef JFSTRX
+    cout << "bbb" << endl;
+    jungfrauLGADStrixelsData *decoder = new jungfrauLGADStrixelsData();
+    int nx = 1024/5, ny = 512*5;
+#endif
+#ifdef JFSTRXOLD
+    cout << "ccc" << endl;
+    jungfrauStrixelsHalfModuleOldDesign *decoder = new jungfrauStrixelsHalfModuleOldDesign();
+    int nx = 1024*3, ny = 512/3;
+#endif
+
+
+    decoder->getDetectorSize(nx, ny);
+
+
+
+
+
+    cout << "Detector size is " << nx << " " << ny << endl;
+
+
+
+
+
+
+
+
+    double *gainmap = NULL;
+    //float *gm;
+
+    int ff, np;
+    // cout << " data size is " << dsize;
+
+    ifstream filebin;
+    char *indir = argv[1];
+    char *outdir = argv[2];
+    char *fformat = argv[3];
+    char *fext = argv[4];
+    int runmin = 0;
+
+    // cout << "argc is " << argc << endl;
+    if (argc >= 6) {
+        runmin = atoi(argv[5]);
+    }
+
+    int runmax = runmin;
+
+    if (argc >= 7) {
+        runmax = atoi(argv[6]);
+    }
+
+    char *pedfile = NULL;
+    if (argc >= 8) {
+        pedfile = argv[7];
+    }
+    double thr = 0;
+    double thr1 = 1;
+
+    if (argc >= 9) {
+        thr = atof(argv[8]);
+    }
+
+    int nframes = 0;
+
+    if (argc >= 10) {
+        nframes = atoi(argv[9]);
+    }
+
+    int xmin = 0, xmax = nx, ymin = 0, ymax = ny;
+    if (argc >= 14) {
+        xmin = atoi(argv[10]);
+        xmax = atoi(argv[11]);
+        ymin = atoi(argv[12]);
+        ymax = atoi(argv[13]);
+    }
+
+    char *gainfname = NULL;
+    if (argc > 14) {
+        gainfname = argv[14];
+        cout << "Gain map file name is: " << gainfname << endl;
+    }
+
+    char ffname[10000];
+    char fname[10000];
+    char imgfname[10000];
+    char cfname[10000];
+
+    std::time_t end_time;
+
+    FILE *of = NULL;
+    cout << "input directory is " << indir << endl;
+    cout << "output directory is " << outdir << endl;
+    cout << "input file is " << fformat << endl;
+    cout << "runmin is " << runmin << endl;
+    cout << "runmax is " << runmax << endl;
+    if (pedfile)
+        cout << "pedestal file is " << pedfile << endl;
+    if (thr > 0)
+        cout << "threshold is " << thr << endl;
+    cout << "Nframes is " << nframes << endl;
+
+    uint32_t nnx, nny;
+
+    singlePhotonDetector *filter = new singlePhotonDetector(
+        decoder, csize, nsigma, 1, NULL, nped, 200, -1, -1, gainmap, NULL);
+
+    if (gainfname) {
+
+        if (filter->readGainMap(gainfname))
+            cout << "using gain map " << gainfname << endl;
+        else
+            cout << "Could not open gain map " << gainfname << endl;
+    } else
+        thr = 0.15 * thr;
+    filter->newDataSet();
+    //int dsize = decoder->getDataSize();
+
+    if (thr > 0) {
+        cout << "threshold is " << thr << endl;
+        filter->setThreshold(thr);
+        cf = 0;
+
+    } else
+        cf = 1;
+
+    filter->setROI(xmin, xmax, ymin, ymax);
+    std::time(&end_time);
+    cout << std::ctime(&end_time) << endl;
+
+    char *buff;
+
+    // multiThreadedAnalogDetector *mt=new
+    // multiThreadedAnalogDetector(filter,nthreads,fifosize);
+    multiThreadedCountingDetector *mt =
+        new multiThreadedCountingDetector(filter, nthreads, fifosize);
+#ifndef ANALOG
+    mt->setDetectorMode(ePhotonCounting);
+    cout << "Counting!" << endl;
+    if (thr > 0) {
+        cf = 0;
+    }
+#endif
+//{
+#ifdef ANALOG
+    mt->setDetectorMode(eAnalog);
+    cout << "Analog!" << endl;
+    cf = 0;
+    // thr1=thr;
+#endif
+    //  }
+
+    mt->StartThreads();
+    mt->popFree(buff);
+
+    //  cout << "mt " << endl;
+
+    int ifr = 0;
+
+    char froot[1000];
+    double *ped=new double[nx * ny];//, *ped1;
+
+    int pos,pos1;
+
+    if (pedfile) {
+
+      if (string(pedfile).find(".dat") != std::string::npos) {
+	pos1=string(pedfile).rfind("/");
+	strcpy(froot,pedfile+pos1);
+	pos=string(froot).find(".dat");
+	froot[pos]='\0';
+      }
+
+        cout << "PEDESTAL " << endl;
+	// sprintf(imgfname, "%s/pedestals.tiff", outdir);
+
+        if (string(pedfile).find(".tif") == std::string::npos) {
+            sprintf(fname, "%s", pedfile);
+            cout << fname << endl;
+            std::time(&end_time);
+            //cout << "aaa" << std::ctime(&end_time) << endl;
+
+            mt->setFrameMode(ePedestal);
+            // sprintf(fn,fformat,irun);
+            filebin.open((const char *)(fname), ios::in | ios::binary);
+            //      //open file
+            if (filebin.is_open()) {
+                ff = -1;
+                while (decoder->readNextFrame(filebin, ff, np, buff)) {
+		  // if (np == 40) {
+		  if ((ifr+1) % 100 == 0) {
+		    cout << " ****" << decoder->getValue(buff,20,20);// << endl;
+		  }
+                        mt->pushData(buff);
+                        mt->nextThread();
+                        mt->popFree(buff);
+                        ifr++;
+                        if (ifr % 100 == 0) {
+			  cout << " ****" << ifr << " " << ff << " " << np << endl;
+			} //else
+                        //cout << ifr << " " << ff << " " << np << endl;
+			if (ifr>=1000)
+			  break;
+                    ff = -1;
+                }
+                filebin.close();
+                while (mt->isBusy()) {
+                    ;
+                }
+
+		sprintf(imgfname, "%s/%s_ped.tiff", outdir, froot);
+		mt->writePedestal(imgfname);
+		sprintf(imgfname, "%s/%s_rms.tiff", outdir, froot);
+		mt->writePedestalRMS(imgfname);
+
+            } else
+                cout << "Could not open pedestal file " << fname
+                     << " for reading " << endl;
+        } else {
+            float *pp = ReadFromTiff(pedfile, nny, nnx);
+            if (pp && (int)nnx == nx && (int)nny == ny) {
+                for (int i = 0; i < nx * ny; i++) {
+                    ped[i] = pp[i];
+                }
+                delete[] pp;
+                mt->setPedestal(ped);
+                cout << "Pedestal set from tiff file " << pedfile << endl;
+            } else {
+                cout << "Could not open pedestal tiff file " << pedfile
+                     << " for reading " << endl;
+            }
+        }
+        std::time(&end_time);
+        cout << std::ctime(&end_time) << endl;
+    }
+
+    ifr = 0;
+    int ifile = 0;
+
+    mt->setFrameMode(eFrame);
+
+    for (int irun = runmin; irun <= runmax; irun++) {
+        cout << "DATA ";
+        // sprintf(fn,fformat,irun);
+        sprintf(ffname, "%s/%s.%s", indir, fformat, fext);
+        sprintf(fname, (const char*)ffname, irun);
+        sprintf(ffname, "%s/%s.tiff", outdir, fformat);
+        sprintf(imgfname, (const char*)ffname, irun);
+        sprintf(ffname, "%s/%s.clust", outdir, fformat);
+        sprintf(cfname, (const char*)ffname, irun);
+        cout << fname << " ";
+        cout << imgfname << endl;
+        std::time(&end_time);
+        cout << std::ctime(&end_time) << endl;
+        //  cout <<  fname << " " << outfname << " " << imgfname <<  endl;
+        filebin.open((const char *)(fname), ios::in | ios::binary);
+        //      //open file
+        ifile = 0;
+        if (filebin.is_open()) {
+            if (thr <= 0 && cf != 0) { // cluster finder
+                if (of == NULL) {
+                    of = fopen(cfname, "w");
+                    if (of) {
+                        mt->setFilePointer(of);
+                        cout << "file pointer set " << endl;
+                    } else {
+                        cout << "Could not open " << cfname << " for writing "
+                             << endl;
+                        mt->setFilePointer(NULL);
+                        return 1;
+                    }
+                }
+            }
+            //     //while read frame
+            ff = -1;
+            ifr = 0;
+            while (decoder->readNextFrame(filebin, ff, np, buff)) {
+              //  if (np == 40) {
+                    //         //push
+	      
+		  if ((ifr+1) % 100 == 0) {
+		    cout << " ****" << decoder->getValue(buff,20,20);// << endl;
+		  }
+                    mt->pushData(buff);
+                    // 	//         //pop
+                    mt->nextThread();
+                    mt->popFree(buff);
+
+                    ifr++;
+                    if (ifr % 100 == 0)
+		      cout << " " << ifr << " " << ff << endl;
+                    if (nframes > 0) {
+                        if (ifr % nframes == 0) {
+                            sprintf(ffname, "%s/%s_f%05d.tiff", outdir, fformat,
+                                    ifile);
+                            sprintf(imgfname, (const char*)ffname, irun);
+                            mt->writeImage(imgfname, thr1);
+                            mt->clearImage();
+                            ifile++;
+                        }
+                    }
+                // } else
+                //     cout << ifr << " " << ff << " " << np << endl;
+                ff = -1;
+            }
+            cout << "--" << endl;
+            filebin.close();
+            while (mt->isBusy()) {
+                ;
+            }
+            if (nframes >= 0) {
+                if (nframes > 0) {
+                    sprintf(ffname, "%s/%s_f%05d.tiff", outdir, fformat, ifile);
+                    sprintf(imgfname, (const char*)ffname, irun);
+                } else {
+                    sprintf(ffname, "%s/%s.tiff", outdir, fformat);
+                    sprintf(imgfname, (const char*)ffname, irun);
+                }
+                cout << "Writing tiff to " << imgfname << " " << thr1 << endl;
+                mt->writeImage(imgfname, thr1);
+                mt->clearImage();
+                if (of) {
+                    fclose(of);
+                    of = NULL;
+                    mt->setFilePointer(NULL);
+                }
+            }
+            std::time(&end_time);
+            cout << std::ctime(&end_time) << endl;
+        } else
+            cout << "Could not open " << fname << " for reading " << endl;
+    }
+    if (nframes < 0) {
+        sprintf(ffname, "%s/%s.tiff", outdir, fformat);
+        strcpy(imgfname, ffname);
+        cout << "Writing tiff to " << imgfname << " " << thr1 << endl;
+        mt->writeImage(imgfname, thr1);
+    }
+
+    return 0;
+}

--- a/slsDetectorCalibration/jungfrauExecutables/jungfrauZmqProcess.cpp
+++ b/slsDetectorCalibration/jungfrauExecutables/jungfrauZmqProcess.cpp
@@ -1,28 +1,26 @@
 // SPDX-License-Identifier: LGPL-3.0-or-other
 // Copyright (C) 2021 Contributors to the SLS Detector Package
 //#define WRITE_QUAD
-#define DEVELOPER
+//#define DEVELOPER
 #undef CORR
+//#undef MOENCH04
+
 #define C_GHOST 0.0004
 
 #define CM_ROWS 20
 
+#define ZMQ
 #include "sls/ZmqSocket.h"
 #include "sls/sls_detector_defs.h"
-#ifndef RECT
-#ifndef MOENCH04
-#include "moench03T1ZmqDataNew.h"
-#endif
-#ifdef MOENCH04
-#include "moench04CtbZmq10GbData.h"
-#endif
 
-#endif
-#ifdef RECT
-#include "moench03T1ZmqDataNewRect.h"
-#endif
+//#include "moench03T1ZmqDataNew.h"
+
+#include "jungfrauModuleData.h"
+
+
 #include "moench03CommonMode.h"
 #include "moench03GhostSummation.h"
+
 #include "sls/tiffIO.h"
 #include <fstream>
 #include <iomanip>
@@ -57,983 +55,852 @@ using namespace std::chrono;
 //\"what\":\"nothing\" ");
 
 int main(int argc, char *argv[]) {
-    /**
-     * trial.o [socket ip] [starting port number] [send_socket ip] [send port
-     * number]
-     *
-     */
-    FILE *of = NULL;
-    int fifosize = 5000;
-    int etabins = 1000, etabinsy = 1000; // nsubpix*2*100;
-    double etamin = -1, etamax = 2;
-    int nSubPixelsX = 2;
-    //	int emin, emax;
-    int nSubPixelsY = 2;
-    // help
-    if (argc < 3) {
-        cprintf(RED, "Help: ./trial [receive socket ip] [receive starting port "
-                     "number] [send_socket ip] [send starting port number] "
-                     "[nthreads] [nsubpix] [gainmap]  [etafile]\n");
-        return EXIT_FAILURE;
-    }
+  /**
+   * trial.o [socket ip] [starting port number] [send_socket ip] [send port
+   * number]
+   *
+   */
+  FILE *of = NULL;
+  int fifosize = 500;
+  int etabins = 1000, etabinsy = 1000; // nsubpix*2*100;
+  double etamin = -1, etamax = 2;
+  int nSubPixelsX = 2;
+  int emin, emax;
+  int nSubPixelsY = 2;
 
-    // receive parameters
-    bool send = false;
-    char *socketip = argv[1];
-    uint32_t portnum = atoi(argv[2]);
-    // send parameters if any
-    char *socketip2 = 0;
-    uint32_t portnum2 = 0;
+  // help
+  if (argc < 3) {
+    cprintf(RED, "Help: ./trial [receive socket ip] [receive starting port "
+	    "number] [send_socket ip] [send starting port number] "
+	    "[nthreads] [nsubpix] [gainmap]  [etafile]\n");
+    return EXIT_FAILURE;
+  }
 
-    zmqHeader zHeader, outHeader;
-    zHeader.jsonversion = SLS_DETECTOR_JSON_HEADER_VERSION;
-    outHeader.jsonversion = SLS_DETECTOR_JSON_HEADER_VERSION;
+  // receive parameters
+  bool send = false;
+  char *socketip = argv[1];
+  uint32_t portnum = atoi(argv[2]);
+  // send parameters if any
+  char *socketip2 = 0;
+  uint32_t portnum2 = 0;
 
-    uint32_t nSigma = 5;
+  sls::zmqHeader zHeader, outHeader;
+  zHeader.jsonversion = SLS_DETECTOR_JSON_HEADER_VERSION;
+  outHeader.jsonversion = SLS_DETECTOR_JSON_HEADER_VERSION;
 
-    int ok;
+  uint32_t nSigma = 5;
 
-    high_resolution_clock::time_point t1;
-    high_resolution_clock::time_point t2;
-    std::chrono::steady_clock::time_point begin, end, finished;
-    // time_t begin,end,finished;
-    int rms = 0;
+  int ok;
 
-    if (argc > 4) {
-        socketip2 = argv[3];
-        portnum2 = atoi(argv[4]);
-        if (portnum2 > 0)
-            send = true;
-    }
-    cout << "\nrx socket ip : " << socketip << "\nrx port num  : " << portnum;
-    if (send) {
-        cout << "\ntx socket ip : " << socketip2
-             << "\ntx port num  : " << portnum2;
-    }
-    int nthreads = 5;
-    if (argc > 5)
-        nthreads = atoi(argv[5]);
+  high_resolution_clock::time_point t1;
+  high_resolution_clock::time_point t2;
+  std::chrono::steady_clock::time_point begin, end, finished;
+  // time_t begin,end,finished;
+  int rms = 0;
 
-    cout << "Number of threads is: " << nthreads << endl;
-    if (argc > 6) {
-        nSubPixelsX = atoi(argv[6]);
-        nSubPixelsY = nSubPixelsX;
+  if (argc > 4) {
+    socketip2 = argv[3];
+    portnum2 = atoi(argv[4]);
+    if (portnum2 > 0)
+      send = true;
+  }
+  cout << "\nrx socket ip : " << socketip << "\nrx port num  : " << portnum;
+  if (send) {
+    cout << "\ntx socket ip : " << socketip2
+	 << "\ntx port num  : " << portnum2;
+  }
+  int nthreads = 4;
+  if (argc > 5)
+    nthreads = atoi(argv[5]);
+  cout << "Number of threads is: " << nthreads << endl;
+   
+  if (argc > 6) {
+    nSubPixelsX = atoi(argv[6]);
+    nSubPixelsY = nSubPixelsX;
 #ifdef RECT
-        nSubPixelsX = 2;
+    nSubPixelsX = 2;
 #endif
-    }
-    cout << "Number of subpixels is: " << nSubPixelsX << " " << nSubPixelsY
-         << endl;
+  }
+  cout << "Number of subpixels is: " << nSubPixelsX << " " << nSubPixelsY
+       << endl;
 
-    char *gainfname = NULL;
-    if (argc > 7) {
-        gainfname = argv[7];
-        cout << "Gain map file name is: " << gainfname << endl;
-    }
+  char *gainfname = NULL;
+  if (argc > 7) {
+    gainfname = argv[7];
+    cout << "Gain map file name is: " << gainfname << endl;
+  }
 
-    char *etafname = NULL;
-    if (argc > 8) {
-        etafname = argv[8];
-        cout << "Eta file name is: " << etafname << endl;
-    }
+  char *etafname = NULL;
+  if (argc > 8) {
+    etafname = argv[8];
+    cout << "Eta file name is: " << etafname << endl;
+  }
 
-    // slsDetectorData *det=new moench03T1ZmqDataNew();
-#ifndef MOENCH04
-    moench03T1ZmqDataNew *det = new moench03T1ZmqDataNew();
-#endif
-#ifdef MOENCH04
-    moench04CtbZmq10GbData *det = new moench04CtbZmq10GbData();
-#endif
-    cout << endl << " det" << endl;
-    int npx, npy;
-    det->getDetectorSize(npx, npy);
+  // slsDetectorData *det=new moench03T1ZmqDataNew();
 
-    int send_something = 0;
 
-    int maxSize = npx * npy * 2; // 32*2*8192;//5000;//atoi(argv[3]);
-    int size = maxSize;          // 32*2*5000;
-    // int multisize=size;
-    // int dataSize=size;
 
-    char dummybuff[size];
+  jungfrauModuleData *det = new jungfrauModuleData();
+  cout << endl << " det" << endl;
+  int npx, npy;
+  det->getDetectorSize(npx, npy);
 
-    moench03CommonMode *cm = NULL;
-    moench03GhostSummation *gs = NULL;
+  int send_something = 0;
+
+  int maxSize = npx * npy * 2; // 32*2*8192;//5000;//atoi(argv[3]);
+  int size = maxSize+sizeof(int);          // 32*2*5000;
+  // int multisize=size;
+  // int dataSize=size;
+
+  char *dummybuff = new char[size];
+
+  moench03CommonMode *cm = NULL;
+  moench03GhostSummation *gs = NULL;
 #ifdef CORR
 
-    // int ncol_cm=CM_ROWS;
-    // double xt_ghost=C_GHOST;
+  // int ncol_cm=CM_ROWS;
+  // double xt_ghost=C_GHOST;
 
-    cm = new moench03CommonMode(CM_ROWS);
-    gs = new moench03GhostSummation(det, C_GHOST);
+  cm = new moench03CommonMode(CM_ROWS);
+  gs = new moench03GhostSummation(det, C_GHOST);
 #endif
-    double *gainmap = NULL;
-    float *gm;
-    double *gmap = NULL;
+  double *gainmap = NULL;
+  float *gm;
+  double *gmap = NULL;
 
-    uint32_t nnnx, nnny;
-    if (gainfname) {
-        gm = ReadFromTiff(gainfname, nnny, nnnx);
-        if (gm && nnnx == (uint)npx && nnny == (uint)npy) {
-            gmap = new double[npx * npy];
-            for (int i = 0; i < npx * npy; i++) {
-                gmap[i] = gm[i];
-            }
-            delete[] gm;
-        } else
-            cout << "Could not open gain map " << gainfname << endl;
-    }
+  uint32_t nnnx, nnny;
+  if (gainfname) {
+    gm = ReadFromTiff(gainfname, nnny, nnnx);
+    if (gm && nnnx == (uint)npx && nnny == (uint)npy) {
+      gmap = new double[npx * npy];
+      for (int i = 0; i < npx * npy; i++) {
+	gmap[i] = gm[i];
+      }
+      delete[] gm;
+    } else
+      cout << "Could not open gain map " << gainfname << endl;
+  }
 
-    // analogDetector<uint16_t> *filter=new
-    // analogDetector<uint16_t>(det,1,NULL,1000);
+  // analogDetector<uint16_t> *filter=new
+  // analogDetector<uint16_t>(det,1,NULL,1000);
 #ifndef INTERP
-    singlePhotonDetector *filter = new singlePhotonDetector(
-        det, 3, nSigma, 1, cm, 1000, 100, -1, -1, gainmap, gs);
+  singlePhotonDetector *filter = new singlePhotonDetector(
+							  det, 3, nSigma, 1, cm, 1000, 0, -1, -1, gainmap, gs);
 
-    multiThreadedCountingDetector *mt =
-        new multiThreadedCountingDetector(filter, nthreads, fifosize);
+  multiThreadedCountingDetector *mt =
+    new multiThreadedCountingDetector(filter, nthreads, fifosize);
 
-    // multiThreadedAnalogDetector *mt=new
-    // multiThreadedAnalogDetector(filter,nthreads,fifosize);
+  // multiThreadedAnalogDetector *mt=new
+  // multiThreadedAnalogDetector(filter,nthreads,fifosize);
 #endif
 #ifdef INTERP
-    eta2InterpolationPosXY *interp = new eta2InterpolationPosXY(
-        npx, npy, nSubPixelsX, nSubPixelsY, etabins, etabinsy, etamin, etamax);
+  eta2InterpolationPosXY *interp = new eta2InterpolationPosXY(
+							      npx, npy, nSubPixelsX, nSubPixelsY, etabins, etabinsy, etamin, etamax);
 
-    if (etafname)
-        interp->readFlatField(etafname);
+  if (etafname)
+    interp->readFlatField(etafname);
 
-    interpolatingDetector *filter = new interpolatingDetector(
-        det, interp, nSigma, 1, cm, 1000, 10, -1, -1, gainmap, gs);
-    multiThreadedInterpolatingDetector *mt =
-        new multiThreadedInterpolatingDetector(filter, nthreads, fifosize);
+  interpolatingDetector *filter = new interpolatingDetector(
+							    det, interp, nSigma, 1, cm, 1000, 10, -1, -1, gainmap, gs);
+  multiThreadedInterpolatingDetector *mt =
+    new multiThreadedInterpolatingDetector(filter, nthreads, fifosize);
 #endif
 
-    char *buff;
-    mt->setFrameMode(eFrame);
-    mt->StartThreads();
-    mt->popFree(buff);
+  char *buff;
+  mt->setFrameMode(eFrame);
+  mt->StartThreads();
+  mt->popFree(buff);
 
-    ZmqSocket *zmqsocket = NULL;
+  sls::ZmqSocket *zmqsocket = NULL;
 
+#ifdef NEWZMQ
+  // receive socket
+  try {
+#endif
+
+    zmqsocket = new sls::ZmqSocket(socketip, portnum);
+
+#ifdef NEWZMQ
+  } catch (...) {
+    cprintf(RED,
+	    "Error: Could not create Zmq socket on port %d with ip %s\n",
+	    portnum, socketip);
+    delete zmqsocket;
+    return EXIT_FAILURE;
+  }
+#endif
+
+
+
+  if (zmqsocket->Connect()) {
+    cprintf(RED, "Error: Could not connect to socket  %s\n",
+	    (zmqsocket->GetZmqServerAddress()).c_str());
+    delete zmqsocket;
+    return EXIT_FAILURE;
+  } else
+    printf("Zmq Client at %s\n", zmqsocket->GetZmqServerAddress().c_str());
+
+  // send socket
+  sls::ZmqSocket *zmqsocket2 = 0;
+  // cout << "zmq2 " << endl;
+  if (send) {
 #ifdef NEWZMQ
     // receive socket
     try {
 #endif
-
-        zmqsocket = new ZmqSocket(socketip, portnum);
+      zmqsocket2 = new sls::ZmqSocket(portnum2, socketip2);
 
 #ifdef NEWZMQ
     } catch (...) {
-        cprintf(RED,
-                "Error: Could not create Zmq socket on port %d with ip %s\n",
-                portnum, socketip);
-        delete zmqsocket;
-        return EXIT_FAILURE;
+      cprintf(RED,
+	      "Error: Could not create Zmq socket server on port %d and "
+	      "ip %s\n",
+	      portnum2, socketip2);
+    
+      send = false;
     }
 #endif
 
-#ifndef NEWZMQ
-    if (zmqsocket->IsError()) {
-        cprintf(RED,
-                "Error: Could not create Zmq socket on port %d with ip %s\n",
-                portnum, socketip);
-        delete zmqsocket;
-        return EXIT_FAILURE;
-    }
-#endif
-    if (zmqsocket->Connect()) {
-        cprintf(RED, "Error: Could not connect to socket  %s\n",
-                (zmqsocket->GetZmqServerAddress()).c_str());
-        delete zmqsocket;
-        return EXIT_FAILURE;
+    if (zmqsocket2->Connect()) {
+      cprintf(RED, "Error: Could not connect to socket  %s\n",
+	      zmqsocket2->GetZmqServerAddress().c_str());
+      //	delete zmqsocket2;
+      send = false;
+      //	return EXIT_FAILURE;
     } else
-        printf("Zmq Client at %s\n", zmqsocket->GetZmqServerAddress().c_str());
+      printf("Zmq Client at %s\n",
+	     zmqsocket2->GetZmqServerAddress().c_str());
+  }
 
-    // send socket
-    ZmqSocket *zmqsocket2 = 0;
-    // cout << "zmq2 " << endl;
-    if (send) {
-#ifdef NEWZMQ
-        // receive socket
-        try {
-#endif
-            zmqsocket2 = new ZmqSocket(portnum2, socketip2);
+  // header variables
+  uint64_t acqIndex = -1;
+  uint64_t frameIndex = -1;
+ 
+  uint64_t subframes = 0;
+  uint64_t insubframe = 0;
+ 
+  double subnorm = 1;
+  uint64_t f0 = -1, nsubframes = 0, nnsubframe = 0;
+  uint64_t fileindex = -1;
+  string filename = "";
 
-#ifdef NEWZMQ
-        } catch (...) {
-            cprintf(RED,
-                    "Error: Could not create Zmq socket server on port %d and "
-                    "ip %s\n",
-                    portnum2, socketip2);
-            //	delete zmqsocket2;
-            //	zmqsocket2=NULL;
-            //	delete zmqsocket;
-            //	return EXIT_FAILURE;
-            send = false;
-        }
-#endif
+  int iframe = 0;
+  char ofname[10000];
 
-#ifndef NEWZMQ
-        if (zmqsocket2->IsError()) {
-            cprintf(RED,
-                    "AAA Error: Could not create Zmq socket server on port %d "
-                    "and ip %s\n",
-                    portnum2, socketip2);
-            //	delete zmqsocket2;
-            // delete zmqsocket;
-            //	return EXIT_FAILURE;
-            send = false;
-        }
+  string fname;
+  //	int length;
+  int *detimage = NULL;
+  int nnx, nny, nnsx, nnsy;
+  uint32_t packetNumber = 0;
+  uint64_t detSpec1 = 0;
+  uint64_t timestamp = 0;
+  int16_t modId = 0;
+  uint32_t expLength = 0;
+  uint16_t xCoord = 0;
+  uint16_t yCoord = 0;
+  // uint16_t zCoord = 0;
+  uint32_t detSpec3 = 0;
+  // uint32_t dr = 16;
+  // int16_t *dout;//=new int16_t [nnx*nny];
+  uint32_t dr = 32;
+  int32_t *dout = NULL; //=new int32_t [nnx*nny];
+  float *doutf = NULL;  //=new int32_t [nnx*nny];
+  uint16_t detSpec4 = 0;
+  uint8_t detType = 0;
+  uint8_t version = 0;
+  string additionalJsonHeader = "";
+
+  int32_t threshold = 0;
+
+  int32_t xmin = 0, xmax = 400, ymin = 0, ymax = 400;
+
+  string frameMode_s, detectorMode_s, intMode_s;
+
+  //	int resetFlat=0;
+  // int resetPed=0;
+  // int nsubPixels=1;
+  // int isPedestal=0;
+  // int isFlat=0;
+  int newFrame = 1;
+  detectorMode dMode = eAnalog;
+  frameMode fMode = eFrame;
+  double *ped;
+
+  filter->getImageSize(nnx, nny, nnsx, nnsy);
+
+  std::map<std::string, std::string> addJsonHeader;
+
+  while (1) {
+
+    //  cout << "+++++++++++++++++++++++++++++++LOOP" << endl;
+    // get header, (if dummy, fail is on parse error or end of acquisition)
+
+    //  rapidjson::Document doc;
+    if (!zmqsocket->ReceiveHeader(0, zHeader,
+				  SLS_DETECTOR_JSON_HEADER_VERSION)) {
+      /* zmqsocket->CloseHeaderMessage();*/
+
+      //	  if (!zmqsocket->ReceiveHeader(0, acqIndex, frameIndex,
+      //subframeIndex, filename, fileindex)) {
+      cprintf(RED, "Got Dummy\n");
+      //   t1=high_resolution_clock::now();
+      // time(&end);
+      // cout << "Measurement lasted " << difftime(end,begin) << endl;
+
+      end = std::chrono::steady_clock::now();
+      cout << "Measurement lasted " << (end - begin).count() * 0.000001
+	   << " ms" << endl;
+
+      while (mt->isBusy()) {
+	;
+      } // wait until all data are processed from the queues
+      usleep(100);
+      if (of) {
+	mt->setFilePointer(NULL);
+	fclose(of);
+	of = NULL;
+      }
+      if (newFrame > 0) {
+	cprintf(RED, "DIDn't receive any data!\n");
+	if (send) {
+
+	  // zHeader.data = false;
+	  outHeader.data = false;
+	  //  zmqsocket2->SendHeaderData(0, true,
+	  //  SLS_DETECTOR_JSON_HEADER_VERSION);
+	  zmqsocket2->SendHeader(0, outHeader);
+	  cprintf(RED, "Sent Dummy\n");
+	}
+      } else {
+	send_something = 0;
+	if (fMode == ePedestal) {
+	  sprintf(ofname, "%s_%ld_ped.tiff", fname.c_str(),
+		  fileindex);
+	  mt->writePedestal(ofname);
+	  cout << "Writing pedestal to " << ofname << endl;
+	  if (rms) {
+	    sprintf(ofname, "%s_%ld_var.tiff", fname.c_str(),
+		    fileindex);
+	    mt->writePedestalRMS(ofname);
+	  }
+	  send_something = 1;
+	}
+#ifdef INTERP
+	else if (fMode == eFlat) {
+	  mt->prepareInterpolation(ok);
+	  sprintf(ofname, "%s_%ld_eta.tiff", fname.c_str(),
+		  fileindex);
+	  mt->writeFlatField(ofname);
+	  cout << "Writing eta to " << ofname << endl;
+	  send_something = 1;
+	}
 #endif
-        if (zmqsocket2->Connect()) {
-            cprintf(RED, "BBB Error: Could not connect to socket  %s\n",
-                    zmqsocket2->GetZmqServerAddress().c_str());
-            //	delete zmqsocket2;
-            send = false;
-            //	return EXIT_FAILURE;
-        } else
-            printf("Zmq Client at %s\n",
-                   zmqsocket2->GetZmqServerAddress().c_str());
+	else {
+	  if (subframes > 0) {
+	    if (insubframe > 0) {
+	      sprintf(ofname, "%s_sf%ld_%ld.tiff", fname.c_str(),
+		      nnsubframe, fileindex);
+	      //		  mt->writeImage(ofname);
+	      doutf = new float[nnx * nny];
+	      if (subframes > 0 && insubframe != subframes &&
+		  insubframe > 0)
+		subnorm =
+		  ((double)subframes) / ((double)insubframe);
+	      else
+		subnorm = 1.;
+	      for (int ix = 0; ix < nnx * nny; ix++) {
+		doutf[ix] = detimage[ix] * subnorm;
+		if (doutf[ix] < 0)
+		  doutf[ix] = 0;
+	      }
+
+	      cout << "Writing image to " << ofname << endl;
+
+	      WriteToTiff(doutf, ofname, nnx, nny);
+
+	      if (doutf)
+		delete[] doutf;
+	      doutf = NULL;
+
+	      nsubframes++;
+	      insubframe = 0;
+	      send_something = 1;
+	    }
+	  } else {
+	    sprintf(ofname, "%s_%ld.tiff", fname.c_str(),
+		    fileindex);
+	    mt->writeImage(ofname);
+	    send_something = 1;
+	  }
+
+	  cout << "Writing image to " << ofname << endl;
+	}
+	//  cout << nns*nnx*nny*nns*dr/8 << " " << length << endl;
+
+	if (send) {
+
+	  if (fMode == ePedestal) {
+	    cprintf(MAGENTA, "Get pedestal!\n");
+	    nnsx = 1;
+	    nnsy = 1;
+
+	    nnx = npx;
+	    nny = npy;
+	    // dout= new int16_t[nnx*nny*nns*nns];
+	    dout = new int32_t[nnx * nny * nnsx * nnsy];
+	    // cout << "get pedestal " << endl;
+	    ped = mt->getPedestal();
+	    // cout << "got pedestal " << endl;
+	    for (int ix = 0; ix < nnx * nny; ix++) {
+
+	      dout[ix] = ped[ix];
+	   
+	    }
+
+	  }
+#ifdef INTERP
+	  else if (fMode == eFlat) {
+	    int nbx, nby;
+	    double emi = 0, ema = 1;
+	    int *ff = mt->getFlatField(nbx, nby, emi, ema);
+	    nnx = nbx;
+	    nny = nby;
+	    dout = new int32_t[nbx * nby];
+	    for (int ix = 0; ix < nbx * nby; ix++) {
+	      dout[ix] = ff[ix];
+	    }
+	  }
+#endif
+	  else {
+	    detimage = mt->getImage(nnx, nny, nnsx, nnsy);
+	    cprintf(MAGENTA, "Get image!\n");
+	    cout << nnx << " " << nny << " " << nnsx << " " << nnsy
+		 << endl;
+	    // nns=1;
+	    // nnx=npx;
+	    // nny=npy;
+	    // nnx=nnx*nns;
+	    // nny=nny*nns;
+	    dout = new int32_t[nnx * nny];
+	    if (subframes > 0 && insubframe != subframes &&
+		insubframe > 0)
+	      subnorm =
+		((double)subframes) / ((double)insubframe);
+	    else
+	      subnorm = 1.;
+	    for (int ix = 0; ix < nnx * nny; ix++) {
+	      // for (int iy=0; iy<nny*nns; iy++) {
+	      //  for (int isx=0; isx<nns; isx++) {
+	      //   for (int isy=0; isy<nns; isy++) {
+	      //     if (isx==0 && isy==0)
+	      //       dout[iy*nnx+ix]=detimage[(iy+isy)*nnx*nns+ix+isx];
+	      //     else
+	      //       dout[iy*nnx+ix]+=detimage[(iy+isy)*nnx*nns+ix+isx];
+
+	      //   }
+	      // }
+	      dout[ix] = detimage[ix] * subnorm;
+	      if (dout[ix] < 0)
+		dout[ix] = 0;
+	      //   cout << ix << " " << dout[ix] << endl;
+	      // }
+	    }
+	  }
+	  // if ((insubframe>0 && subframes>0) || (subframes<=0) ){
+
+	  if (send_something) {
+
+	    outHeader.data = true;
+	    outHeader.dynamicRange = dr;
+	    outHeader.fileIndex = fileindex;
+	    outHeader.ndetx = 1;
+	    outHeader.ndety = 1;
+	    outHeader.npixelsx = nnx;
+	    outHeader.npixelsy = nny;
+	    outHeader.imageSize = nnx * nny * dr / 8;
+	    outHeader.acqIndex = acqIndex;
+	    outHeader.frameIndex = frameIndex;
+	    outHeader.fname = fname;
+	    outHeader.frameNumber = acqIndex;
+	    outHeader.expLength = expLength;
+	    outHeader.packetNumber = packetNumber;
+	    outHeader.detSpec1 = detSpec1;
+	    outHeader.timestamp = timestamp;
+	    outHeader.modId = modId;
+	    outHeader.row = xCoord;
+	    outHeader.column = yCoord;
+	    outHeader.detSpec3 = detSpec3;
+	    outHeader.detSpec4 = detSpec4;
+	    outHeader.detType = detType;
+	    outHeader.version = version;
+
+	    zmqsocket2->SendHeader(0, outHeader);
+	    zmqsocket2->SendData((char *)dout, nnx * nny * dr / 8);
+	    cprintf(GREEN, "Sent Data\n");
+	  }
+	  outHeader.data = false;
+	  zmqsocket2->SendHeader(0, outHeader);
+	  // zmqsocket2->SendHeaderData(0, true,
+	  // SLS_DETECTOR_JSON_HEADER_VERSION);
+	  cprintf(RED, "Sent Dummy\n");
+	  if (dout)
+	    delete[] dout;
+	  dout = NULL;
+	}
+      }
+
+      mt->clearImage();
+
+      newFrame = 1;
+
+      // time(&finished);
+      // cout << "Processing lasted " << difftime(finished,begin) << endl;
+
+      finished = std::chrono::steady_clock::now();
+      cout << "Processing lasted "
+	   << (finished - begin).count() * 0.000001 << " ms" << endl;
+#ifdef OPTIMIZE
+      return 0;
+#endif
+      continue; // continue to not get out
     }
 
-    // header variables
-    uint64_t acqIndex = -1;
-    uint64_t frameIndex = -1;
-#ifdef MOENCH_BRANCH
-    uint32_t subFrameIndex = -1;
-    int *flippedData = 0;
-#endif
+    //#ifdef NEWZMQ
+    if (newFrame) {
+      begin = std::chrono::steady_clock::now();
 
-    uint64_t subframes = 0;
-    // uint64_t  isubframe=0;
-    uint64_t insubframe = 0;
-    double subnorm = 1;
-    uint64_t f0 = -1, nsubframes = 0, nnsubframe = 0;
+      size = zHeader.imageSize; // doc["size"].GetUint();
 
-    uint64_t fileindex = -1;
-    string filename = "";
-    //	char* image = new char[size];
-    // int* image = new int[(size/sizeof(int))]();
-    // uint32_t flippedDataX = -1;
-    // int *nph;
-    int iframe = 0;
-    char ofname[10000];
+      // dynamicRange  = zheader.dynamicRange; //doc["bitmode"].GetUint();
+      // nPixelsX = zHeader.npixelsx; //doc["shape"][0].GetUint();
+      // nPixelsY = zHeader.npixelsy;// doc["shape"][1].GetUint();
+      filename = zHeader.fname; // doc["fname"].GetString();
+      acqIndex =
+	zHeader
+	.acqIndex; // doc["acqIndex"].GetUint64();
+      //  frameIndex       =
+      //  zHeader.frameIndex;//doc["fIndex"].GetUint64();
+      fileindex = zHeader.fileIndex; // doc["fileIndex"].GetUint64();
+      expLength = zHeader.expLength; // doc["expLength"].GetUint();
+      packetNumber =
+	zHeader.packetNumber;      // doc["packetNumber"].GetUint();
+      detSpec1 = zHeader.detSpec1;     // doc["detSpec1"].GetUint();
+      timestamp = zHeader.timestamp; // doc["timestamp"].GetUint();
+      modId = zHeader.modId;         // doc["modId"].GetUint();
+      detSpec3 = zHeader.detSpec3;         // doc["detSpec3"].GetUint();
+      //  detSpec4=r.detSpec4;//doc["detSpec4"].GetUint();
+      detType = zHeader.detType; // doc["detType"].GetUint();
+      version = zHeader.version; // doc["version"].GetUint();
+      /*document["bitmode"].GetUint(); zHeader.dynamicRange
 
-    string fname;
-    //	int length;
-    int *detimage = NULL;
-    int nnx, nny, nnsx, nnsy;
-    // uint32_t imageSize = 0, nPixelsX = 0, nPixelsY = 0,
-    // uint32_t  dynamicRange = 0;
-    //  infinite loop
-    uint32_t packetNumber = 0;
-    uint64_t bunchId = 0;
-    uint64_t timestamp = 0;
-    int16_t modId = 0;
-    uint32_t expLength = 0;
-    uint16_t xCoord = 0;
-    uint16_t yCoord = 0;
-    // uint16_t zCoord = 0;
-    uint32_t debug = 0;
-    // uint32_t dr = 16;
-    // int16_t *dout;//=new int16_t [nnx*nny];
-    uint32_t dr = 32;
-    int32_t *dout = NULL; //=new int32_t [nnx*nny];
-    float *doutf = NULL;  //=new int32_t [nnx*nny];
-    uint16_t roundRNumber = 0;
-    uint8_t detType = 0;
-    uint8_t version = 0;
-    string additionalJsonHeader = "";
 
-    int32_t threshold = 0;
+       */
 
-    int32_t xmin = 0, xmax = 400, ymin = 0, ymax = 400;
+      // strcpy(fname,filename.c_str());
+      fname = filename;
+      addJsonHeader = zHeader.addJsonHeader;
 
-    string frameMode_s, detectorMode_s, intMode_s;
-
-    //	int resetFlat=0;
-    // int resetPed=0;
-    //	int nsubPixels=1;
-    // int isPedestal=0;
-    // int isFlat=0;
-    int newFrame = 1;
-    detectorMode dMode = eAnalog;
-    frameMode fMode = eFrame;
-    double *ped;
-
-    filter->getImageSize(nnx, nny, nnsx, nnsy);
-
-    std::map<std::string, std::string> addJsonHeader;
-
-    while (1) {
-
-        //  cout << "+++++++++++++++++++++++++++++++LOOP" << endl;
-        // get header, (if dummy, fail is on parse error or end of acquisition)
-
-        //  rapidjson::Document doc;
-        if (!zmqsocket->ReceiveHeader(0, zHeader,
-                                      SLS_DETECTOR_JSON_HEADER_VERSION)) {
-            /* zmqsocket->CloseHeaderMessage();*/
-
-            //	  if (!zmqsocket->ReceiveHeader(0, acqIndex, frameIndex,
-            //subframeIndex, filename, fileindex)) {
-            cprintf(RED, "Got Dummy\n");
-            //   t1=high_resolution_clock::now();
-            // time(&end);
-            // cout << "Measurement lasted " << difftime(end,begin) << endl;
-
-            end = std::chrono::steady_clock::now();
-            cout << "Measurement lasted " << (end - begin).count() * 0.000001
-                 << " ms" << endl;
-
-            while (mt->isBusy()) {
-                ;
-            } // wait until all data are processed from the queues
-
-            if (of) {
-                mt->setFilePointer(NULL);
-                fclose(of);
-                of = NULL;
-            }
-            if (newFrame > 0) {
-                cprintf(RED, "DIDn't receive any data!\n");
-                if (send) {
-
-                    // zHeader.data = false;
-                    outHeader.data = false;
-                    //  zmqsocket2->SendHeaderData(0, true,
-                    //  SLS_DETECTOR_JSON_HEADER_VERSION);
-                    zmqsocket2->SendHeader(0, outHeader);
-                    cprintf(RED, "Sent Dummy\n");
-                }
-            } else {
-                send_something = 0;
-                if (fMode == ePedestal) {
-                    sprintf(ofname, "%s_%ld_ped.tiff", fname.c_str(),
-                            fileindex);
-                    mt->writePedestal(ofname);
-                    cout << "Writing pedestal to " << ofname << endl;
-                    if (rms) {
-                        sprintf(ofname, "%s_%ld_var.tiff", fname.c_str(),
-                                fileindex);
-                        mt->writePedestalRMS(ofname);
-                    }
-                    send_something = 1;
-                }
+      rms = 0;
+      fMode = eFrame;
+      frameMode_s = "frame";
+      cprintf(MAGENTA, "Frame mode: ");
+      //	      if (doc.HasMember("frameMode")) {
+      if (addJsonHeader.find("frameMode") != addJsonHeader.end()) {
+	//	if (doc["frameMode"].IsString()) {
+	frameMode_s = addJsonHeader.at(
+				       "frameMode"); // doc["frameMode"].GetString();
+	if (frameMode_s == "pedestal") {
+	  fMode = ePedestal;
+	  // isPedestal=1;
+	} else if (frameMode_s == "newPedestal") {
+	  mt->newDataSet(); // resets pedestal
+	  // cprintf(MAGENTA, "Resetting pedestal\n");
+	  fMode = ePedestal;
+	  // isPedestal=1;
+	} else if (frameMode_s == "variance") {
+	  mt->newDataSet(); // resets pedestal
+	  // cprintf(MAGENTA, "Resetting pedestal\n");
+	  fMode = ePedestal;
+	  // isPedestal=1;
+	  rms = 1;
+	} else if (frameMode_s == "raw") {
+	  // mt->newDataSet(); //resets pedestal
+	  //  cprintf(MAGENTA, "Resetting pedestal\n");
+	  fMode = eRaw;
+	  // isPedestal=1;
+	}
 #ifdef INTERP
-                else if (fMode == eFlat) {
-                    mt->prepareInterpolation(ok);
-                    sprintf(ofname, "%s_%ld_eta.tiff", fname.c_str(),
-                            fileindex);
-                    mt->writeFlatField(ofname);
-                    cout << "Writing eta to " << ofname << endl;
-                    send_something = 1;
-                }
-#endif
-                else {
-                    if (subframes > 0) {
-                        if (insubframe > 0) {
-                            sprintf(ofname, "%s_sf%ld_%ld.tiff", fname.c_str(),
-                                    nnsubframe, fileindex);
-                            //		  mt->writeImage(ofname);
-                            doutf = new float[nnx * nny];
-                            if (subframes > 0 && insubframe != subframes &&
-                                insubframe > 0)
-                                subnorm =
-                                    ((double)subframes) / ((double)insubframe);
-                            else
-                                subnorm = 1.;
-                            for (int ix = 0; ix < nnx * nny; ix++) {
-                                doutf[ix] = detimage[ix] * subnorm;
-                                if (doutf[ix] < 0)
-                                    doutf[ix] = 0;
-                            }
+	else if (frameMode_s == "flatfield") {
+	  fMode = eFlat;
+	  // isFlat=1;
+	} else if (frameMode_s == "newFlatfield") {
+	  mt->resetFlatField();
+	  // isFlat=1;
+	  cprintf(MAGENTA, "Resetting flatfield\n");
+	  fMode = eFlat;
+	}
+	//#endif
+	else {
+	  // isPedestal=0;
+	  // isFlat=0;
+	  fMode = eFrame;
+	  frameMode_s = "frame";
+	}
+	//}
+      }
+      cprintf(MAGENTA, "%s\n", frameMode_s.c_str());
+      mt->setFrameMode(fMode);
 
-                            cout << "Writing image to " << ofname << endl;
+      // threshold=0;
+      cprintf(MAGENTA, "Threshold: ");
+      if (addJsonHeader.find("threshold") != addJsonHeader.end()) {
+	istringstream(addJsonHeader.at("threshold")) >> threshold;
+      }
+      mt->setThreshold(threshold);
+      cprintf(MAGENTA, "%d\n", threshold);
+      
+      cprintf(MAGENTA, "subframes: ");
+      if (addJsonHeader.find("subframes") != addJsonHeader.end()) {
+	istringstream(addJsonHeader.at("subframes")) >> subframes;
+      }
+     
+      cprintf(MAGENTA, "%d\n", subframes);
+      
 
-                            WriteToTiff(doutf, ofname, nnx, nny);
 
-                            if (doutf)
-                                delete[] doutf;
-                            doutf = NULL;
 
-                            nsubframes++;
-                            insubframe = 0;
-                            send_something = 1;
-                        }
-                    } else {
-                        sprintf(ofname, "%s_%ld.tiff", fname.c_str(),
-                                fileindex);
-                        mt->writeImage(ofname);
-                        send_something = 1;
-                    }
+      xmin = 0;
+      xmax = npx;
+      ymin = 0;
+      ymax = npy;
+      cprintf(MAGENTA, "ROI: ");
 
-                    cout << "Writing image to " << ofname << endl;
-                }
-                //  cout << nns*nnx*nny*nns*dr/8 << " " << length << endl;
+      if (addJsonHeader.find("roi") != addJsonHeader.end()) {
+	istringstream(addJsonHeader.at("roi")) >> xmin >> xmax >>
+	  ymin >> ymax;
+      }
 
-                if (send) {
-
-                    if (fMode == ePedestal) {
-                        cprintf(MAGENTA, "Get pedestal!\n");
-                        nnsx = 1;
-                        nnsy = 1;
-
-                        nnx = npx;
-                        nny = npy;
-                        // dout= new int16_t[nnx*nny*nns*nns];
-                        dout = new int32_t[nnx * nny * nnsx * nnsy];
-                        // cout << "get pedestal " << endl;
-                        ped = mt->getPedestal();
-                        // cout << "got pedestal " << endl;
-                        for (int ix = 0; ix < nnx * nny; ix++) {
-
-                            dout[ix] = ped[ix];
-                            // if (ix<100*400)
-                            //   cout << ix << " " << ped[ix] << endl;
-                        }
-
-                    }
+      cprintf(MAGENTA, "%d %d %d %d\n", xmin, xmax, ymin, ymax);
+      mt->setROI(xmin, xmax, ymin, ymax);
+      if (addJsonHeader.find("dynamicRange") != addJsonHeader.end()) {
+	istringstream(addJsonHeader.at("dynamicRange")) >> dr;
+	dr = 32;
+      }
+      dMode = eAnalog;
+      detectorMode_s = "analog";
+      cprintf(MAGENTA, "Detector mode: ");
+      if (addJsonHeader.find("detectorMode") != addJsonHeader.end()) {
+	;
+	detectorMode_s = addJsonHeader.at(
+					  "detectorMode"); //=doc["detectorMode"].GetString();
 #ifdef INTERP
-                    else if (fMode == eFlat) {
-                        int nb;
-                        double emi = 0, ema = 1;
-                        int *ff = mt->getFlatField(nb, emi, ema);
-                        nnx = nb;
-                        nny = nb;
-                        dout = new int32_t[nb * nb];
-                        for (int ix = 0; ix < nb * nb; ix++) {
-                            dout[ix] = ff[ix];
-                        }
-                    }
+	if (detectorMode_s == "interpolating") {
+	  dMode = eInterpolating;
+	  mt->setInterpolation(interp);
+	} else
 #endif
-                    else {
-                        detimage = mt->getImage(nnx, nny, nnsx, nnsy);
-                        cprintf(MAGENTA, "Get image!\n");
-                        cout << nnx << " " << nny << " " << nnsx << " " << nnsy
-                             << endl;
-                        // nns=1;
-                        // nnx=npx;
-                        // nny=npy;
-                        // nnx=nnx*nns;
-                        // nny=nny*nns;
-                        dout = new int32_t[nnx * nny];
-                        if (subframes > 0 && insubframe != subframes &&
-                            insubframe > 0)
-                            subnorm =
-                                ((double)subframes) / ((double)insubframe);
-                        else
-                            subnorm = 1.;
-                        for (int ix = 0; ix < nnx * nny; ix++) {
-                            // for (int iy=0; iy<nny*nns; iy++) {
-                            //  for (int isx=0; isx<nns; isx++) {
-                            //   for (int isy=0; isy<nns; isy++) {
-                            //     if (isx==0 && isy==0)
-                            //       dout[iy*nnx+ix]=detimage[(iy+isy)*nnx*nns+ix+isx];
-                            //     else
-                            //       dout[iy*nnx+ix]+=detimage[(iy+isy)*nnx*nns+ix+isx];
-
-                            //   }
-                            // }
-                            dout[ix] = detimage[ix] * subnorm;
-                            if (dout[ix] < 0)
-                                dout[ix] = 0;
-                            //   cout << ix << " " << dout[ix] << endl;
-                            // }
-                        }
-                    }
-                    // if ((insubframe>0 && subframes>0) || (subframes<=0) ){
-
-                    if (send_something) {
-
-                        //  zmqsocket2->SendHeaderData (0,
-                        //  false,SLS_DETECTOR_JSON_HEADER_VERSION , dr,
-                        //  fileindex, 1,1,nnx,nny,nnx*nny*dr/8,acqIndex,
-                        //  frameIndex, fname,acqIndex,0 , packetNumber,bunchId,
-                        //  timestamp, modId,xCoord, yCoord, zCoord,debug,
-                        //  roundRNumber, detType, version, 0,0,
-                        //  0,&additionalJsonHeader);
-
-                        outHeader.data = true;
-                        outHeader.dynamicRange = dr;
-                        outHeader.fileIndex = fileindex;
-                        outHeader.ndetx = 1;
-                        outHeader.ndety = 1;
-                        outHeader.npixelsx = nnx;
-                        outHeader.npixelsy = nny;
-                        outHeader.imageSize = nnx * nny * dr / 8;
-                        outHeader.acqIndex = acqIndex;
-                        outHeader.frameIndex = frameIndex;
-                        outHeader.fname = fname;
-                        outHeader.frameNumber = acqIndex;
-                        outHeader.expLength = expLength;
-                        outHeader.packetNumber = packetNumber;
-                        outHeader.bunchId = bunchId;
-                        outHeader.timestamp = timestamp;
-                        outHeader.modId = modId;
-                        outHeader.row = xCoord;
-                        outHeader.column = yCoord;
-                        outHeader.debug = debug;
-                        outHeader.roundRNumber = roundRNumber;
-                        outHeader.detType = detType;
-                        outHeader.version = version;
-
-                        zmqsocket2->SendHeader(0, outHeader);
-                        zmqsocket2->SendData((char *)dout, nnx * nny * dr / 8);
-                        cprintf(GREEN, "Sent Data\n");
-                    }
-                    outHeader.data = false;
-                    zmqsocket2->SendHeader(0, outHeader);
-                    // zmqsocket2->SendHeaderData(0, true,
-                    // SLS_DETECTOR_JSON_HEADER_VERSION);
-                    cprintf(RED, "Sent Dummy\n");
-                    if (dout)
-                        delete[] dout;
-                    dout = NULL;
-                }
-            }
-
-            mt->clearImage();
-
-            newFrame = 1;
-
-            // time(&finished);
-            // cout << "Processing lasted " << difftime(finished,begin) << endl;
-
-            finished = std::chrono::steady_clock::now();
-            cout << "Processing lasted "
-                 << (finished - begin).count() * 0.000001 << " ms" << endl;
-#ifdef OPTIMIZE
-            return 0;
-#endif
-            continue; // continue to not get out
-        }
-
-        //#ifdef NEWZMQ
-        if (newFrame) {
-            begin = std::chrono::steady_clock::now();
-
-            size = zHeader.imageSize; // doc["size"].GetUint();
-
-            // dynamicRange  = zheader.dynamicRange; //doc["bitmode"].GetUint();
-            // nPixelsX = zHeader.npixelsx; //doc["shape"][0].GetUint();
-            // nPixelsY = zHeader.npixelsy;// doc["shape"][1].GetUint();
-            filename = zHeader.fname; // doc["fname"].GetString();
-            acqIndex =
-                zHeader
-                    .acqIndex; // doc["acqIndex"].GetUint64();
-                               //  frameIndex       =
-                               //  zHeader.frameIndex;//doc["fIndex"].GetUint64();
-            fileindex = zHeader.fileIndex; // doc["fileIndex"].GetUint64();
-            expLength = zHeader.expLength; // doc["expLength"].GetUint();
-            packetNumber =
-                zHeader.packetNumber;      // doc["packetNumber"].GetUint();
-            bunchId = zHeader.bunchId;     // doc["bunchId"].GetUint();
-            timestamp = zHeader.timestamp; // doc["timestamp"].GetUint();
-            modId = zHeader.modId;         // doc["modId"].GetUint();
-            debug = zHeader.debug;         // doc["debug"].GetUint();
-            //  roundRNumber=r.roundRNumber;//doc["roundRNumber"].GetUint();
-            detType = zHeader.detType; // doc["detType"].GetUint();
-            version = zHeader.version; // doc["version"].GetUint();
-            /*document["bitmode"].GetUint(); zHeader.dynamicRange
-
-document["fileIndex"].GetUint64(); zHeader.fileIndex
-
-document["detshape"][0].GetUint();
-zHeader.ndetx
-
-document["detshape"][1].GetUint();
-zHeader.ndety
-
-document["shape"][0].GetUint();
-zHeader.npixelsx
-
-document["shape"][1].GetUint();
-zHeader.npixelsy
-
-document["size"].GetUint(); zHeader.imageSize
-
-document["acqIndex"].GetUint64(); zHeader.acqIndex
-
-document["frameIndex"].GetUint64(); zHeader.frameIndex
-
-document["fname"].GetString(); zHeader.fname
-
-document["frameNumber"].GetUint64(); zHeader.frameNumber
-
-document["expLength"].GetUint(); zHeader.expLength
-
-document["packetNumber"].GetUint(); zHeader.packetNumber
-
-document["bunchId"].GetUint64(); zHeader.bunchId
-
-document["timestamp"].GetUint64(); zHeader.timestamp
-
-document["modId"].GetUint(); zHeader.modId
-
-document["row"].GetUint(); zHeader.row
-
-document["column"].GetUint(); zHeader.column
-
-document["reserved"].GetUint(); zHeader.reserved
-
-document["debug"].GetUint(); zHeader.debug
-
-document["roundRNumber"].GetUint(); zHeader.roundRNumber
-
-document["detType"].GetUint(); zHeader.detType
-
-document["version"].GetUint(); zHeader.version
-
-document["flippedDataX"].GetUint(); zHeader.flippedDataX
-
-document["quad"].GetUint(); zHeader.quad
-
-document["completeImage"].GetUint(); zHeader.completeImage
-            */
-            // dataSize=size;
-
-            // strcpy(fname,filename.c_str());
-            fname = filename;
-            // cprintf(BLUE, "Header Info:\n"
-            // 	      "size: %u\n"
-            // 	      "multisize: %u\n"
-            // 	      "dynamicRange: %u\n"
-            // 	      "nPixelsX: %u\n"
-            // 	      "nPixelsY: %u\n"
-            // 	      "currentFileName: %s\n"
-            // 	      "currentAcquisitionIndex: %lu\n"
-            // 	      "currentFrameIndex: %lu\n"
-            // 	      "currentFileIndex: %lu\n"
-            // 	      "currentSubFrameIndex: %u\n"
-            // 	      "xCoordX: %u\n"
-            // 	      "yCoordY: %u\n"
-            // 	      "zCoordZ: %u\n"
-            // 	      "flippedDataX: %u\n"
-            // 	      "packetNumber: %u\n"
-            // 	      "bunchId: %u\n"
-            // 	      "timestamp: %u\n"
-            // 	      "modId: %u\n"
-            // 	      "debug: %u\n"
-            // 	      "roundRNumber: %u\n"
-            // 	      "detType: %u\n"
-            // 	      "version: %u\n",
-            // 	      size, multisize, dynamicRange, nPixelsX, nPixelsY,
-            // 	      filename.c_str(), acqIndex,
-            // 	      frameIndex, fileindex, subFrameIndex,
-            // 	      xCoord, yCoord,zCoord,
-            // 	      flippedDataX, packetNumber, bunchId, timestamp, modId,
-            // debug, roundRNumber, detType, version);
-
-            addJsonHeader = zHeader.addJsonHeader;
-
-            /* Analog detector commands */
-            // isPedestal=0;
-            // isFlat=0;
-            rms = 0;
-            fMode = eFrame;
-            frameMode_s = "frame";
-            cprintf(MAGENTA, "Frame mode: ");
-            //	      if (doc.HasMember("frameMode")) {
-            if (addJsonHeader.find("frameMode") != addJsonHeader.end()) {
-                //	if (doc["frameMode"].IsString()) {
-                frameMode_s = addJsonHeader.at(
-                    "frameMode"); // doc["frameMode"].GetString();
-                if (frameMode_s == "pedestal") {
-                    fMode = ePedestal;
-                    // isPedestal=1;
-                } else if (frameMode_s == "newPedestal") {
-                    mt->newDataSet(); // resets pedestal
-                    // cprintf(MAGENTA, "Resetting pedestal\n");
-                    fMode = ePedestal;
-                    // isPedestal=1;
-                } else if (frameMode_s == "variance") {
-                    mt->newDataSet(); // resets pedestal
-                    // cprintf(MAGENTA, "Resetting pedestal\n");
-                    fMode = ePedestal;
-                    // isPedestal=1;
-                    rms = 1;
-                }
+	  if (detectorMode_s == "counting") {
+	    dMode = ePhotonCounting;
 #ifdef INTERP
-                else if (frameMode_s == "flatfield") {
-                    fMode = eFlat;
-                    // isFlat=1;
-                } else if (frameMode_s == "newFlatfield") {
-                    mt->resetFlatField();
-                    // isFlat=1;
-                    cprintf(MAGENTA, "Resetting flatfield\n");
-                    fMode = eFlat;
-                }
-                //#endif
-                else {
-                    fMode = eFrame;
-                    // isPedestal=0;
-                    // isFlat=0;
-                    fMode = eFrame;
-                    frameMode_s = "frame";
-                }
-                //}
-            }
-            cprintf(MAGENTA, "%s\n", frameMode_s.c_str());
-            mt->setFrameMode(fMode);
-
-            // threshold=0;
-            cprintf(MAGENTA, "Threshold: ");
-            if (addJsonHeader.find("threshold") != addJsonHeader.end()) {
-                istringstream(addJsonHeader.at("threshold")) >> threshold;
-                //		threshold=atoi(addJsonHeader.at("threshold").c_str());//doc["frameMode"].GetString();
-            }
-            // if (doc.HasMember("threshold")) {
-            // if (doc["threshold"].IsInt()) {
-            //   threshold=doc["threshold"].GetInt();
-            mt->setThreshold(threshold);
-            //	}
-            // }
-            cprintf(MAGENTA, "%d\n", threshold);
-
-            xmin = 0;
-            xmax = npx;
-            ymin = 0;
-            ymax = npy;
-            cprintf(MAGENTA, "ROI: ");
-
-            if (addJsonHeader.find("roi") != addJsonHeader.end()) {
-                istringstream(addJsonHeader.at("roi")) >> xmin >> xmax >>
-                    ymin >> ymax;
-                //  if (doc.HasMember("roi")) {
-                // if (doc["roi"].IsArray()) {
-                // if (doc["roi"].Size() > 0 )
-                //  if (doc["roi"][0].IsInt())
-                //    xmin=doc["roi"][0].GetInt();
-
-                //   if (doc["roi"].Size() > 1 )
-                //     if (doc["roi"][1].IsInt())
-                //       xmax=doc["roi"][1].GetInt();
-
-                //   if (doc["roi"].Size() > 2 )
-                //     if (doc["roi"][2].IsInt())
-                //       ymin=doc["roi"][2].GetInt();
-
-                //   if (doc["roi"].Size() > 3 )
-                //     if (doc["roi"][3].IsInt())
-                //       ymax=doc["roi"][3].GetInt();
-                // }
-            }
-
-            cprintf(MAGENTA, "%d %d %d %d\n", xmin, xmax, ymin, ymax);
-            mt->setROI(xmin, xmax, ymin, ymax);
-            if (addJsonHeader.find("dynamicRange") != addJsonHeader.end()) {
-                istringstream(addJsonHeader.at("dynamicRange")) >> dr;
-                dr = 32;
-            }
-            // if (doc.HasMember("dynamicRange")) {
-            // 	dr=doc["dynamicRange"].GetUint();
-            // 	dr=32;
-            // }
-
-            dMode = eAnalog;
-            detectorMode_s = "analog";
-            cprintf(MAGENTA, "Detector mode: ");
-            if (addJsonHeader.find("detectorMode") != addJsonHeader.end()) {
-                ;
-                // if (doc.HasMember("detectorMode")) {
-                // if (doc["detectorMode"].IsString()) {
-                detectorMode_s = addJsonHeader.at(
-                    "detectorMode"); //=doc["detectorMode"].GetString();
+	    mt->setInterpolation(NULL);
+#endif
+	  } else {
+	    dMode = eAnalog;
 #ifdef INTERP
-                if (detectorMode_s == "interpolating") {
-                    dMode = eInterpolating;
-                    mt->setInterpolation(interp);
-                } else
+	    mt->setInterpolation(NULL);
 #endif
-                    if (detectorMode_s == "counting") {
-                    dMode = ePhotonCounting;
-#ifdef INTERP
-                    mt->setInterpolation(NULL);
-#endif
-                } else {
-                    dMode = eAnalog;
-#ifdef INTERP
-                    mt->setInterpolation(NULL);
-#endif
-                }
-                // }
-            }
+	  }
+	// }
+	if (fMode == eRaw) {
+	  detectorMode_s = "analog";
+	  dMode = eAnalog;
+	}
+      }
 
-            mt->setDetectorMode(dMode);
-            cprintf(MAGENTA, "%s\n", detectorMode_s.c_str());
+      mt->setDetectorMode(dMode);
+      cprintf(MAGENTA, "%s\n", detectorMode_s.c_str());
 
-            // cout << "done " << endl;
+      cout << "done " << endl;
 
-            // /* Single Photon Detector commands */
-            // nSigma=5;
-            // if (doc.HasMember("nSigma")) {
-            // 	if (doc["nSigma"].IsInt())
-            // 	  nSigma=doc["nSigma"].GetInt();
-            // 	mt->setNSigma(nSigma);
-            // }
+      /* Single Photon Detector commands */
+      nSigma = 5;
 
-            // emin=-1;
-            // emax=-1;
-            // if (doc.HasMember("energyRange")) {
-            // 	if (doc["energyRange"].IsArray()) {
-            // 	  if (doc["energyRange"].Size() > 0 )
-            // 	    if (doc["energyRange"][0].IsInt())
-            // 	      emin=doc["energyRange"][0].GetInt();
+      if (addJsonHeader.find("nSigma") != addJsonHeader.end()) {
+	;
+	istringstream(addJsonHeader.at("nSigma")) >> nSigma;
+	mt->setNSigma(nSigma);
+      }
 
-            // 	  if (doc["energyRange"].Size() > 1 )
-            // 	    if (doc["energyRange"][1].IsInt())
-            // 	      emax=doc["energyRange"][1].GetUint();
-            // 	}
-            // }
-            // if (doc.HasMember("eMin")) {
-            // 	if (doc["eMin"][1].IsInt())
-            // 	  emin=doc["eMin"].GetInt();
-            // }
-            // if (doc.HasMember("eMax")) {
-            // 	if (doc["eMax"][1].IsInt())
-            // 	  emin=doc["eMax"].GetInt();
-            // }
-            // mt->setEnergyRange(emin,emax);
+      emin = -1;
+      emax = -1;
+      if (addJsonHeader.find("energyRange") != addJsonHeader.end()) {
+	istringstream(addJsonHeader.at("energyRange")) >> emin >> emax;
+      }
+      if (addJsonHeader.find("eMin") != addJsonHeader.end()) {
+	istringstream(addJsonHeader.at("eMin")) >> emin;
+      }
 
-            // /* interpolating detector commands */
+      if (addJsonHeader.find("eMax") != addJsonHeader.end()) {
+	istringstream(addJsonHeader.at("eMax")) >> emax;
+      }
 
-            // if (doc.HasMember("nSubPixels")) {
-            // 	if (doc["nSubPixels"].IsUint())
-            // 	nSubPixels=doc["nSubPixels"].GetUint();
-            // 	mt->setNSubPixels(nSubPixels);
-            // }
+      mt->setEnergyRange(emin, emax);
 
-            // threshold=0;
-            // cprintf(MAGENTA, "Subframes: ");
-            // subframes=0;
-            // //isubframe=0;
-            // insubframe=0;
-            // subnorm=1;
-            // f0=0;
-            // nnsubframe=0;
-            // if (doc.HasMember("subframes")) {
-            // 	if (doc["subframes"].IsInt()) {
-            // 	  subframes=doc["subframes"].GetInt();
-            // 	}
-            // }
-            // cprintf(MAGENTA, "%ld\n", subframes);
+      /* interpolating detector commands */
+      // must set subpixels X and Y separately
+      //  if (addJsonHeader.find("nSubPixels")!= addJsonHeader.end()) {
+      //  	istringstream(addJsonHeader.at("nSubPixels")) >>
+      //  nSubPixels ; 	mt->setNSubPixels(nSubPixels);
+      //  }
 
-            newFrame = 0;
-            /* zmqsocket->CloseHeaderMessage();*/
-        }
+      threshold = 0;
+      cprintf(MAGENTA, "Subframes: ");
+      subframes = 0;
+      // isubframe=0;
+      insubframe = 0;
+      subnorm = 1;
+      f0 = 0;
+      nnsubframe = 0;
+      if (addJsonHeader.find("subframes") != addJsonHeader.end()) {
+	istringstream(addJsonHeader.at("subframes")) >> subframes;
+      }
+
+      cprintf(MAGENTA, "%ld\n", subframes);
+
+      newFrame = 0;
+    }
 #endif
 
-        // cout << "file" << endl;
-        //  cout << "data " << endl;
-        if (of == NULL) {
-#ifdef WRITE_QUAD
-            sprintf(ofname, "%s_%ld.clust2", filename.c_str(), fileindex);
-#endif
-#ifndef WRITE_QUAD
-            sprintf(ofname, "%s_%ld.clust", filename.c_str(), fileindex);
-#endif
-            of = fopen(ofname, "w");
-            if (of) {
-                mt->setFilePointer(of);
-            } else {
-                cout << "Could not open " << ofname << " for writing " << endl;
-                mt->setFilePointer(NULL);
-            }
-        }
+    frameIndex = zHeader.frameIndex; ////doc["fIndex"].GetUint64();
 
-        // cout << "data" << endl;
-        // get data
-        // acqIndex = doc["acqIndex"].GetUint64();
+    // subFrameIndex    = doc["expLength"].GetUint();
 
-        frameIndex = zHeader.frameIndex; ////doc["fIndex"].GetUint64();
+    //  detSpec1=doc["detSpec1"].GetUint();
+    //  timestamp=doc["timestamp"].GetUint();
+    packetNumber = zHeader.packetNumber; // doc["packetNumber"].GetUint();
+    // cout << acqIndex << " " << frameIndex << " " << subFrameIndex << "
+    // "<< detSpec1 << " " << timestamp << " " << packetNumber << endl;
+    // cprintf(GREEN, "frame\n");
+    if (packetNumber >= 40) {
+      //*((int*)buff)=frameIndex;
+      if (insubframe == 0)
+	f0 = frameIndex;
+      memcpy(buff, &frameIndex, sizeof(int));
+      // length =
+      zmqsocket->ReceiveData(0, buff + sizeof(int), size);
 
-        // subFrameIndex    = doc["expLength"].GetUint();
+      mt->setFilePointer(NULL);
 
-        //  bunchId=doc["bunchId"].GetUint();
-        //  timestamp=doc["timestamp"].GetUint();
-        packetNumber = zHeader.packetNumber; // doc["packetNumber"].GetUint();
-        // cout << acqIndex << " " << frameIndex << " " << subFrameIndex << "
-        // "<< bunchId << " " << timestamp << " " << packetNumber << endl;
-        // cprintf(GREEN, "frame\n");
-        if (packetNumber >= 40) {
-            //*((int*)buff)=frameIndex;
-            if (insubframe == 0)
-                f0 = frameIndex;
-            memcpy(buff, &frameIndex, sizeof(int));
-            // length =
-            zmqsocket->ReceiveData(0, buff + sizeof(int), size);
-            mt->pushData(buff);
-            mt->nextThread();
-            mt->popFree(buff);
-            insubframe++;
-            nsubframes = frameIndex + 1 - f0;
-        } else {
-            cprintf(RED, "Incomplete frame: received only %d packet\n",
-                    packetNumber);
-            // length =
-            zmqsocket->ReceiveData(0, dummybuff, size);
-        }
+      mt->pushData(buff);
+      mt->nextThread();
+      mt->popFree(buff);
+      insubframe++;
+      nsubframes = frameIndex + 1 - f0;
+      // cout << "insubframe " << insubframe << endl;
+      // cout << "nsubframes " << nsubframes << endl;
+      // cout << "f0 " << f0 << endl;
+      // cout << "frameIndex " << frameIndex << endl;
 
-        if (subframes > 0 && insubframe >= subframes && fMode == eFrame) {
-            while (mt->isBusy()) {
-                ;
-            } // wait until all data are processed from the queues
-            detimage = mt->getImage(nnx, nny, nnsx, nnsy);
-            cprintf(MAGENTA, "Get image!\n");
-            dout = new int32_t[nnx * nny];
-            doutf = new float[nnx * nny];
-            if (subframes > 0 && insubframe != subframes && insubframe > 0)
-                subnorm = ((double)subframes) / ((double)insubframe);
-            else
-                subnorm = 1.;
-            for (int ix = 0; ix < nnx * nny; ix++) {
-                dout[ix] = detimage[ix] * subnorm;
-                if (dout[ix] < 0)
-                    dout[ix] = 0;
-                doutf[ix] = dout[ix];
-            }
-            sprintf(ofname, "%s_sf%ld_%ld.tiff", fname.c_str(), nnsubframe,
-                    fileindex);
+    } else {
+      cprintf(RED, "Incomplete frame: received only %d packet\n",
+	      packetNumber);
+      // length =
+      zmqsocket->ReceiveData(0, dummybuff, size);
+    }
 
-            cout << "Writing image to " << ofname << endl;
+    if (subframes > 0 && insubframe >= subframes &&
+	(fMode == eFrame || fMode == eRaw)) {
+      while (mt->isBusy()) {
+	;
+      } // wait until all data are processed from the queues
+      usleep(100);
 
-            WriteToTiff(doutf, ofname, nnx, nny);
-            nsubframes++;
-            insubframe = 0;
-            nnsubframe++;
+      detimage = mt->getImage(nnx, nny, nnsx, nnsy);
 
-            //   zmqsocket2->SendHeaderData (0,
-            //   false,SLS_DETECTOR_JSON_HEADER_VERSION , dr, fileindex,
-            //   1,1,nnx,nny,nnx*nny*dr/8,acqIndex, frameIndex, fname,acqIndex,0
-            //   , packetNumber,bunchId, timestamp, modId,xCoord, yCoord,
-            //   zCoord,debug, roundRNumber, detType, version, 0,0,
-            //   0,&additionalJsonHeader);
-            zHeader.data = true;
-            zmqsocket2->SendHeader(0, zHeader);
-            zmqsocket2->SendData((char *)dout, nnx * nny * dr / 8);
-            cprintf(GREEN, "Sent subdata\n");
+      cprintf(MAGENTA, "Get image!\n");
+      dout = new int32_t[nnx * nny];
+      doutf = new float[nnx * nny];
+      if (subframes > 0 && insubframe != subframes && insubframe > 0)
+	subnorm = ((double)subframes) / ((double)insubframe);
+      else
+	subnorm = 1.;
+      for (int ix = 0; ix < nnx * nny; ix++) {
+	dout[ix] = detimage[ix] * subnorm;
+	if (dout[ix] < 0)
+	  dout[ix] = 0;
+	doutf[ix] = dout[ix];
+      }
+      sprintf(ofname, "%s_sf%ld_%ld.tiff", fname.c_str(), nnsubframe,
+	      fileindex);
 
-            if (dout)
-                delete[] dout;
-            dout = NULL;
+      cout << "Writing image to " << ofname << endl;
 
-            if (doutf)
-                delete[] doutf;
-            doutf = NULL;
+      WriteToTiff(doutf, ofname, nnx, nny);
+      nsubframes++;
+      insubframe = 0;
+      nnsubframe++;
 
-            mt->clearImage();
-        }
+      //   zmqsocket2->SendHeaderData (0,
+      //   false,SLS_DETECTOR_JSON_HEADER_VERSION , dr, fileindex,
+      //   1,1,nnx,nny,nnx*nny*dr/8,acqIndex, frameIndex, fname,acqIndex,0
+      //   , packetNumber,detSpec1, timestamp, modId,xCoord, yCoord,
+      //   zCoord,detSpec3, detSpec4, detType, version, 0,0,
+      //   0,&additionalJsonHeader);
 
-        iframe++;
+      //  zmqsocket2->SendHeaderData (0,
+      //  false,SLS_DETECTOR_JSON_HEADER_VERSION , dr, fileindex,
+      //  1,1,nnx,nny,nnx*nny*dr/8,acqIndex, frameIndex, fname,acqIndex,0
+      //  , packetNumber,detSpec1, timestamp, modId,xCoord, yCoord,
+      //  zCoord,detSpec3, detSpec4, detType, version, 0,0,
+      //  0,&additionalJsonHeader);
 
-    } // exiting infinite loop
+      outHeader.data = true;
+      outHeader.dynamicRange = dr;
+      outHeader.fileIndex = fileindex;
+      outHeader.ndetx = 1;
+      outHeader.ndety = 1;
+      outHeader.npixelsx = nnx;
+      outHeader.npixelsy = nny;
+      outHeader.imageSize = nnx * nny * dr / 8;
+      outHeader.acqIndex = acqIndex;
+      outHeader.frameIndex = frameIndex;
+      outHeader.fname = fname;
+      outHeader.frameNumber = acqIndex;
+      outHeader.expLength = expLength;
+      outHeader.packetNumber = packetNumber;
+      outHeader.detSpec1 = detSpec1;
+      outHeader.timestamp = timestamp;
+      outHeader.modId = modId;
+      outHeader.row = xCoord;
+      outHeader.column = yCoord;
+      outHeader.detSpec3 = detSpec3;
+      outHeader.detSpec4 = detSpec4;
+      outHeader.detType = detType;
+      outHeader.version = version;
 
-    delete zmqsocket;
-    if (send)
-        delete zmqsocket2;
+      zmqsocket2->SendHeader(0, outHeader);
+      zmqsocket2->SendData((char *)dout, nnx * nny * dr / 8);
+      cprintf(GREEN, "Sent subdata\n");
 
-    cout << "Goodbye" << endl;
-    return 0;
+      if (dout)
+	delete[] dout;
+      dout = NULL;
+
+      if (doutf)
+	delete[] doutf;
+      doutf = NULL;
+
+      mt->clearImage();
+    }
+
+    iframe++;
+
+  } // exiting infinite loop
+
+  delete zmqsocket;
+  if (send)
+    delete zmqsocket2;
+
+  cout << "Goodbye" << endl;
+  return 0;
 }

--- a/slsDetectorCalibration/jungfrauExecutables/onlinedisp_zmq.cpp
+++ b/slsDetectorCalibration/jungfrauExecutables/onlinedisp_zmq.cpp
@@ -1,0 +1,679 @@
+#include "onlinedisp_zmq.h"
+bool  hasallpede;
+TH1F * his102;TH1F * his101;
+int processedf;
+sls::zmqHeader zHeader;
+#define PEDEFNAME "current_pede.dat"
+#define NPRO 50
+#define NPRI 50
+
+//#define JFSTRX
+#ifdef JFSTRX
+#include "jungfrauLGADStrixelsData.h"
+#else
+#include "jungfrauModuleData.h"
+#endif
+
+
+
+int main(int argc, char* argv[]) 
+{
+  goout=1;
+  hasallpede=false;
+  dophotonmap=true;  if ((argc<3)) {printf("USAGE: command photon_energy_(peakinADC) [rx_ip]  [port] \n"); return -1  ;}
+  else { 
+    phene=atoi(argv[1]);
+    if (phene<0) dophotonmap=false;
+    threshold=float (phene/2);
+    printf( " \n");
+    printf( "phene %d  \n",phene);
+  }
+  
+  if (argc>=3) {
+    strcpy(serverip,argv[2]);
+    printf("ip is %s ",serverip);
+  }
+
+  portnum=30001;
+  if (argc>=4 ){ portnum= atoi(argv[3]);
+  }
+  printf(", port number  is %d ",portnum);  printf(". \n"); 
+
+  
+#ifdef JFSTRX
+    cout << "JFSTRX" << endl;
+    jungfrauLGADStrixelsData *decoder = new jungfrauLGADStrixelsData();
+    nx = 1024/5; ny= 512*5;
+#else
+    nx = 1024; ny= 512;
+#endif
+
+
+
+
+  gain_flag=false;
+  pede_flag=false;
+  bw_flag=false;
+ 
+  HDraw_every=20;
+  fixranges=false;
+
+  
+  hchptr = (short*) malloc(NCH*sizeof(short)); 
+
+  startsocket(); //create and connect ZMQ 
+
+  for (ipx=0;ipx<NCH;ipx++) hchptr[(ipx)]=0;
+  
+  
+  //  cout<<   decoder->getValue((char*)(hchptr),279,130)<<endl;
+
+
+  nonblock(NB_ENABLE);
+
+  cout <<"opening the rootapp" <<endl;
+ 
+  rootapp = new TApplication("Online JF display",&argc, argv);
+ 
+  LoadPaletteFalse();
+
+  char hname[100];
+
+
+
+  his1000= new TH2F("his1000","2d , ev. pede corrected",nx,-0.5,nx-0.5,ny,-0.5,ny-0.5);
+  his1000->SetOption("colz");
+  his2000= new TH2F("his2000","2d gain ",nx,-0.5,nx-0.5,ny,-0.5,ny-0.5);
+  his2000->GetZaxis()->SetRangeUser(0,4);
+
+  if (dophotonmap) {
+    his3000= new TH2F("his3000"," photon map  ",nx,-0.5,nx-0.5,ny,-0.5,ny-0.5);
+  }
+  else {
+    his3000= new TH2F("his3000"," raw adc  ",nx,-0.5,nx-0.5,ny,-0.5,ny-0.5);
+  }
+ 
+  his4500= new TH2F("his45000","L vs R",101,-50,500,101,-50,500);
+  hchip=new TH1I*[8];
+  for (i=0;i<8;i++) {
+    sprintf(hname,"hchip%d",i);
+    hchip[i] = new TH1I(hname,hname,NBIN,MIN_POS,MAX_POS);
+  }
+
+  cout <<"end of histo booking" <<endl;
+  if  (A2==NULL)  A2 = new TCanvas("A2","Plotting Canvas gain",150,10,500,250);
+  if  (A3==NULL)  A3 = new TCanvas("A3","Plotting Canvas ADC",150,360,1200,550);
+  if  (A4==NULL)  A4 = new TCanvas("A4","Plotting Canvas PHs",750,300,1000,800);
+  A4->Clear();
+  A4->Divide(4,2,0.005,0.005);
+  if  (A5==NULL)  A5 = new TCanvas("A5","Plotting Canvas Photon Map",750,300,1000,600);
+  if  (A6==NULL)  A6 = new TCanvas("A6","Plotting Canvas LvsR",650,250,650,660);
+
+  gSystem->ProcessEvents();
+  int running=0;
+  char runc[15]="*\\-/|";
+  printhelp();
+ 
+ 
+ 
+  while (1==1) { // loop on streamed frames  
+
+    if(!zmqSocket->ReceiveHeader(0,zHeader,  SLS_DETECTOR_JSON_HEADER_VERSION)){
+      cout<< "Receiver stopped, waiting for new stream" << endl; 
+      zmqSocket->Disconnect();
+      zmqSocket->Connect();
+    }
+    else {
+	
+      //   if (((icount++)%10)==0) cout <<"recived frameindex "<<zHeader.frameIndex <<endl; 
+      //cout <<"there" <<endl;
+      zmqSocket->ReceiveData(0, (char *)(&image_data), NCH*2);
+    }
+
+    {
+
+      framesinstream++;
+      running++;
+     
+      fill1Ds=true; //alway fill 1d and LR plots 
+      //if  (((framesinstream%(int(HDraw_every)))==(int (HDraw_every)-1))) {fill1Ds=true;}else{fill1Ds=false;} 
+      if  (((framesinstream%(HDraw_every))==(HDraw_every)-1)) {show2Ds=true;}else{show2Ds=false;} 
+      if  (((framesinstream%NPRI)==NPRI-1))  { cout<<"\r   "<<"frame (from start):   "<<framesinstream<<" " << runc[((running/NPRI)%5)]<<  "   discarded frames %=" << (1-float(processedf)/float(zHeader.frameIndex-frameIndex_old))*100  << " current framenumber= "  <<zHeader.frameIndex  << "       "<<std::flush; processedf=0;frameIndex_old=zHeader.frameIndex;}
+
+ 
+      npacket=0;
+      if  (show2Ds)  {
+	his1000->Reset(); 
+	his2000->Reset(); 
+	if (!dophotonmap) his3000->Reset(); //FOR RAW ADC DISPLAY 
+      }
+
+
+      if ((fill1Ds)or(show2Ds)or(dophotonmap)) { // do something, otherwise skip to the next
+	processedf++;
+
+	for (i=0 ;i<NCH;i++) {
+      
+	  adcvalue= (image_data[i]) & 0x3fff;
+     
+	  if ((image_data[i] & 0xc000)!=0){ gain = (image_data[i]>>14) & 0x3;} else {gain=0;}
+	  if (pede_flag){
+	  
+	    if (gain_flag)
+	      {
+		if ((gain==0)||(!hasallpede)) adcpedecorr=(adcvalue&0x3fff)*fgaind[i]-fpeded[i]*fgaind[i];
+	  
+		if ((gain==1)&&hasallpede)  adcpedecorr=(fpedeG1d[i]*fgaind[i]+G1Poffset-adcvalue*fgaind[i])*30.0; 
+		if ((gain==3)&&hasallpede)  adcpedecorr=(fpedeG2d[i]*fgaind[i]+G2Poffset-adcvalue*fgaind[i])*340.0;
+	      }
+	    else
+
+	      {
+		  
+		if ((gain==0)||(!hasallpede))  adcpedecorr=(adcvalue&0x3fff)-fpeded[i];
+		if ((gain==1)&&hasallpede) adcpedecorr=(fpedeG1d[i]+G1Poffset-adcvalue)*30.0; 
+		if ((gain==3)&&hasallpede) adcpedecorr=(fpedeG2d[i]+G2Poffset-adcvalue)*340.0;
+	      }
+	 
+
+	  } else {adcpedecorr=float (adcvalue);}  //end of if pede 
+       
+
+      
+
+	  if ((adcpedecorr>threshold)&&(pede_flag))  hchptr[(i)]= hchptr[(i)]+(int)((adcpedecorr+threshold)/phene); 
+
+
+	  if (fill1Ds) {
+	    if (((i%1024)<1004)&&((i%1024)>20)&&((i/1024)>20)) { //skip the pix near guardring for PH plots
+	      ichip= i/(256*256*4)*4+((i/256)%4)  ;
+	   
+	      hchip[ichip]->Fill(adcpedecorr,1);
+	    
+	      if (((i%256)<253)&&((i%256)>2)) his4500->Fill(adcpedecorrold,adcpedecorr,1);
+	      adcpedecorrold=adcpedecorr;
+	    
+	    
+	    }
+	  }//if (fill1Ds)
+
+
+	
+
+	  if ((show2Ds)) {
+	    factor=2.0;
+	    value=adcpedecorr;
+	    if ((i%256==0)||(i%256==255)) value=int(value/factor);
+	    if ((i/1024==255)||(i/1024==256)||(i/1024==767)||(i/1024==768)) value=int(value/factor);
+
+	    his1000->Fill(float(i%1024),float(int (i/1024)),value);
+
+	    if (!dophotonmap) his3000->Fill(float(i%1024),float(int (i/1024)) ,adcvalue);
+	  
+	    his2000->Fill(float(i%1024),float(int (i/1024)) ,gain);
+
+	    value=(int)(hchptr[i]);
+	 
+	    if ((i%256==0)||(i%256==255)) value=int(value/factor);
+	    if ((i/1024==255)||(i/1024==256)||(i/1024==767)||(i/1024==768)) value=int(value/factor);
+	    if (dophotonmap) his3000->Fill(float(i%1024),float(int (i/1024)),float(value));
+
+	  }
+	}//   for (i=0 ;i<NCH-0;i++)
+      }// /end of do something 
+   
+
+
+      if   ((show2Ds)) {
+
+	for (ipx=0;ipx<NCH;ipx++) hchptr[(ipx)]=0;
+
+
+
+	Plot2DHistos();  Plot1DHistos();  
+      }
+   
+ 
+      ifp=kbhit();
+      processifp(ifp);
+     
+      if  (((framesinstream%NPRO))==NPRO-1) gSystem->ProcessEvents();
+	
+
+    }
+
+   
+
+  
+
+  }// end of infinite loop 
+
+  rootapp->Run();
+  nonblock(NB_DISABLE);
+  return 0;
+   
+
+}
+void processifp(int ifp){
+
+  if (ifp!=0){
+    c=fgetc(stdin);
+    if (c=='s') {if (goout==0){goout=1;}else {myloop();}}
+    if (c=='S') SetRanges();
+    if (c=='+') { HDraw_every=HDraw_every*0.8;cout<< endl <<"Drawing every "<< HDraw_every<<" frames "<<endl; }
+    if (c=='-') { HDraw_every=HDraw_every*1.25;cout<< endl <<"Drawing every "<< HDraw_every<<" frames "<<endl;}
+    if (c=='G') {gain_flag=not gain_flag ;if (gain_flag) {cout<<"gain corr enab."<< endl;}else {cout<<"gain corr disab."<< endl;}}
+    if (c=='[') { G1Poffset=G1Poffset-10;cout<< endl <<"G1Poffset "<<G1Poffset<<endl; }
+    if (c==']') { G1Poffset=G1Poffset+10;cout<< endl <<"G1Poffset "<<G1Poffset<<endl; }
+    if (c=='{') { G2Poffset=G2Poffset-10;cout<< endl <<"G2Poffset "<<G2Poffset<<endl; }
+    if (c=='}') { G2Poffset=G2Poffset+10;cout<< endl <<"G2Poffset "<<G2Poffset<<endl; }
+    if (c=='p') { //stopsocket();
+      loadpede();//startsocket();  
+    }
+    if (c=='b') {LoadPaletteBW(1.1111);bw_flag=true; } 
+    if (c=='B') {LoadPaletteBW(0.9);bw_flag=true; }
+    if (c=='O')  savepede();
+    if (c=='o')  readpede();
+    if (c=='P')  loadallpede(); 
+    if (c=='u')  his1000->SetOption("surf2z");
+    if (c=='C')  his1000->SetOption("colz");
+
+    if (c=='q') exit(0);
+    if (c=='r') historeset();
+    if (c=='R') axisreset();
+  }
+
+}
+void loadallpede(){
+  cout <<"not implemented "<< endl;
+  // hasallpede=true;
+ 
+  // system("./sls_detector_put  setbit 0x5d 12 "); //setting to FSG1 ;
+  
+  //  loadpede();
+  //  loadpede(); 
+  //  for (i=0;i<NCH;i++) {fpedeG1d[i]=fpeded[i];}
+
+  // system("./sls_detector_put  setbit 0x5d 13 "); //setting to FSG0 ;
+  // sleep(1);
+  // loadpede(); 
+  // loadpede(); 
+  // for (i=0;i<NCH;i++) {fpedeG2d[i]=fpeded[i];}
+  //   system("./sls_detector_put clearbit 0x5d 12  "); //setting to G0;
+  //   system("./sls_detector_put clearbit 0x5d 13  "); //setting to G0;
+  // sleep(2);
+
+  // loadpede(); 
+  // loadpede();
+
+
+
+
+
+}
+void loadpede(void){
+  //startsocket(); 
+  framesinstream=0;
+  pede_flag=true;
+  nframes=0;
+ 
+
+
+  for (ipx=0;ipx<NCH;ipx++) fpeded[ipx]=0; 
+  
+
+  
+  while (framesinstream<50) { // loop on files 
+
+
+    if (!zmqSocket->ReceiveHeader(0,zHeader,  SLS_DETECTOR_JSON_HEADER_VERSION)){ 
+      return;
+    }
+
+    cout <<"received frameindex "<<zHeader.frameIndex << endl; 
+ 
+    zmqSocket->ReceiveData(0,  (char *)(&image_data), NCH*2);
+    framesinstream++;nframes++;
+    for (ipx=0;ipx<NCH;ipx++) fpeded[ipx]=(fpeded[ipx]*(nframes-1)+(float)(image_data[ipx]&0x3fff))/(float)(nframes);
+  
+
+
+  }
+
+  for (ipx=0;ipx<NCH;ipx++) { ipeded[ipx]=(short)(fpeded[ipx]);
+    if (ipx%60033==0) printf("i=%d pede= %d  %f .\n",ipx, ipeded[ipx],fpeded[ipx]);
+  }
+  printf("total frames for pede: %d \n",nframes);
+  //stopsocket(); 
+
+  printhelp();
+}
+
+int kbhit()
+{
+  struct timeval tv;
+  fd_set fds;
+  tv.tv_sec = 0;
+  tv.tv_usec = 0;
+  FD_ZERO(&fds);
+  FD_SET(STDIN_FILENO, &fds); //STDIN_FILENO is 0
+  select(STDIN_FILENO+1, &fds, NULL, NULL, &tv);
+  return FD_ISSET(STDIN_FILENO, &fds);
+}
+void myloop(void){ //wait doing nothing.    
+  goout=0;
+  int ifp;
+ 
+ 
+  while (goout==0){
+   
+    ifp=kbhit();
+    processifp(ifp);
+
+
+    gSystem->ProcessEvents();
+    usleep(5000);
+
+  }
+}
+void printhelp(){
+  cout<< endl << "s=start/pause| p/n=getnewpede/raw | o/O=read/save pede | n=nopede(raw) | r/R=rst His/Axis | +/- = faster/slower ref. |q=exit | U/C sUrf2/Colz  " <<endl;
+}
+
+void historeset(){
+ 
+  his4500->Reset();
+  his3000->Reset();
+  for (i=0;i<8;i++) {
+    hchip[i]->Reset();
+  
+  }
+  Plot2DHistos();
+  Plot1DHistos();
+
+}
+
+void SetRanges() {
+  string str;
+  std::cin.clear();
+  //cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+
+  cout<< endl;
+  cout<<  " adc min " <<endl;
+  //getline(cin, str);
+  // adcmin= stoi(str);
+  std::cin >> adcmin;
+  cout<<  " adc max " <<endl;
+  std::cin >> adcmax;
+  cout<<  " p.map min " <<endl;
+  std::cin >> pmmin;
+  cout<<  " p.map max " <<endl;
+  std::cin >> pmmax;
+
+  fixranges=true;
+
+
+
+}
+
+
+void axisreset(){
+  fixranges=false;
+  his1000->GetXaxis()->UnZoom();
+
+  his1000->GetYaxis()->UnZoom();
+  his1000->GetZaxis()->UnZoom();
+  his2000->GetXaxis()->UnZoom();
+  his2000->GetYaxis()->UnZoom();
+
+  his3000->GetZaxis()->UnZoom();
+  
+  for (i=0;i<8;i++) {
+    hchip[i]->GetXaxis()->UnZoom();
+    hchip[i]->GetYaxis()->UnZoom();
+  }
+
+  his4500->GetXaxis()->UnZoom(); 
+  his4500->GetYaxis()->UnZoom(); 
+  his4500->GetZaxis()->UnZoom(); 
+  
+  Plot2DHistos();
+  Plot1DHistos();
+  
+
+}
+
+
+
+
+
+void nonblock(int state)
+{
+  struct termios ttystate;
+  //get the terminal state
+  tcgetattr(STDIN_FILENO, &ttystate);
+  if (state==NB_ENABLE)
+    {
+      //turn off canonical mode
+      ttystate.c_lflag &= ~ICANON;
+      //minimum of number input read.
+      ttystate.c_cc[VMIN] = 1;
+    }
+  else if (state==NB_DISABLE)
+    { //turn on canonical mode
+      ttystate.c_lflag |= ICANON;
+    }
+  //set the terminal attributes.
+  tcsetattr(STDIN_FILENO, TCSANOW, &ttystate); 
+}
+
+
+void LoadPaletteFalse(){
+  const Int_t NRGBs = 5;
+  const Int_t NCont = 90;
+
+  Double_t stops[NRGBs] = { 0.00, 0.34, 0.61, 0.84, 1.00 };
+  Double_t red[NRGBs]   = { 0.00, 0.00, 0.87, 1.00, 0.51 };
+  Double_t green[NRGBs] = { 0.00, 0.81, 1.00, 0.20, 0.00 };
+  Double_t blue[NRGBs]  = { 0.51, 1.00, 0.12, 0.00, 0.00 };
+  TColor::CreateGradientColorTable(NRGBs, stops, red,green, blue, NCont);
+  gStyle->SetNumberContours(NCont);
+  TColor::CreateGradientColorTable(NRGBs, stops, red,green  ,blue, NCont);
+  gStyle->SetNumberContours(NCont);
+
+}
+void LoadPaletteBW(float gammatune){
+
+  vgamma=vgamma*gammatune;
+  cout<< "gamma is "<<vgamma<<endl;
+  const Int_t NRGBs = 99;
+  const Int_t NCont = 990;
+  Double_t stops[NRGBs] ;
+  Double_t red[NRGBs]  ;
+  Double_t green[NRGBs];
+  Double_t blue[NRGBs] ;
+
+  for (int iRGB=0;iRGB<NRGBs;iRGB++){
+
+
+    stops[iRGB] =(1/float(NRGBs)*float(iRGB));
+    red[iRGB]   =  pow(stops[iRGB],vgamma);
+    green[iRGB] = red[iRGB];
+    blue[iRGB]  =red[iRGB];
+    //  cout << iRGB<<"  "<< stops[iRGB] <<" " << red[iRGB]<<endl;
+
+  }
+
+
+  TColor::CreateGradientColorTable(NRGBs, stops, red, green, blue, NCont);
+  gStyle->SetNumberContours(NCont);
+
+  
+
+  // TColor::SetPalette(52,0,1);
+
+}
+
+void Plot1DHistos(void){
+
+  if (hchip[0]->GetXaxis()->GetLast()!=oldh0xlast){
+    oldh0xlast=hchip[0]->GetXaxis()->GetLast();
+    oldh0xfirst=hchip[0]->GetXaxis()->GetFirst();
+    for (int ipad=1; ipad<8;ipad++) {
+      hchip[ipad]->GetXaxis()->SetRange(oldh0xfirst,oldh0xlast);
+     
+    
+    }
+  }    
+  
+
+  for (int ipad=0; ipad<8;ipad++) {
+    A4->cd(ipad+1);  
+    gStyle->SetOptStat(1);    gPad->SetLogy();
+     hchip[ipad%4+(1-int(ipad/4))*4]->Draw();
+  
+  }
+  A4->cd();
+  A4->Update();
+}
+
+
+void Plot2DHistos(void){
+  gStyle->SetOptStat(0);
+  A3->cd();
+
+  //  if (bw_flag) LoadPaletteBW(1.0);
+
+  if (fixranges) {
+
+    his1000->GetZaxis()->SetRangeUser(float(adcmin),float(adcmax));
+    his3000->GetZaxis()->SetRangeUser(float(pmmin),float(pmmax));
+    
+
+  }
+
+  his1000->SetMinimum(-200);
+  his1000->Draw();
+
+  A3->Update();
+  A2->cd();
+  // if (bw_flag)  LoadPaletteFalse();
+  his2000->GetXaxis()->SetRange(his1000->GetXaxis()->GetFirst(),his1000->GetXaxis()->GetLast());
+  his2000->GetYaxis()->SetRange(his1000->GetYaxis()->GetFirst(),his1000->GetYaxis()->GetLast());
+
+  his2000->Draw("colz"); 
+  A2->Update(); 
+  A5->cd();
+
+  his3000->GetXaxis()->SetRange(his1000->GetXaxis()->GetFirst(),his1000->GetXaxis()->GetLast());
+  his3000->GetYaxis()->SetRange(his1000->GetYaxis()->GetFirst(),his1000->GetYaxis()->GetLast());
+  his3000->Draw("colz");
+  A5->Update();
+ 
+  A6->cd();
+  his4500->Draw("colz");
+  A6->Update();
+  
+
+
+}
+
+
+void startsocket(void) {
+
+
+
+
+  try {
+    zmqSocket = new sls::ZmqSocket(serverip, portnum);
+
+  } catch (...) {
+    cprintf(RED,
+	    "Error: Could not create Zmq socket on port %d with ip %s\n",
+	    portnum, serverip);
+    delete zmqSocket;
+    return;
+  }
+  zmqSocket->SetReceiveHighWaterMark(3);
+  zmqSocket->SetReceiveBuffer(1024*1024); 
+  zmqSocket->Connect();
+
+
+  cout<<"Zmq Client[] "<< zmqSocket->GetZmqServerAddress()<<endl;
+
+
+  haveconnection=true;
+ 
+ 
+
+
+}
+
+
+
+ 
+
+void tryconnect(void) 
+
+{
+  int itry=0;
+  cout<< endl;
+ 
+  
+
+  while (haveconnection==false) {
+    sleep(1);
+    cout<<"\r trying to (re)connect " <<itry++ << " " << endl ; 
+    startsocket();
+  }
+
+}
+
+void stopsocket(void) {
+  // cout<<" cfd " << cfd << endl;; 
+  
+   
+
+  delete zmqSocket;
+  zmqSocket=0;
+  //zmqSocket->~ZmqSocket ();
+
+    
+
+  haveconnection=false;
+
+    
+  
+
+}
+void savepede(void) {
+
+  int pfd;
+
+  pfd=open(PEDEFNAME,O_CREAT|O_WRONLY, 0666);
+  if (pfd==-1) perror("open pede file");
+   
+  write(pfd,fpeded,2*NCH*sizeof(float));
+  write(pfd,fpedeG1d,2*NCH*sizeof(float));
+  write(pfd,fpedeG2d,2*NCH*sizeof(float));
+  close(pfd);
+ 
+}
+
+void readpede(void) {
+
+  int pfd;
+
+  pfd=open(PEDEFNAME,O_RDONLY);
+  if (pfd==-1) perror("open pede file");
+   
+  read(pfd,fpeded,NCH*2*sizeof(float));
+  read(pfd,fpedeG1d,NCH*2*sizeof(float));
+  read(pfd,fpedeG2d,NCH*2*sizeof(float));
+   
+  close(pfd);
+  pede_flag=true;
+  hasallpede=true;
+
+}
+

--- a/slsDetectorCalibration/jungfrauExecutables/onlinedisp_zmq.h
+++ b/slsDetectorCalibration/jungfrauExecutables/onlinedisp_zmq.h
@@ -1,0 +1,204 @@
+
+/**************************************************************************/
+/* Header files   section needs cleanup                     */
+/**************************************************************************/
+#include <stdio.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include "sls/ZmqSocket.h"
+
+#include "sls/tiffIO.h"
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <stdlib.h>  /* exit() */
+#include <string.h>  /* memset(), memcpy() */
+#include <sys/utsname.h>   /* uname() */
+#include <sys/types.h>
+#include <sys/socket.h>   /* socket(), bind(),
+			     listen(), accept() */
+#include <sys/time.h>
+#include <sys/types.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <unistd.h>  /* fork(), write(), close() */
+#include <time.h> 
+#include <sys/time.h>
+#include <sys/mman.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <cmath>
+#include <sys/stat.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <rapidjson/document.h> //json header in zmq stream
+#include <omp.h>
+#define NTHREADS 2
+
+#include <chrono>
+#include <cstdio>
+#include <ctime> // time_t
+
+using namespace std;
+using namespace std::chrono;
+using namespace sls;
+
+#include "TCanvas.h"
+#include "TH1F.h"
+#include "TF1.h"
+#include "TH2F.h"
+#include "TMath.h"
+#include "TFile.h"
+#include "TStyle.h"
+#include "TSystem.h"
+#include "TTimer.h"
+#include "TProfile.h"
+#include "TColor.h"
+#include <iostream>
+#include <fstream> 
+#include <termios.h>
+#include <TApplication.h>
+#include <stdio.h>
+#include <math.h>
+#include <fstream>
+#include <iomanip>
+#include <sstream>
+#include <string>
+#include <vector>
+#include <iostream>
+#include "sls/ansi.h"
+#define SLS_DETECTOR_JSON_HEADER_VERSION 0x4
+
+#define PI 3.14159265
+
+#define FALSE              0
+#define OFFSET 0
+#define NBIN 500  
+#define MIN_POS  -500.5   // 400.5   
+#define MAX_POS 3499.5   //-100.5
+
+
+#define NCH 524288
+// #define NCH 262144 in case of half_frames 
+
+char serverip[256];
+int portnum;
+FILE * sfilefd;
+
+short* hchptr; // photon counted map "histogram"
+int value;
+float factor=1.84;
+int npacket=0;
+int totalnpacket=0;
+float vgamma;
+ 
+struct sockaddr_in serveraddr;
+struct sockaddr_in clientaddr;
+struct in_addr      inadr;
+struct hostent      *server;
+ 
+int i=0;
+int ipx=0;
+bool haveconnection;
+
+
+TStyle *gStyle;
+TApplication* rootapp;
+TCanvas *A2;
+TCanvas *A3;
+TCanvas *A4;
+TCanvas *A5;
+TCanvas *A6;
+
+TH1I **hchip;
+TH2F **h4500chip;
+short image_data[NCH*2];
+short imaged[NCH*2];
+float fpeded[NCH*2];
+float fpedeG2d[NCH*2];
+float fpedeG1d[NCH*2];
+short ipeded[NCH*2];
+short pcimaged[NCH*2];
+
+float fgaind[NCH*2];
+
+
+float  adcpedecorr,adcpedecorrold;
+
+bool gain_flag;
+bool bw_flag;
+bool fill2Ds;
+bool show2Ds;
+bool fill1Ds;
+bool pede_flag;
+bool dophotonmap;
+
+int nx, ny;
+int nframes;
+int goout;
+int framesinstream;
+int ifp;
+float threshold;
+int phene;
+int  adcvalue;
+int gain;
+int ichip;
+int frameIndex_old;
+
+char pedefilename[128];
+int  framenum,bunchid;
+
+TH2F* his1000;
+TH2F* his2000;
+TH2F* his3000;
+TH2F* his4500;
+TH1I* hproj;
+TH1I* hchcum;
+
+
+using namespace std;
+void printhelp(void);
+void processifp(int ifp);
+void historeset(void);
+void SetRanges(void);
+void startsocket(void);
+void stopsocket(void);
+void axisreset(void);
+int kbhit(void);
+void myloop(void);   
+void loadpede(void);
+void loadallpede(void);
+void loadgain(void);
+void nonblock(int state);
+void LoadPaletteFalse(void);
+void LoadPaletteBW(float);
+void Plot1DHistos(void);
+void Plot2DHistos(void);
+void savepede(void);
+void readpede(void);
+int findinterpoindex(int startindex);
+int findclumax(int startindex);
+void tryconnect(void) ;
+
+#define NB_ENABLE 1 
+#define NB_DISABLE 0
+char c; 
+int HDraw_every;
+
+
+float  oldh0xfirst,oldh0xlast;
+int idx;
+int GXPoffset,G1Poffset,G2Poffset;
+int ix,iy;
+int adcmin,adcmax;
+int pmmin,pmmax; //min/mnx for the photon map
+bool fixranges;
+
+
+sls::ZmqSocket *zmqSocket= NULL;

--- a/slsDetectorGui/include/qDrawPlot.h
+++ b/slsDetectorGui/include/qDrawPlot.h
@@ -60,6 +60,7 @@ class qDrawPlot : public QWidget, private Ui::PlotObject {
     void SavePlot();
     void SetGapPixels(bool enable);
     void UpdatePlot();
+
   protected:
     void resizeEvent(QResizeEvent *event);
 

--- a/slsDetectorGui/include/qDrawPlot.h
+++ b/slsDetectorGui/include/qDrawPlot.h
@@ -59,7 +59,7 @@ class qDrawPlot : public QWidget, private Ui::PlotObject {
     void ClonePlot();
     void SavePlot();
     void SetGapPixels(bool enable);
-
+    void UpdatePlot();
   protected:
     void resizeEvent(QResizeEvent *event);
 
@@ -67,7 +67,7 @@ class qDrawPlot : public QWidget, private Ui::PlotObject {
     void Zoom1DGainPlot(const QRectF &rect);
     void Zoom2DGainPlot(const QRectF &rect);
     void SetSaveFileName(QString val);
-    void UpdatePlot();
+    //    void UpdatePlot();
 
   signals:
     void AcquireFinishedSignal();

--- a/slsDetectorGui/src/qTabPlot.cpp
+++ b/slsDetectorGui/src/qTabPlot.cpp
@@ -441,7 +441,6 @@ void qTabPlot::SetXRange() {
         MaintainAspectRatio(static_cast<int>(slsDetectorDefs::Y));
     } else {
         SetXYRange();
-	
     }
 }
 
@@ -627,7 +626,6 @@ void qTabPlot::SetZRange() {
     }
     plot->SetZRange(zRange, isZRange);
     plot->UpdatePlot();
-
 }
 
 void qTabPlot::GetStreamingFrequency() {

--- a/slsDetectorGui/src/qTabPlot.cpp
+++ b/slsDetectorGui/src/qTabPlot.cpp
@@ -441,6 +441,7 @@ void qTabPlot::SetXRange() {
         MaintainAspectRatio(static_cast<int>(slsDetectorDefs::Y));
     } else {
         SetXYRange();
+	
     }
 }
 
@@ -487,6 +488,7 @@ void qTabPlot::SetXYRange() {
     }
 
     plot->SetXYRangeChanged(disablezoom, xyRange, isRange);
+    plot->UpdatePlot();
     emit DisableZoomSignal(disablezoom);
 }
 
@@ -624,6 +626,8 @@ void qTabPlot::SetZRange() {
         zRange[1] = val;
     }
     plot->SetZRange(zRange, isZRange);
+    plot->UpdatePlot();
+
 }
 
 void qTabPlot::GetStreamingFrequency() {

--- a/slsDetectorSoftware/src/DetectorImpl.cpp
+++ b/slsDetectorSoftware/src/DetectorImpl.cpp
@@ -557,14 +557,7 @@ void DetectorImpl::createReceivingDataSockets() {
             int hwm = shm()->zmqHwm;
             if (hwm >= 0) {
                 zmqSocket[iSocket]->SetReceiveHighWaterMark(hwm);
-                if (zmqSocket[iSocket]->GetReceiveHighWaterMark() != hwm) {
-                    throw ZmqSocketError("Could not set zmq rcv hwm to " +
-                                         std::to_string(hwm));
-                }
-                if (hwm < DEFFAULT_LOW_HWM) {
-                    //1MB (or the OS buffering deafeat the HWL purpose
-                    zmqSocket[iSocket]->SetReceiveBuffer(DEFAULT_LOW_HWM_BUFFERSIZE); 
-                }
+                // need not reconnect. cannot be connected (detector idle)
             }
             LOG(logINFO) << "Zmq Client[" << iSocket << "] at "
                          << zmqSocket.back()->GetZmqServerAddress() << "[hwm: "
@@ -1152,11 +1145,7 @@ void DetectorImpl::setClientStreamingHwm(const int limit) {
         if (limit >= 0) {
             for (auto &it : zmqSocket) {
                 it->SetReceiveHighWaterMark(limit);
-                if (it->GetReceiveHighWaterMark() != limit) {
-                    shm()->zmqHwm = -1;
-                    throw ZmqSocketError("Could not set zmq rcv hwm to " +
-                                         std::to_string(limit));
-                }
+                // need not reconnect. cannot be connected (detector idle)
             }
             LOG(logINFO) << "Setting Client Zmq socket rcv hwm to " << limit;
         }

--- a/slsDetectorSoftware/src/DetectorImpl.h
+++ b/slsDetectorSoftware/src/DetectorImpl.h
@@ -351,8 +351,8 @@ class DetectorImpl : public virtual slsDetectorDefs {
 
     void updateDetectorSize();
 
-    int destroyReceivingDataSockets();
-    int createReceivingDataSockets();
+    void destroyReceivingDataSockets();
+    void createReceivingDataSockets();
 
     /**
      * Reads frames from receiver through a constant socket

--- a/slsDetectorSoftware/src/DetectorImpl.h
+++ b/slsDetectorSoftware/src/DetectorImpl.h
@@ -84,9 +84,7 @@ class DetectorImpl : public virtual slsDetectorDefs {
      */
     virtual ~DetectorImpl();
 
-    template <class CT> struct NonDeduced {
-        using type = CT;
-    };
+    template <class CT> struct NonDeduced { using type = CT; };
     template <typename RT, typename... CT>
     Result<RT> Parallel(RT (Module::*somefunc)(CT...),
                         std::vector<int> positions,

--- a/slsReceiverSoftware/src/DataStreamer.cpp
+++ b/slsReceiverSoftware/src/DataStreamer.cpp
@@ -91,17 +91,8 @@ void DataStreamer::CreateZmqSockets(uint32_t port, const IpAddr ip, int hwm) {
         // set if custom
         if (hwm >= 0) {
             zmqSocket->SetSendHighWaterMark(hwm);
-            if (zmqSocket->GetSendHighWaterMark() != hwm) {
-                throw RuntimeError(
-                    "Could not set zmq send high water mark to " +
-                    std::to_string(hwm));
-            }
-            if (hwm < DEFFAULT_LOW_HWM) {
-                //1MB (or the OS buffering deafeat the HWL purpose
-                zmqSocket->SetSendBuffer(DEFAULT_LOW_HWM_BUFFERSIZE); 
-            }
-            //needed, or HWL is not taken  
-            zmqSocket->Rebind(); 
+            // needed, or HWL is not taken
+            zmqSocket->Rebind();
         }
     } catch (std::exception &e) {
         std::ostringstream oss;

--- a/slsReceiverSoftware/src/DataStreamer.cpp
+++ b/slsReceiverSoftware/src/DataStreamer.cpp
@@ -87,6 +87,7 @@ void DataStreamer::CreateZmqSockets(uint32_t port, const IpAddr ip, int hwm) {
     std::string sip = ip.str();
     try {
         zmqSocket = new ZmqSocket(portnum, (ip != 0 ? sip.c_str() : nullptr));
+
         // set if custom
         if (hwm >= 0) {
             zmqSocket->SetSendHighWaterMark(hwm);
@@ -95,15 +96,18 @@ void DataStreamer::CreateZmqSockets(uint32_t port, const IpAddr ip, int hwm) {
                     "Could not set zmq send high water mark to " +
                     std::to_string(hwm));
             }
-	    if (hwm <25) {
-	      zmqSocket->SetSendBuffer(1024*1024); //1MB (or the OS buffering deafeat the HWL purpose
-	    }
-	    zmqSocket->Rebind(); //needed, or HWL is not taken  
+            if (hwm < DEFFAULT_LOW_HWM) {
+                //1MB (or the OS buffering deafeat the HWL purpose
+                zmqSocket->SetSendBuffer(DEFAULT_LOW_HWM_BUFFERSIZE); 
+            }
+            //needed, or HWL is not taken  
+            zmqSocket->Rebind(); 
         }
-    } catch (...) {
-        LOG(logERROR) << "Could not create Zmq socket on port " << portnum
-                      << " for Streamer " << index;
-        throw;
+    } catch (std::exception &e) {
+        std::ostringstream oss;
+        oss << "Could not create zmq pub socket on port " << portnum;
+        oss << " [" << e.what() << ']';
+        throw RuntimeError(oss.str());
     }
     LOG(logINFO) << index << " Streamer: Zmq Server started at "
                  << zmqSocket->GetZmqServerAddress()

--- a/slsReceiverSoftware/src/DataStreamer.cpp
+++ b/slsReceiverSoftware/src/DataStreamer.cpp
@@ -95,6 +95,10 @@ void DataStreamer::CreateZmqSockets(uint32_t port, const IpAddr ip, int hwm) {
                     "Could not set zmq send high water mark to " +
                     std::to_string(hwm));
             }
+	    if (hwm <25) {
+	      zmqSocket->SetSendBuffer(1024*1024); //1MB (or the OS buffering deafeat the HWL purpose
+	    }
+	    zmqSocket->Rebind(); //needed, or HWL is not taken  
         }
     } catch (...) {
         LOG(logERROR) << "Could not create Zmq socket on port " << portnum

--- a/slsSupportLib/include/sls/ZmqSocket.h
+++ b/slsSupportLib/include/sls/ZmqSocket.h
@@ -32,8 +32,8 @@ namespace sls {
 #define ROIVERBOSITY
 
 // high water mark for gui
-#define DEFFAULT_LOW_HWM (25)
-#define DEFAULT_LOW_HWM_BUFFERSIZE (1024 * 1024)
+#define DEFFAULT_LOW_HWM           (25)
+#define DEFAULT_LOW_HWM_BUFFERSIZE (1024 * 1024) // 1MB
 
 /** zmq header structure */
 struct zmqHeader {
@@ -112,23 +112,28 @@ class ZmqSocket {
     /** Returns high water mark for outbound messages */
     int GetSendHighWaterMark();
 
-    /** Sets high water mark for outbound messages. Default 1000 (zmqlib) */
+    /** Sets high water mark for outbound messages. Default 1000 (zmqlib). Also
+     * changes send buffer size depending on low hwm. Must rebind.  */
     void SetSendHighWaterMark(int limit);
 
     /** Returns high water mark for inbound messages */
     int GetReceiveHighWaterMark();
 
-    /** Sets high water mark for inbound messages. Default 1000 (zmqlib) */
+    /** Sets high water mark for inbound messages. Default 1000 (zmqlib). Also
+     * changes receiver buffer size depending on low hwm. Must reconnect */
     void SetReceiveHighWaterMark(int limit);
 
- /** Sets kernel buffer for  outbound messages. Default Unknown */
+    /** Gets kernel buffer for  outbound messages. Default 0 (os) */
+    int GetSendBuffer();
+
+    /** Sets kernel buffer for  outbound messages. Default 0 (os) */
     void SetSendBuffer(int limit);
 
-/** Sets kernel buffer for  inbound messages. Default Unknown */
-    void SetReceiveBuffer(int limit);
+    /** Gets kernel buffer for  inbound messages. Default 0 (os) */
+    int GetReceiveBuffer();
 
-    /** unbinds and rebind, to apply changes of HWM  */
-    void Rebind();
+    /** Sets kernel buffer for  inbound messages. Default 0 (os) */
+    void SetReceiveBuffer(int limit);
 
     /**
      * Returns Port Number
@@ -141,6 +146,9 @@ class ZmqSocket {
      * @returns Server Address
      */
     std::string GetZmqServerAddress() { return sockfd.serverAddress; }
+
+    /** unbinds and rebind, to apply changes of HWM  */
+    void Rebind();
 
     /**
      * Connect client socket to server socket

--- a/slsSupportLib/include/sls/ZmqSocket.h
+++ b/slsSupportLib/include/sls/ZmqSocket.h
@@ -117,6 +117,15 @@ class ZmqSocket {
     /** Sets high water mark for inbound messages. Default 1000 (zmqlib) */
     void SetReceiveHighWaterMark(int limit);
 
+ /** Sets kernel buffer for  outbound messages. Default Unknown */
+    void SetSendBuffer(int limit);
+
+/** Sets kernel buffer for  inbound messages. Default Unknown */
+    void SetReceiveBuffer(int limit);
+
+    /** unbinds and rebind, to apply changes of HWM  */
+    void Rebind();
+
     /**
      * Returns Port Number
      * @returns Port Number

--- a/slsSupportLib/include/sls/ZmqSocket.h
+++ b/slsSupportLib/include/sls/ZmqSocket.h
@@ -31,6 +31,10 @@ namespace sls {
 // #define ZMQ_DETAIL
 #define ROIVERBOSITY
 
+// high water mark for gui
+#define DEFFAULT_LOW_HWM (25)
+#define DEFAULT_LOW_HWM_BUFFERSIZE (1024 * 1024)
+
 /** zmq header structure */
 struct zmqHeader {
     /** true if incoming data, false if end of acquisition */

--- a/slsSupportLib/src/ZmqSocket.cpp
+++ b/slsSupportLib/src/ZmqSocket.cpp
@@ -104,6 +104,23 @@ void ZmqSocket::SetSendHighWaterMark(int limit) {
     }
 }
 
+void ZmqSocket::SetSendBuffer(int limit) {
+    if (zmq_setsockopt(sockfd.socketDescriptor, ZMQ_SNDBUF, &limit,
+                       sizeof(limit))) {
+        PrintError();
+        throw ZmqSocketError("Could not set ZMQ_SNDBUF");
+    }
+}
+
+void ZmqSocket::SetReceiveBuffer(int limit) {
+    if (zmq_setsockopt(sockfd.socketDescriptor, ZMQ_RCVBUF, &limit,
+                       sizeof(limit))) {
+        PrintError();
+        throw ZmqSocketError("Could not set ZMQ_RCVBUF");
+    }
+}
+
+
 int ZmqSocket::GetReceiveHighWaterMark() {
     int value = 0;
     size_t value_size = sizeof(value);
@@ -122,6 +139,22 @@ void ZmqSocket::SetReceiveHighWaterMark(int limit) {
         throw ZmqSocketError("Could not set ZMQ_SNDHWM");
     }
 }
+
+void ZmqSocket::Rebind() { // the purpose is to apply HWL changes, which are frozen at bind, which is in the constructor.
+
+    //    unbbind
+    if (zmq_unbind(sockfd.socketDescriptor, sockfd.serverAddress.c_str())) {
+        PrintError();
+        throw ZmqSocketError("Could not unbind socket");
+    }
+// bind address
+    if (zmq_bind(sockfd.socketDescriptor, sockfd.serverAddress.c_str())) {
+        PrintError();
+        throw ZmqSocketError("Could not bind socket");
+    }
+
+}
+
 
 int ZmqSocket::Connect() {
     if (zmq_connect(sockfd.socketDescriptor, sockfd.serverAddress.c_str())) {

--- a/slsSupportLib/tests/test-container_utils.cpp
+++ b/slsSupportLib/tests/test-container_utils.cpp
@@ -136,19 +136,18 @@ TEST_CASE("compare a vector of arrays", "[support]") {
     CHECK(minusOneIfDifferent(vec1) == arr);
 }
 
-TEST_CASE("remove duplicates from vector"){
-    std::vector<int> v{5,6,5,3};
+TEST_CASE("remove duplicates from vector") {
+    std::vector<int> v{5, 6, 5, 3};
     auto r = removeDuplicates(v);
-    CHECK(r == true); //did indeed remove elements
-    CHECK( v == std::vector<int>{3,5,6});
+    CHECK(r == true); // did indeed remove elements
+    CHECK(v == std::vector<int>{3, 5, 6});
 }
 
-TEST_CASE("remove duplicated empty vector"){
+TEST_CASE("remove duplicated empty vector") {
     std::vector<int> v;
     auto r = removeDuplicates(v);
-    CHECK(r == false); //no elements to remove
-    CHECK( v == std::vector<int>{});
+    CHECK(r == false); // no elements to remove
+    CHECK(v == std::vector<int>{});
 }
-
 
 } // namespace sls


### PR DESCRIPTION
- modifications in slsDetectorCalibration for jungfrau

gui: 
   - X, Y or Z range changed will call UpdatePlot from tabPlot directly

Client: 
   - minor refactoring that create/destroy zmq sockets use exceptions instead of returning ok or fail, creating zmq sockets exception message adds port number.

Receiver:
   -  minor refactoring when creating zmq sockets: exception message adds port number.
   - when creating zmq sockets, If hwm<25, rebind when changing hwm
  
Zmq Support lib:
   - added functions to set send and receiver buffer limits and to rebind zmq pub socket.
   - setting hwm < 25, also sets the zmq rx or snd buffer size to 1MB