### PR TITLE
8.0.2.rc: fix to rapidjson for build with gcc 14

### DIFF
--- a/libs/rapidjson/rapidjson/document.h
+++ b/libs/rapidjson/rapidjson/document.h
@@ -316,7 +316,8 @@ struct GenericStringRef {
 
     GenericStringRef(const GenericStringRef& rhs) : s(rhs.s), length(rhs.length) {}
 
-    GenericStringRef& operator=(const GenericStringRef& rhs) { s = rhs.s; length = rhs.length; }
+    // Removed to fix failing build in GCC 14
+    // GenericStringRef& operator=(const GenericStringRef& rhs) { s = rhs.s; length = rhs.length; }
 
     //! implicit conversion to plain CharType pointer
     operator const Ch *() const { return s; }


### PR DESCRIPTION
Fix a compile issue with gcc 14. Should be safe to remove and has been done so in later commits to rapidjson. 