### PR TITLE
8.0.2.rc: moench empty data callback

### DIFF
--- a/slsDetectorCalibration/moenchExecutables/moenchZmqProcess.cpp
+++ b/slsDetectorCalibration/moenchExecutables/moenchZmqProcess.cpp
@@ -183,8 +183,8 @@ int main(int argc, char *argv[]) {
     gainfname = args["gainfile"];
     etafname = args["etafilefile"];
     
-    if (atoi(args["nuninterfaces"].c_str())>1){
-      cprintf(RED, "Sorry, at the  moment only a single interface is supported instead of %d\n",atoi(args["nuninterfaces"].c_str()));
+    if (atoi(args["numinterfaces"].c_str())>1){
+      cprintf(RED, "Sorry, at the  moment only a single interface is supported instead of %d\n",atoi(args["numinterfaces"].c_str()));
       return EXIT_FAILURE;
     }
 
@@ -272,54 +272,35 @@ int main(int argc, char *argv[]) {
 
     sls::ZmqSocket *zmqsocket = NULL;
 
-#ifdef NEWZMQ
     // receive socket
     try {
-#endif
-
       zmqsocket = new sls::ZmqSocket(socketip.c_str(), portnum);
-
-#ifdef NEWZMQ
     } catch (...) {
         cprintf(RED,
-                "Error: Could not create Zmq socket on port %d with ip %s\n",
+                "Error: Could not create Zmq receiving socket on port %d with ip %s\n",
                 portnum, socketip.c_str());
         delete zmqsocket;
         return EXIT_FAILURE;
     }
-#endif
-
-#ifndef NEWZMQ
-    if (zmqsocket->IsError()) {
-        cprintf(RED,
-                "Error: Could not create Zmq socket on port %d with ip %s\n",
-                portnum, socketip.c_str());
-        delete zmqsocket;
-        return EXIT_FAILURE;
-    }
-#endif
     if (zmqsocket->Connect()) {
-        cprintf(RED, "Error: Could not connect to socket  %s\n",
+        cprintf(RED, "Error: Could not connect to zmq receiving socket  %s\n",
                 (zmqsocket->GetZmqServerAddress()).c_str());
         delete zmqsocket;
         return EXIT_FAILURE;
     } else
-        printf("Zmq Client at %s\n", zmqsocket->GetZmqServerAddress().c_str());
+    
+    printf("Zmq receiving at %s\n", zmqsocket->GetZmqServerAddress().c_str());
 
     // send socket
     sls::ZmqSocket *zmqsocket2 = 0;
     // cout << "zmq2 " << endl;
     if (send) {
-#ifdef NEWZMQ
         // receive socket
         try {
-#endif
-	  zmqsocket2 = new sls::ZmqSocket(portnum2, socketip2.c_str());
-
-#ifdef NEWZMQ
+    	  zmqsocket2 = new sls::ZmqSocket(portnum2, socketip2.c_str());
         } catch (...) {
             cprintf(RED,
-                    "Error: Could not create Zmq socket server on port %d and "
+                    "Error: Could not create Zmq sending socket on port %d and "
                     "ip %s\n",
                     portnum2, socketip2.c_str());
             //	delete zmqsocket2;
@@ -328,28 +309,7 @@ int main(int argc, char *argv[]) {
             //	return EXIT_FAILURE;
             send = false;
         }
-#endif
-
-#ifndef NEWZMQ
-        if (zmqsocket2->IsError()) {
-            cprintf(RED,
-                    "AAA Error: Could not create Zmq socket server on port %d "
-                    "and ip %s\n",
-                    portnum2, socketip2.c_str());
-            //	delete zmqsocket2;
-            // delete zmqsocket;
-            //	return EXIT_FAILURE;
-            send = false;
-        }
-#endif
-        if (zmqsocket2->Connect()) {
-            cprintf(RED, "BBB Error: Could not connect to socket  %s\n",
-                    zmqsocket2->GetZmqServerAddress().c_str());
-            //	delete zmqsocket2;
-            send = false;
-            //	return EXIT_FAILURE;
-        } else
-            printf("Zmq Client at %s\n",
+            printf("Zmq sending socket at %s\n",
                    zmqsocket2->GetZmqServerAddress().c_str());
     }
 

--- a/slsDetectorSoftware/CMakeLists.txt
+++ b/slsDetectorSoftware/CMakeLists.txt
@@ -79,9 +79,10 @@ if(SLS_USE_TEXTCLIENT)
     # Loop over list to generate command line binaries
     set(bin_names "sls_detector_put" 
             "sls_detector_get" 
-            "sls_detector_acquire" 
+            "sls_detector_acquire"
+            "sls_detector_acquire_zmq" 
             "sls_detector_help")
-    set(cmd_name "PUT" "GET" "READOUT" "HELP")
+    set(cmd_name "PUT" "GET" "READOUT" "READOUTZMQ" "HELP")
     list(LENGTH bin_names len1)
     math(EXPR len2 "${len1} - 1")
 

--- a/slsDetectorSoftware/src/CmdLineApp.cpp
+++ b/slsDetectorSoftware/src/CmdLineApp.cpp
@@ -31,7 +31,7 @@ int main(int argc, char *argv[]) {
 #endif
 
 #ifdef READOUTZMQ
-    int action = slsDetectorDefs::READOUT_ACTION_ZMQ;
+    int action = slsDetectorDefs::READOUT_ZMQ_ACTION;
 #endif
 
 #ifdef HELP
@@ -50,7 +50,7 @@ int main(int argc, char *argv[]) {
     parser.Parse(argc, argv);
 
     // If we called sls_detector_acquire, add the acquire command
-    if (action == slsDetectorDefs::READOUT_ACTION || action == slsDetectorDefs::READOUT_ACTION_ZMQ)
+    if (action == slsDetectorDefs::READOUT_ACTION || action == slsDetectorDefs::READOUT_ZMQ_ACTION)
         parser.setCommand("acquire");
 
     if (parser.isHelp())

--- a/slsDetectorSoftware/src/CmdLineApp.cpp
+++ b/slsDetectorSoftware/src/CmdLineApp.cpp
@@ -30,6 +30,10 @@ int main(int argc, char *argv[]) {
     int action = slsDetectorDefs::READOUT_ACTION;
 #endif
 
+#ifdef READOUTZMQ
+    int action = slsDetectorDefs::READOUT_ACTION_ZMQ;
+#endif
+
 #ifdef HELP
     int action = slsDetectorDefs::HELP_ACTION;
 #endif
@@ -46,7 +50,7 @@ int main(int argc, char *argv[]) {
     parser.Parse(argc, argv);
 
     // If we called sls_detector_acquire, add the acquire command
-    if (action == slsDetectorDefs::READOUT_ACTION)
+    if (action == slsDetectorDefs::READOUT_ACTION || action == slsDetectorDefs::READOUT_ACTION_ZMQ)
         parser.setCommand("acquire");
 
     if (parser.isHelp())

--- a/slsDetectorSoftware/src/CmdProxy.cpp
+++ b/slsDetectorSoftware/src/CmdProxy.cpp
@@ -232,7 +232,7 @@ std::string CmdProxy::Acquire(int action) {
             throw RuntimeError("Individual detectors not allowed for readout.");
         }
 
-        if (action == defs::READOUT_ACTION_ZMQ) {
+        if (action == defs::READOUT_ZMQ_ACTION) {
             det->registerDataCallback(&(EmptyDataCallBack), this);
         }
         det->acquire();

--- a/slsDetectorSoftware/src/CmdProxy.cpp
+++ b/slsDetectorSoftware/src/CmdProxy.cpp
@@ -205,6 +205,12 @@ std::string CmdProxy::VirtualServer(int action) {
     return os.str();
 }
 
+void CmdProxy::EmptyDataCallBack(detectorData *data, uint64_t frameIndex,
+                                uint32_t subFrameIndex, void *this_pointer) {
+    LOG(logDEBUG) << "EmptyDataCallBack to start up zmq sockets";
+}
+
+
 std::string CmdProxy::Acquire(int action) {
     std::ostringstream os;
     if (action == defs::HELP_ACTION) {
@@ -226,6 +232,9 @@ std::string CmdProxy::Acquire(int action) {
             throw RuntimeError("Individual detectors not allowed for readout.");
         }
 
+        if (action == defs::READOUT_ACTION_ZMQ) {
+            det->registerDataCallback(&(EmptyDataCallBack), this);
+        }
         det->acquire();
 
         if (det->getUseReceiverFlag().squash(false)) {

--- a/slsDetectorSoftware/src/CmdProxy.h
+++ b/slsDetectorSoftware/src/CmdProxy.h
@@ -1350,6 +1350,7 @@ class CmdProxy {
     std::string GapPixels(int action);
     std::string BadChannels(int action);
     /* acquisition parameters */
+    static void EmptyDataCallBack(detectorData *data, uint64_t frameIndex, uint32_t subFrameIndex, void *this_pointer);
     std::string Acquire(int action);
     std::string Exptime(int action);
     std::string ReadoutSpeed(int action);

--- a/slsSupportLib/include/sls/sls_detector_defs.h
+++ b/slsSupportLib/include/sls/sls_detector_defs.h
@@ -215,7 +215,7 @@ typedef struct {
     /**
         type of action performed (for text client)
     */
-    enum { GET_ACTION, PUT_ACTION, READOUT_ACTION, HELP_ACTION, READOUT_ACTION_ZMQ };
+    enum { GET_ACTION, PUT_ACTION, READOUT_ACTION, HELP_ACTION, READOUT_ZMQ_ACTION };
 
     /**
         dimension indexes

--- a/slsSupportLib/include/sls/sls_detector_defs.h
+++ b/slsSupportLib/include/sls/sls_detector_defs.h
@@ -215,7 +215,7 @@ typedef struct {
     /**
         type of action performed (for text client)
     */
-    enum { GET_ACTION, PUT_ACTION, READOUT_ACTION, HELP_ACTION };
+    enum { GET_ACTION, PUT_ACTION, READOUT_ACTION, HELP_ACTION, READOUT_ACTION_ZMQ };
 
     /**
         dimension indexes


### PR DESCRIPTION
moench (feature to wait for post processing to be done in new sls_detector_acquire_zmq executable)
- READOUT_ACTION_ZMQ added to action enums
- sls_detector_acquire_zmq added to executables 
-  empty data call back so that client listens to last dummy zmq packet from moench post processor
-  processor: remove NEWZMQ ifdefs and remove connect for zmq publisher socket