### PR TITLE
Fix stop rx stuck

### DIFF
--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -441,6 +441,12 @@ This document describes the differences between v7.0.0.rc1 and v6.1.2
         cannot stop, even though it was successful. It is fixed now.
 
 
+    *   Stop detector when receiver is stuck
+        If receiver was stuck or crashed, stop acquisition command should
+        stop detector first before checking receiver status to restream 
+        dummy header. Fixed. 
+
+
     *   Free and config command fail
         Free and config command checked mismatch of size of shared memory before 
         freeing or loading new config. Fixed.

--- a/slsDetectorSoftware/src/DetectorImpl.cpp
+++ b/slsDetectorSoftware/src/DetectorImpl.cpp
@@ -1224,8 +1224,7 @@ int DetectorImpl::acquire() {
         // let the progress thread (no callback) know acquisition is done
         if (dataReady == nullptr) {
             setJoinThreadFlag(true);
-        }
-        if (receiver) {
+        } else if (receiver) {
             while (numZmqRunning != 0) {
                 Parallel(&Module::restreamStopFromReceiver, {});
                 std::this_thread::sleep_for(std::chrono::milliseconds(200));
@@ -1315,6 +1314,7 @@ void DetectorImpl::processData(bool receiver) {
         }
         // only update progress
         else {
+            LOG(logINFO) << "Type 'q' and hit enter to stop";
             double progress = 0;
             printProgress(progress);
 


### PR DESCRIPTION
stop should really stop even if receiver had crashed, so check rx status after sending stop; 
also ensuring restream  in acquire happens only if thers a callback