### PR TITLE
enable fix g0 when in expert mode

### DIFF
--- a/slsDetectorGui/src/qTabSettings.cpp
+++ b/slsDetectorGui/src/qTabSettings.cpp
@@ -132,7 +132,7 @@ void qTabSettings::SetupWidgetWindow() {
 }
 
 void qTabSettings::SetExportMode(bool exportMode) {
-    if (comboGainMode->isVisible()) {
+    if (comboGainMode->isEnabled()) {
         ShowFixG0(exportMode);
     }
 }


### PR DESCRIPTION
Earlier, one had to be in the settings tab and enable expert mode for it to work. it should now work from any tab.