### PR TITLE
7.0.3.rc: gui acq finished callback for different status

### DIFF
--- a/slsDetectorSoftware/src/DetectorImpl.cpp
+++ b/slsDetectorSoftware/src/DetectorImpl.cpp
@@ -1234,10 +1234,20 @@ int DetectorImpl::acquire() {
         dataProcessingThread.join();
 
         if (acquisition_finished != nullptr) {
-            int status = Parallel(&Module::getRunStatus, {}).squash(ERROR);
+            // status
+            runStatus status = IDLE;
+            auto statusList = Parallel(&Module::getRunStatus, {});
+            if (statusList.any(ERROR)) 
+                status = ERROR;
+            if (statusList.contains_only(IDLE, STOPPED)) 
+                status = STOPPED;
+            else 
+                status = statusList.squash(RUNNING);
+            // progress
             auto a = Parallel(&Module::getReceiverProgress, {});
             double progress = (*std::max_element(a.begin(), a.end()));
-            acquisition_finished(progress, status, acqFinished_p);
+            // callback
+            acquisition_finished(progress, static_cast<int>(status), acqFinished_p);
         }
 
         clock_gettime(CLOCK_REALTIME, &end);

--- a/slsDetectorSoftware/src/DetectorImpl.cpp
+++ b/slsDetectorSoftware/src/DetectorImpl.cpp
@@ -1239,7 +1239,7 @@ int DetectorImpl::acquire() {
             auto statusList = Parallel(&Module::getRunStatus, {});
             if (statusList.any(ERROR)) 
                 status = ERROR;
-            if (statusList.contains_only(IDLE, STOPPED)) 
+            else if (statusList.contains_only(IDLE, STOPPED)) 
                 status = STOPPED;
             else 
                 status = statusList.squash(RUNNING);


### PR DESCRIPTION
fix acquisition finished status to have different status for different modules, but does not have to be error. for eg. jf sync fw (2.4.1 gives idle for master and stopped for slaves when stopping acquiistion)