### PR TITLE
developer: blocking acquire stop with slave temporarily in waiting

### DIFF
--- a/slsDetectorSoftware/src/DetectorImpl.cpp
+++ b/slsDetectorSoftware/src/DetectorImpl.cpp
@@ -744,9 +744,8 @@ void DetectorImpl::readFrameFromReceiver() {
             }
         }
 
-        LOG(logDEBUG) << "Call Back Info:"
-                      << "\n\t nDetPixelsX: " << nDetPixelsX
-                      << "\n\t nDetPixelsY: " << nDetPixelsY
+        LOG(logDEBUG) << "Call Back Info:" << "\n\t nDetPixelsX: "
+                      << nDetPixelsX << "\n\t nDetPixelsY: " << nDetPixelsY
                       << "\n\t databytes: " << multisize
                       << "\n\t dynamicRange: " << dynamicRange;
 
@@ -764,8 +763,8 @@ void DetectorImpl::readFrameFromReceiver() {
                 callbackImage = multigappixels;
                 imagesize = n;
             }
-            LOG(logDEBUG) << "Image Info:"
-                          << "\n\tnDetActualPixelsX: " << nDetActualPixelsX
+            LOG(logDEBUG) << "Image Info:" << "\n\tnDetActualPixelsX: "
+                          << nDetActualPixelsX
                           << "\n\tnDetActualPixelsY: " << nDetActualPixelsY
                           << "\n\timagesize: " << imagesize
                           << "\n\tdynamicRange: " << dynamicRange;
@@ -800,8 +799,7 @@ void DetectorImpl::readFrameFromReceiver() {
 int DetectorImpl::insertGapPixels(char *image, char *&gpImage, bool quadEnable,
                                   int dr, int &nPixelsx, int &nPixelsy) {
 
-    LOG(logDEBUG) << "Insert Gap pixels:"
-                  << "\n\t nPixelsx: " << nPixelsx
+    LOG(logDEBUG) << "Insert Gap pixels:" << "\n\t nPixelsx: " << nPixelsx
                   << "\n\t nPixelsy: " << nPixelsy
                   << "\n\t quadEnable: " << quadEnable << "\n\t dr: " << dr;
 
@@ -886,12 +884,10 @@ int DetectorImpl::insertGapPixels(char *image, char *&gpImage, bool quadEnable,
                   << "nMod1Pixelsy: " << nMod1Pixelsy << "\n\t"
                   << "nMod1GapPixelsx: " << nMod1GapPixelsx << "\n\t"
                   << "nMod1GapPixelsy: " << nMod1GapPixelsy << "\n\t"
-                  << "nChipy: " << nChipy << "\n\t"
-                  << "nChipx: " << nChipx << "\n\t"
-                  << "nModx: " << nModx << "\n\t"
-                  << "nMody: " << nMody << "\n\t"
-                  << "nTotx: " << nTotx << "\n\t"
-                  << "nToty: " << nToty << "\n\t"
+                  << "nChipy: " << nChipy << "\n\t" << "nChipx: " << nChipx
+                  << "\n\t" << "nModx: " << nModx << "\n\t"
+                  << "nMody: " << nMody << "\n\t" << "nTotx: " << nTotx
+                  << "\n\t" << "nToty: " << nToty << "\n\t"
                   << "bytesPerPixel: " << bytesPerPixel << "\n\t"
                   << "imagesize: " << imagesize << "\n\t"
                   << "nChipBytesx: " << nChipBytesx << "\n\t"
@@ -1323,6 +1319,11 @@ void DetectorImpl::startAcquisition(const bool blocking, Positions pos) {
             // ensure all status normal (slaves not blocking)
             // to catch those slaves that are still 'waiting'
             auto status = Parallel(&Module::getRunStatus, pos);
+            // if any slave still waiting, wait 50 ms and check one time
+            if (status.any(WAITING)) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(50));
+                status = Parallel(&Module::getRunStatus, pos);
+            }
             if (!status.contains_only(IDLE, STOPPED, RUN_FINISHED)) {
                 throw RuntimeError("Acquisition not successful. "
                                    "Unexpected detector status");

--- a/slsDetectorSoftware/src/DetectorImpl.cpp
+++ b/slsDetectorSoftware/src/DetectorImpl.cpp
@@ -1319,8 +1319,8 @@ void DetectorImpl::startAcquisition(const bool blocking, Positions pos) {
             // ensure all status normal (slaves not blocking)
             // to catch those slaves that are still 'waiting'
             auto status = Parallel(&Module::getRunStatus, pos);
-            // if any slave still waiting, wait 50 ms and check one time
-            if (status.any(WAITING)) {
+            // if any slave still waiting, wait up to 1s
+            for (int i = 0; i != 20 && status.any(WAITING); ++i) {
                 std::this_thread::sleep_for(std::chrono::milliseconds(50));
                 status = Parallel(&Module::getRunStatus, pos);
             }


### PR DESCRIPTION
client: stopping a blocking acquire of multi modules checks status to catch slaves that might still be in waiting.

Problem is (gotthard2 25um at least) slave is in waiting only temporarily before going go idle/stopped.

So a 50ms sleep is necessary ot not throw an unnecessary error