### PR TITLE
1. Dev/update python bindings for port pr

### DIFF
--- a/python/slsdet/detector.py
+++ b/python/slsdet/detector.py
@@ -182,6 +182,7 @@ class Detector(CppDetectorApi):
 
     @port.setter
     def port(self, value):
+        ut.validate_port(value)
         ut.set_using_dict(self.setControlPort, value)
 
     @property
@@ -197,6 +198,7 @@ class Detector(CppDetectorApi):
 
     @stopport.setter
     def stopport(self, args):
+        ut.validate_port(args)
         ut.set_using_dict(self.setStopPort, args)
 
 
@@ -866,6 +868,7 @@ class Detector(CppDetectorApi):
 
     @rx_tcpport.setter
     def rx_tcpport(self, port):
+        ut.validate_port(port)
         ut.set_using_dict(self.setRxPort, port)
 
     @property
@@ -1145,11 +1148,14 @@ class Detector(CppDetectorApi):
     @rx_zmqport.setter
     def rx_zmqport(self, port):
         if isinstance(port, int):
+            ut.validate_port(port)
             self.setRxZmqPort(port, -1)
         elif isinstance(port, dict):
+            ut.validate_port(port)
             ut.set_using_dict(self.setRxZmqPort, port)
         elif is_iterable(port):
             for i, p in enumerate(port):
+                ut.validate_port(p)
                 self.setRxZmqPort(p, i)
         else:
             raise ValueError("Unknown argument type")
@@ -1179,11 +1185,14 @@ class Detector(CppDetectorApi):
     @zmqport.setter
     def zmqport(self, port):
         if isinstance(port, int):
+            ut.validate_port(port)
             self.setClientZmqPort(port, -1)
         elif isinstance(port, dict):
+            ut.validate_port(port)
             ut.set_using_dict(self.setClientZmqPort, port)
         elif is_iterable(port):
             for i, p in enumerate(port):
+                ut.validate_port(p)
                 self.setClientZmqPort(p, i)
         else:
             raise ValueError("Unknown argument type")
@@ -1493,6 +1502,7 @@ class Detector(CppDetectorApi):
 
     @udp_dstport.setter
     def udp_dstport(self, port):
+        ut.validate_port(port)
         ut.set_using_dict(self.setDestinationUDPPort, port)
 
     @property
@@ -1514,6 +1524,7 @@ class Detector(CppDetectorApi):
 
     @udp_dstport2.setter
     def udp_dstport2(self, port):
+        ut.validate_port(port)
         ut.set_using_dict(self.setDestinationUDPPort2, port)
 
     @property
@@ -2026,6 +2037,7 @@ class Detector(CppDetectorApi):
     @virtual.setter
     def virtual(self, args):
         n_detectors, starting_port = args
+        ut.validate_port(starting_port)
         self.setVirtualDetectorServers(n_detectors, starting_port)
 
     

--- a/python/slsdet/utils.py
+++ b/python/slsdet/utils.py
@@ -278,3 +278,9 @@ def hostname_list(args):
         return hosts
     else:
         raise ValueError("hostname needs to be string or list of strings")
+
+
+def validate_port(value):
+    if value <= 0 or value > 65535:
+        raise ValueError("port must be in range 1 - 65535")
+

--- a/python/src/detector.cpp
+++ b/python/src/detector.cpp
@@ -48,7 +48,7 @@ void init_det(py::module &m) {
                            Detector::setHostname,
                        py::arg());
     CppDetectorApi.def("setVirtualDetectorServers",
-                       (void (Detector::*)(int, int)) &
+                       (void (Detector::*)(int, uint16_t)) &
                            Detector::setVirtualDetectorServers,
                        py::arg(), py::arg());
     CppDetectorApi.def("getShmId",
@@ -751,19 +751,19 @@ void init_det(py::module &m) {
             Detector::setDestinationUDPMAC2,
         py::arg(), py::arg() = Positions{});
     CppDetectorApi.def("getDestinationUDPPort",
-                       (Result<int>(Detector::*)(sls::Positions) const) &
+                       (Result<uint16_t>(Detector::*)(sls::Positions) const) &
                            Detector::getDestinationUDPPort,
                        py::arg() = Positions{});
     CppDetectorApi.def("setDestinationUDPPort",
-                       (void (Detector::*)(int, int)) &
+                       (void (Detector::*)(uint16_t, int)) &
                            Detector::setDestinationUDPPort,
                        py::arg(), py::arg() = -1);
     CppDetectorApi.def("getDestinationUDPPort2",
-                       (Result<int>(Detector::*)(sls::Positions) const) &
+                       (Result<uint16_t>(Detector::*)(sls::Positions) const) &
                            Detector::getDestinationUDPPort2,
                        py::arg() = Positions{});
     CppDetectorApi.def("setDestinationUDPPort2",
-                       (void (Detector::*)(int, int)) &
+                       (void (Detector::*)(uint16_t, int)) &
                            Detector::setDestinationUDPPort2,
                        py::arg(), py::arg() = -1);
     CppDetectorApi.def("reconfigureUDPDestination",
@@ -844,12 +844,12 @@ void init_det(py::module &m) {
                            Detector::setRxHostname,
                        py::arg());
     CppDetectorApi.def("getRxPort",
-                       (Result<int>(Detector::*)(sls::Positions) const) &
+                       (Result<uint16_t>(Detector::*)(sls::Positions) const) &
                            Detector::getRxPort,
                        py::arg() = Positions{});
-    CppDetectorApi.def("setRxPort",
-                       (void (Detector::*)(int, int)) & Detector::setRxPort,
-                       py::arg(), py::arg() = -1);
+    CppDetectorApi.def(
+        "setRxPort", (void (Detector::*)(uint16_t, int)) & Detector::setRxPort,
+        py::arg(), py::arg() = -1);
     CppDetectorApi.def("getRxFifoDepth",
                        (Result<int>(Detector::*)(sls::Positions) const) &
                            Detector::getRxFifoDepth,
@@ -1032,11 +1032,12 @@ void init_det(py::module &m) {
                            Detector::setRxZmqStartingFrame,
                        py::arg(), py::arg() = Positions{});
     CppDetectorApi.def("getRxZmqPort",
-                       (Result<int>(Detector::*)(sls::Positions) const) &
+                       (Result<uint16_t>(Detector::*)(sls::Positions) const) &
                            Detector::getRxZmqPort,
                        py::arg() = Positions{});
     CppDetectorApi.def("setRxZmqPort",
-                       (void (Detector::*)(int, int)) & Detector::setRxZmqPort,
+                       (void (Detector::*)(uint16_t, int)) &
+                           Detector::setRxZmqPort,
                        py::arg(), py::arg() = -1);
     CppDetectorApi.def(
         "getRxZmqIP",
@@ -1048,11 +1049,11 @@ void init_det(py::module &m) {
                            Detector::setRxZmqIP,
                        py::arg(), py::arg() = Positions{});
     CppDetectorApi.def("getClientZmqPort",
-                       (Result<int>(Detector::*)(sls::Positions) const) &
+                       (Result<uint16_t>(Detector::*)(sls::Positions) const) &
                            Detector::getClientZmqPort,
                        py::arg() = Positions{});
     CppDetectorApi.def("setClientZmqPort",
-                       (void (Detector::*)(int, int)) &
+                       (void (Detector::*)(uint16_t, int)) &
                            Detector::setClientZmqPort,
                        py::arg(), py::arg() = -1);
     CppDetectorApi.def(
@@ -1524,14 +1525,6 @@ void init_det(py::module &m) {
                        (Result<int>(Detector::*)(sls::Positions) const) &
                            Detector::getSYNCClock,
                        py::arg() = Positions{});
-    CppDetectorApi.def("getADCPipeline",
-                       (Result<int>(Detector::*)(sls::Positions) const) &
-                           Detector::getADCPipeline,
-                       py::arg() = Positions{});
-    CppDetectorApi.def("setADCPipeline",
-                       (void (Detector::*)(int, sls::Positions)) &
-                           Detector::setADCPipeline,
-                       py::arg(), py::arg() = Positions{});
     CppDetectorApi.def("getVoltageList",
                        (std::vector<defs::dacIndex>(Detector::*)() const) &
                            Detector::getVoltageList);
@@ -1891,6 +1884,14 @@ void init_det(py::module &m) {
                             sls::Positions)) &
             Detector::setAdditionalJsonParameter,
         py::arg(), py::arg(), py::arg() = Positions{});
+    CppDetectorApi.def("getADCPipeline",
+                       (Result<int>(Detector::*)(sls::Positions) const) &
+                           Detector::getADCPipeline,
+                       py::arg() = Positions{});
+    CppDetectorApi.def("setADCPipeline",
+                       (void (Detector::*)(int, sls::Positions)) &
+                           Detector::setADCPipeline,
+                       py::arg(), py::arg() = Positions{});
     CppDetectorApi.def(
         "programFPGA",
         (void (Detector::*)(const std::string &, const bool, sls::Positions)) &
@@ -1978,19 +1979,19 @@ void init_det(py::module &m) {
                            Detector::setADCInvert,
                        py::arg(), py::arg() = Positions{});
     CppDetectorApi.def("getControlPort",
-                       (Result<int>(Detector::*)(sls::Positions) const) &
+                       (Result<uint16_t>(Detector::*)(sls::Positions) const) &
                            Detector::getControlPort,
                        py::arg() = Positions{});
     CppDetectorApi.def("setControlPort",
-                       (void (Detector::*)(int, sls::Positions)) &
+                       (void (Detector::*)(uint16_t, sls::Positions)) &
                            Detector::setControlPort,
                        py::arg(), py::arg() = Positions{});
     CppDetectorApi.def("getStopPort",
-                       (Result<int>(Detector::*)(sls::Positions) const) &
+                       (Result<uint16_t>(Detector::*)(sls::Positions) const) &
                            Detector::getStopPort,
                        py::arg() = Positions{});
     CppDetectorApi.def("setStopPort",
-                       (void (Detector::*)(int, sls::Positions)) &
+                       (void (Detector::*)(uint16_t, sls::Positions)) &
                            Detector::setStopPort,
                        py::arg(), py::arg() = Positions{});
     CppDetectorApi.def("getDetectorLock",


### PR DESCRIPTION
- python bindings for port PR
- more user friendly error message for exception thrown when python arg does not match uint16_t type for port