### PR TITLE
8.0.0rc: : gui acq finished callback for different status

### DIFF
--- a/slsDetectorSoftware/src/DetectorImpl.cpp
+++ b/slsDetectorSoftware/src/DetectorImpl.cpp
@@ -1223,15 +1223,21 @@ int DetectorImpl::acquire() {
             // status
             runStatus status = IDLE;
             auto statusList = Parallel(&Module::getRunStatus, {});
-            if (statusList.any(ERROR)) 
-                status = ERROR;
-            else if (statusList.contains_only(IDLE, STOPPED)) 
-                status = STOPPED;
-            else 
-                status = statusList.squash(RUNNING);
+            status = statusList.squash(ERROR);
+            // difference, but none error
+            if (status == ERROR && (!statusList.any(ERROR))) {
+                // handle jf sync issue (master idle, slaves stopped)
+                if (statusList.contains_only(IDLE, STOPPED)) {
+                    status = STOPPED;
+                }
+                else 
+                    status = statusList.squash(RUNNING);
+            }
+
             // progress
             auto a = Parallel(&Module::getReceiverProgress, {});
             double progress = (*std::max_element(a.begin(), a.end()));
+            
             // callback
             acquisition_finished(progress, static_cast<int>(status), acqFinished_p);
         }

--- a/slsDetectorSoftware/src/DetectorImpl.cpp
+++ b/slsDetectorSoftware/src/DetectorImpl.cpp
@@ -1225,7 +1225,7 @@ int DetectorImpl::acquire() {
             auto statusList = Parallel(&Module::getRunStatus, {});
             if (statusList.any(ERROR)) 
                 status = ERROR;
-            if (statusList.contains_only(IDLE, STOPPED)) 
+            else if (statusList.contains_only(IDLE, STOPPED)) 
                 status = STOPPED;
             else 
                 status = statusList.squash(RUNNING);

--- a/slsDetectorSoftware/src/DetectorImpl.cpp
+++ b/slsDetectorSoftware/src/DetectorImpl.cpp
@@ -1220,10 +1220,20 @@ int DetectorImpl::acquire() {
         dataProcessingThread.join();
 
         if (acquisition_finished != nullptr) {
-            int status = Parallel(&Module::getRunStatus, {}).squash(ERROR);
+            // status
+            runStatus status = IDLE;
+            auto statusList = Parallel(&Module::getRunStatus, {});
+            if (statusList.any(ERROR)) 
+                status = ERROR;
+            if (statusList.contains_only(IDLE, STOPPED)) 
+                status = STOPPED;
+            else 
+                status = statusList.squash(RUNNING);
+            // progress
             auto a = Parallel(&Module::getReceiverProgress, {});
             double progress = (*std::max_element(a.begin(), a.end()));
-            acquisition_finished(progress, status, acqFinished_p);
+            // callback
+            acquisition_finished(progress, static_cast<int>(status), acqFinished_p);
         }
 
         clock_gettime(CLOCK_REALTIME, &end);


### PR DESCRIPTION
fix acquisition finished status to have different status for different modules, but does not have to be error. 