### PR TITLE
fixed linking issue in arping and failing shm test

### DIFF
--- a/slsDetectorSoftware/tests/test-SharedMemory.cpp
+++ b/slsDetectorSoftware/tests/test-SharedMemory.cpp
@@ -101,7 +101,7 @@ TEST_CASE("Move SharedMemory", "[detector]") {
     shm2 = std::move(shm); // shm is now a moved from object!
 
     CHECK(shm2()->x == 9);
-    CHECK(shm() == nullptr);
+    REQUIRE_THROWS(shm()); // trying to access should throw instead of returning a nullptr
     CHECK(shm2.getName() == std::string("/slsDetectorPackage_detector_") +
                                 std::to_string(shm_id));
     shm2.removeSharedMemory();

--- a/slsReceiverSoftware/src/Arping.cpp
+++ b/slsReceiverSoftware/src/Arping.cpp
@@ -85,8 +85,8 @@ void Arping::ProcessExecution() {
         if (!error.empty()) {
             LOG(logERROR) << error;
         }
-
-        std::this_thread::sleep_for(std::chrono::seconds(timeIntervalSeconds));
+        const auto interval = std::chrono::seconds(60);
+        std::this_thread::sleep_for(interval);
     }
 }
 

--- a/slsReceiverSoftware/src/Arping.h
+++ b/slsReceiverSoftware/src/Arping.h
@@ -36,7 +36,6 @@ class Arping {
         std::vector<std::string>(MAX_NUMBER_OF_LISTENING_THREADS);
     std::atomic<bool> runningFlag{false};
     std::atomic<pid_t> childPid{0};
-    static const int timeIntervalSeconds = 60;
 };
 
 } // namespace sls


### PR DESCRIPTION
Addresses two issues:

- one of the shm tests were failing since we throw on trying to get shm when it holds a nullptr. --> updated test
- linking issue in debug build of arping --> moved unnecessary static member to a local variable