### PR TITLE
Dev: trigger signal issues handled at acquire

### DIFF
--- a/docs/src/troubleshooting.rst
+++ b/docs/src/troubleshooting.rst
@@ -92,6 +92,9 @@ Common
             sls_detector_put rx_arping 1
 
 
+#. Only the slaves get no data 
+    * Check trigger cabling and trigger configuration
+    * When you cannot stop Jungfrau slaves in sync mode, refer to :ref:`Cannot stop slaves<Jungfrau Troubleshooting Sync Slaves Cannot Stop>`.
 
 .. _Receiver PC Tuning:
 
@@ -421,3 +424,19 @@ Cannot get multi module data
     * Comment out this line in the config file: powerchip 1
     * Powering on the chip increases the power consumption by a considerable amount. If commenting out this line aids in getting data (strange data due to powered off chip), then it could be the power supply current limit. Fix it (possibly to 8A current limit) and uncomment the powerchip line back in config file.
 
+
+
+.. _Jungfrau Troubleshooting Sync Slaves Cannot Stop:
+
+Cannot stop slaves in sync mode
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+#. If cabling is accessible, ensure termination board and flatband cable between the masters and the slaves are connnected properly. Then try to stop.
+#. If cabling is inaccessible, unsync first so that the slaves can get the stop directly from the client using the command. Then, don't use sync mode until the cabling is fixed.
+    .. code-block:: bash
+        
+        # unsync, slaves command will fail as it is still in waiting state
+        sls_detector_put sync 0
+
+        # stop should now be successful as master does not determine the stop anymore
+        sls_detector_put stop

--- a/python/slsdet/detector.py
+++ b/python/slsdet/detector.py
@@ -1673,6 +1673,11 @@ class Detector(CppDetectorApi):
     def sync(self):
         """
         [Jungfrau][Moench] Enables or disables synchronization between modules.
+
+        Note
+        ----
+        Sync mode requires at least one master configured. Also requires flatband cabling between master and slave with termination board.
+
         """
         return self.getSynchronization()
 

--- a/slsDetectorSoftware/include/sls/Detector.h
+++ b/slsDetectorSoftware/include/sls/Detector.h
@@ -216,7 +216,10 @@ class Detector {
     /** [Jungfrau][Moench] **/
     Result<bool> getSynchronization(Positions pos = {}) const;
 
-    /** [Jungfrau][Moench]  */
+    /** [Jungfrau][Moench]  Sync mode requires at least one master configured.
+       Also requires flatband cabling between master and slave with
+       termination board.
+     */
     void setSynchronization(bool value);
 
     /** [Gotthard2][Mythen3] */

--- a/slsDetectorSoftware/src/CmdProxy.h
+++ b/slsDetectorSoftware/src/CmdProxy.h
@@ -1543,7 +1543,9 @@ class CmdProxy {
     INTEGER_COMMAND_SET_NOID_GET_ID(
         sync, getSynchronization, setSynchronization, StringTo<int>,
         "[0, 1]\n\t[Jungfrau][Moench] Enables or disables "
-        "synchronization between modules.");
+        "synchronization between modules. Sync mode requires at least one "
+        "master configured. Also requires flatband cabling between master and "
+        "slave with termination board.");
 
     INTEGER_COMMAND_VEC_ID(row, getRow, setRow, StringTo<int>,
                            "[value]\n\tSet Detector row (udp header) to value. "

--- a/slsDetectorSoftware/src/DetectorImpl.cpp
+++ b/slsDetectorSoftware/src/DetectorImpl.cpp
@@ -1316,19 +1316,17 @@ void DetectorImpl::startAcquisition(const bool blocking, Positions pos) {
         if (!slaves.empty()) {
             Parallel(&Module::startAcquisition, slaves);
         }
-        if (!masters.empty()) {
-            if (blocking) {
-                Parallel(&Module::startAndReadAll, masters);
-                // ensure all status normal (slaves not blocking)
-                // to catch those slaves that are still 'waiting'
-                auto status = Parallel(&Module::getRunStatus, pos);
-                if (!status.contains_only(IDLE, STOPPED, RUN_FINISHED)) {
-                    throw RuntimeError("Acquisition not successful. "
-                                       "Unexpected detector status");
-                }
-            } else {
-                Parallel(&Module::startAcquisition, masters);
+        if (blocking) {
+            Parallel(&Module::startAndReadAll, masters);
+            // ensure all status normal (slaves not blocking)
+            // to catch those slaves that are still 'waiting'
+            auto status = Parallel(&Module::getRunStatus, pos);
+            if (!status.contains_only(IDLE, STOPPED, RUN_FINISHED)) {
+                throw RuntimeError("Acquisition not successful. "
+                                   "Unexpected detector status");
             }
+        } else {
+            Parallel(&Module::startAcquisition, masters);
         }
     }
     // all in parallel

--- a/slsDetectorSoftware/src/DetectorImpl.cpp
+++ b/slsDetectorSoftware/src/DetectorImpl.cpp
@@ -1309,7 +1309,7 @@ void DetectorImpl::startAcquisition(const bool blocking, Positions pos) {
         std::vector<int> masters;
         std::vector<int> slaves;
         getMasterSlaveList(pos, masters, slaves);
-        if (masters.empty() && shm()->detType == JUNGFRAU) {
+        if (masters.empty()) {
             throw RuntimeError("Cannot start acquisition in sync mode. No "
                                "master module found");
         }

--- a/slsDetectorSoftware/src/DetectorImpl.cpp
+++ b/slsDetectorSoftware/src/DetectorImpl.cpp
@@ -1309,6 +1309,10 @@ void DetectorImpl::startAcquisition(const bool blocking, Positions pos) {
         std::vector<int> masters;
         std::vector<int> slaves;
         getMasterSlaveList(pos, masters, slaves);
+        if (masters.empty() && shm()->detType == JUNGFRAU) {
+            throw RuntimeError("Cannot start acquisition in sync mode. No "
+                               "master module found");
+        }
         if (!slaves.empty()) {
             Parallel(&Module::startAcquisition, slaves);
         }


### PR DESCRIPTION
Case: trigger signal has an issue (termination board or flat band cable not connected properly)

if blocking and handling sync, only master gets blocking acq, slaves get non blocking as they are first and so dont get status checked. So no error thrown when slaves dont get trigger (due to not connected etc) and acq returns with slaves still in waiting status. so check status of all in blocking acq

ensure a sync multi module (jf, m3, g2) has atleast one master when starting acquisition.

(from 8.0.0.rc)