### PR TITLE
Fixed build of the moenchZmqExecutables

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Configure CMake
         # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
         # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DSLS_USE_TESTS=ON -DSLS_USE_HDF5=ON -DSLS_USE_GUI=ON
+        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DSLS_USE_TESTS=ON -DSLS_USE_HDF5=ON -DSLS_USE_GUI=ON -DSLS_USE_MOENCH=ON
 
       - name: Build
         # Build your program with the given configuration

--- a/slsDetectorCalibration/analogDetector.h
+++ b/slsDetectorCalibration/analogDetector.h
@@ -220,7 +220,7 @@ template <class dataType> class analogDetector {
        clone. Must be virtual!
        \returns a clone of the original analog detector
      */
-    virtual analogDetector *Clone() { return new analogDetector(this); }
+    virtual analogDetector *Clone() = 0;
 
     /**
        Gives an id to the structure. For debugging purposes in case of
@@ -1097,8 +1097,7 @@ template <class dataType> class analogDetector {
         return thr;
     };
 
-    virtual int setClusterSize(int n = -1) { 
-    };
+    virtual int setClusterSize(int n = -1) = 0;
 
     /**
        gets threshold value for conversion into number of photons

--- a/slsDetectorCalibration/interpolations/eta2InterpolationBase.h
+++ b/slsDetectorCalibration/interpolations/eta2InterpolationBase.h
@@ -23,7 +23,7 @@ class eta2InterpolationBase : public virtual etaInterpolationBase {
               /* if (etamin>=etamax) { */
               /*   etamin=-1; */
               /*   etamax=2;  */
-              /*   //  cout << ":" <<endl; */
+              /*   //  std::cout << ":" <<endl; */
               /* } */
               /* etastep=(etamax-etamin)/nbeta; */
 
@@ -164,7 +164,7 @@ class eta2InterpolationBase : public virtual etaInterpolationBase {
             dY = -1.;
             break;
         default:
-            cout << "bad quadrant" << endl;
+            std::cout << "bad quadrant" << std::endl;
             dX = 0.;
             dY = 0.;
         }
@@ -174,19 +174,19 @@ class eta2InterpolationBase : public virtual etaInterpolationBase {
             ex = (etax - etamin) / etastepX;
             ey = (etay - etamin) / etastepY;
             if (ex < 0) {
-                cout << "x*" << ex << endl;
+                std::cout << "x*" << ex << std::endl;
                 ex = 0;
             }
             if (ex >= nbetaX) {
-                cout << "x?" << ex << endl;
+                std::cout << "x?" << ex << std::endl;
                 ex = nbetaX - 1;
             }
             if (ey < 0) {
-                cout << "y*" << ey << " " << nbetaY << endl;
+                std::cout << "y*" << ey << " " << nbetaY << std::endl;
                 ey = 0;
             }
             if (ey >= nbetaY) {
-                cout << "y?" << ey << " " << nbetaY << endl;
+                std::cout << "y?" << ey << " " << nbetaY << std::endl;
                 ey = nbetaY - 1;
             }
 
@@ -236,7 +236,7 @@ class eta2InterpolationBase : public virtual etaInterpolationBase {
         // calcMyEta(totquad,quad,cl,etax, etay);
         calcEta(totquad, cc, etax, etay);
 
-        //     cout <<"******"<< etax << " " << etay << endl;
+        //     std::cout <<"******"<< etax << " " << etay << std::endl;
 
         return addToFlatFieldDistribution(etax, etay);
     }
@@ -270,16 +270,16 @@ class eta2InterpolationBase : public virtual etaInterpolationBase {
     /*     cc[0][1] = cl[yoff * 3 + xoff + 1]; */
     /*     cc[1][1] = cl[(yoff + 1) * 3 + xoff + 1]; */
 
-    /*     /\* cout << cl[0] << " " << cl[1] << " " << cl[2] << endl;   *\/ */
-    /*     /\* cout << cl[3] << " " << cl[4] << " " << cl[5] << endl;   *\/ */
-    /*     /\* cout << cl[6] << " " << cl[7] << " " << cl[8] << endl;   *\/ */
-    /*     /\* cout <<"******"<<totquad << " " << quad << endl;  *\/ */
-    /*     /\* cout << cc[0][0]<< " " << cc[0][1] << endl;  *\/ */
-    /*     /\* cout << cc[1][0]<< " " << cc[1][1] << endl;  *\/ */
+    /*     /\* std::cout << cl[0] << " " << cl[1] << " " << cl[2] << std::endl;   *\/ */
+    /*     /\* std::cout << cl[3] << " " << cl[4] << " " << cl[5] << std::endl;   *\/ */
+    /*     /\* std::cout << cl[6] << " " << cl[7] << " " << cl[8] << std::endl;   *\/ */
+    /*     /\* std::cout <<"******"<<totquad << " " << quad << std::endl;  *\/ */
+    /*     /\* std::cout << cc[0][0]<< " " << cc[0][1] << std::endl;  *\/ */
+    /*     /\* std::cout << cc[1][0]<< " " << cc[1][1] << std::endl;  *\/ */
     /*     // calcMyEta(totquad,quad,cl,etax, etay); */
     /*     calcEta(totquad, cc, etax, etay); */
 
-    /*     //     cout <<"******"<< etax << " " << etay << endl; */
+    /*     //     std::cout <<"******"<< etax << " " << etay << std::endl; */
 
     /*     return addToFlatFieldDistribution(etax, etay); */
     /* } */
@@ -331,7 +331,7 @@ class eta2InterpolationBase : public virtual etaInterpolationBase {
 
     virtual int *getInterpolatedImage() {
         int ipx, ipy;
-        // cout << "ff" << endl;
+        // std::cout << "ff" << std::endl;
         calcDiff(1, hhx, hhy); // get flat
         double avg = 0;
         for (ipx = 0; ipx < nSubPixelsX; ipx++)
@@ -347,8 +347,8 @@ class eta2InterpolationBase : public virtual etaInterpolationBase {
                 ipy = iby % nSubPixelsY - nSubPixelsY / 2;
                 if (ipy < 0)
                     ipy = nSubPixelsY + ipy;
-                // cout << ipx << " " << ipy << " " << ibx << " " << iby <<
-                // endl;
+                // std::cout << ipx << " " << ipy << " " << ibx << " " << iby <<
+                // std::endl;
                 if (flat[ipx + ipy * nSubPixelsX] > 0)
                     hintcorr[ibx + iby * nSubPixelsX * nPixelsX] =
                         hint[ibx + iby * nSubPixelsX * nPixelsX] *

--- a/slsDetectorCalibration/interpolations/etaInterpolationBase.h
+++ b/slsDetectorCalibration/interpolations/etaInterpolationBase.h
@@ -21,14 +21,14 @@ class etaInterpolationBase : public slsInterpolation {
                          double emax = 0)
         : slsInterpolation(nx, ny, ns, nsy), hhx(NULL), hhy(NULL), heta(NULL),
           nbetaX(nb), nbetaY(nby), etamin(emin), etamax(emax) {
-        // cout << "eb " << nb << " " << emin << " " << emax << endl;
-        // cout << nb << " " << etamin << " " << etamax << endl;
+        // std::cout << "eb " << nb << " " << emin << " " << emax << std::endl;
+        // std::cout << nb << " " << etamin << " " << etamax << std::endl;
         if (nbetaX <= 0) {
-            // cout << "aaa:" <<endl;
+            // std::cout << "aaa:" <<endl;
             nbetaX = nSubPixelsX * 10;
         }
         if (nbetaY <= 0) {
-            // cout << "aaa:" <<endl;
+            // std::cout << "aaa:" <<endl;
             nbetaY = nSubPixelsY * 10;
         }
         if (etamin >= etamax) {
@@ -145,9 +145,9 @@ class etaInterpolationBase : public slsInterpolation {
         uint32_t nny;
         float *gm = ReadFromTiff(imgname, nnx, nny);
         /* if (nnx!=nny) { */
-        /*   cout << "different number of bins in x " << nnx << "  and y " <<
-         * nny<< " !"<< endl; */
-        /*   cout << "Aborting read"<< endl; */
+        /*   std::cout << "different number of bins in x " << nnx << "  and y " <<
+         * nny<< " !"<< std::endl; */
+        /*   std::cout << "Aborting read"<< std::endl; */
         /*   return 0; */
         /* } */
         nbetaX = nnx;
@@ -254,12 +254,12 @@ class etaInterpolationBase : public slsInterpolation {
             if (ibx >= 0 && ibx < nSubPixelsX && iby >= 0 &&
                 iby < nSubPixelsY) {
                 //
-                // if (ibx>0 && iby>0) cout << ibx << " " << iby << " " << ii <<
-                // endl;
+                // if (ibx>0 && iby>0) std::cout << ibx << " " << iby << " " << ii <<
+                // std::endl;
                 ftest[ibx + iby * nSubPixelsX] += heta[ii];
             } else
-                cout << "Bad interpolation " << ii << " " << ibx << " " << iby
-                     << endl;
+                std::cout << "Bad interpolation " << ii << " " << ibx << " " << iby
+                     << std::endl;
         }
 
         sprintf(tit, "/scratch/ftest_%d.tiff", ind);
@@ -282,7 +282,7 @@ class etaInterpolationBase : public slsInterpolation {
         }
         sprintf(tit, "/scratch/eta_bad_%d.tiff", ind);
         WriteToTiff(etah, tit, nbetaX, nbetaY);
-        // cout << "Index: " << ind << "\t Bad bins: "<< nbad << endl;
+        // std::cout << "Index: " << ind << "\t Bad bins: "<< nbad << std::endl;
         // int ibx=0, iby=0;
 
         delete[] ftest;
@@ -330,9 +330,9 @@ class etaInterpolationBase : public slsInterpolation {
             }
         }
 
-        //  cout << endl << endl;
+        //  std::cout << std::endl << std::endl;
         for (ipy = 0; ipy < nSubPixelsY; ipy++) {
-            cout.width(5);
+            std::cout.width(5);
             // flat_y[ipy]=p_tot_y[ipy];//avg/nSubPixels;
             for (ipx = 0; ipx < nSubPixelsX; ipx++) {
 
@@ -353,19 +353,19 @@ class etaInterpolationBase : public slsInterpolation {
                 //"   ";
             }
 
-            /* cout << "** "  << setprecision(4) <<  flat_y[ipy]; */
-            // cout << "\n";
+            /* std::cout << "** "  << setprecision(4) <<  flat_y[ipy]; */
+            // std::cout << "\n";
         }
-        /* cout << "**" << endl; cout.width(5); */
+        /* std::cout << "**" << std::endl; std::cout.width(5); */
         /* for (ipx=0; ipx<nSubPixels; ipx++) { */
-        /*   cout  << setprecision(4) <<  flat_x[ipx] << " "; */
+        /*   std::cout  << setprecision(4) <<  flat_x[ipx] << " "; */
         /* } */
-        // cout << "**" << endl; cout.width(5);
-        // cout << "Min diff: " << mindiff/sqrt(avg) << " Max diff: " <<
-        // maxdiff/sqrt(avg) << " Nbad: " << nbad << endl;
+        // std::cout << "**" << std::endl; std::cout.width(5);
+        // std::cout << "Min diff: " << mindiff/sqrt(avg) << " Max diff: " <<
+        // maxdiff/sqrt(avg) << " Nbad: " << nbad << std::endl;
 
-        //   cout << "Bad pixels: " <<
-        //   100.*(float)nbad/((float)(nSubPixels*nSubPixels)) << " %" << endl;
+        //   std::cout << "Bad pixels: " <<
+        //   100.*(float)nbad/((float)(nSubPixels*nSubPixels)) << " %" << std::endl;
         delete[] p_tot_x;
         delete[] p_tot_y;
         delete[] p_tot;

--- a/slsDetectorCalibration/interpolations/etaInterpolationPosXY.h
+++ b/slsDetectorCalibration/interpolations/etaInterpolationPosXY.h
@@ -14,8 +14,8 @@ class etaInterpolationPosXY : public virtual etaInterpolationBase {
                           int nb = -1, int nby = -1, double emin = 1,
                           double emax = 0)
         : etaInterpolationBase(nx, ny, ns, nsy, nb, nby, emin, emax){
-              //  cout << "epxy " << nb << " " << emin << " " << emax << endl;
-              //  cout << nbeta << " " << etamin << " " << etamax << endl;
+              //  std::cout << "epxy " << nb << " " << emin << " " << emax << std::endl;
+              //  std::cout << nbeta << " " << etamin << " " << etamax << std::endl;
           };
 
     etaInterpolationPosXY(etaInterpolationPosXY *orig)
@@ -32,14 +32,14 @@ class etaInterpolationPosXY : public virtual etaInterpolationBase {
 
         ///*Eta Distribution Rebinning*///
         // double bsize=1./nSubPixels; //precision
-        // cout<<"nPixelsX = "<<nPixelsX<<" nPixelsY = "<<nPixelsY<<" nSubPixels
+        // std::cout<<"nPixelsX = "<<nPixelsX<<" nPixelsY = "<<nPixelsY<<" nSubPixels
         // = "<<nSubPixels<<endl;
         double tot_eta = 0;
         double tot_eta_x = 0;
         double tot_eta_y = 0;
         for (int ip = 0; ip < nbetaX * nbetaY; ip++)
             tot_eta += heta[ip];
-        cout << "total eta entries is :" << tot_eta << endl;
+        std::cout << "total eta entries is :" << tot_eta << std::endl;
         if (tot_eta <= 0) {
             ok = 0;
             return;
@@ -57,7 +57,7 @@ class etaInterpolationPosXY : public virtual etaInterpolationBase {
 
             for (int iby = 0; iby < nbetaY; iby++) {
                 etay = etamin + iby * etastepY;
-                // cout << etax << endl;
+                // std::cout << etax << std::endl;
 
                 // tot_eta_x+=hx[iby];
                 if (etay >= 0 && etay <= 1)
@@ -90,7 +90,7 @@ class etaInterpolationPosXY : public virtual etaInterpolationBase {
 
             for (int ibx = 0; ibx < nbetaX; ibx++) {
                 etax = etamin + ibx * etastepX;
-                // cout << etax << endl;
+                // std::cout << etax << std::endl;
                 if (etax >= 0 && etax <= 1)
                     hx[ibx] = heta[ibx + ib * nbetaX];
                 else {
@@ -178,7 +178,7 @@ class eta2InterpolationPosXY : public virtual eta2InterpolationBase,
         : etaInterpolationBase(nx, ny, ns, nsy, nb, nby, emin, emax),
           eta2InterpolationBase(nx, ny, ns, nsy, nb, nby, emin, emax),
           etaInterpolationPosXY(nx, ny, ns, nsy, nb, nby, emin, emax){
-              //  cout << "e2pxy " << nb << " " << emin << " " << emax << endl;
+              //  std::cout << "e2pxy " << nb << " " << emin << " " << emax << std::endl;
           };
 
     eta2InterpolationPosXY(eta2InterpolationPosXY *orig)
@@ -198,8 +198,8 @@ class eta3InterpolationPosXY : public virtual eta3InterpolationBase,
         : etaInterpolationBase(nx, ny, ns, nsy, nb, nby, emin, emax),
           eta3InterpolationBase(nx, ny, ns, nsy, nb, nby, emin, emax),
           etaInterpolationPosXY(nx, ny, ns, nsy, nb, nby, emin, emax){
-              //   cout << "e3pxy " << nbeta << " " << etamin << " " << etamax
-              //   << " " << nSubPixels<< endl;
+              //   std::cout << "e3pxy " << nbeta << " " << etamin << " " << etamax
+              //   << " " << nSubPixels<< std::endl;
           };
 
     eta3InterpolationPosXY(eta3InterpolationPosXY *orig)


### PR DESCRIPTION
- Added std:: in a few places
- Changed analogDetector::setClusterSize and Clone to pure virtual function instead of missing return type (size) This means that analogDetector has to be derived from and the two methods overridden. 
- Added automatic build on github for moenchZmq