### PR TITLE
start acq list: mixup with master pos

### DIFF
--- a/slsDetectorSoftware/src/DetectorImpl.cpp
+++ b/slsDetectorSoftware/src/DetectorImpl.cpp
@@ -1311,7 +1311,7 @@ void DetectorImpl::startAcquisition(const bool blocking, Positions pos) {
         if (!masters.empty()) {
             Parallel((blocking ? &Module::startAndReadAll
                                : &Module::startAcquisition),
-                     pos);
+                     masters);
         }
     }
     // all in parallel
@@ -1385,7 +1385,7 @@ void DetectorImpl::processData(bool receiver) {
                     if (fgetc(stdin) == 'q') {
                         LOG(logINFO)
                             << "Caught the command to stop acquisition";
-                        Parallel(&Module::stopAcquisition, {});
+                        stopDetector({});
                     }
                 }
                 // get and print progress


### PR DESCRIPTION
- fix that only master starts second and not all (for start acq), typo with pos and masters list. 
- Also ensuring pressing 'q' and enter for blocking acquire follows the same procedure of master first.
- sync in shared memory?