### PR TITLE
8.0.2.rc: client: status for blocking acquire stop with slave temporarily in waiting

### DIFF
--- a/slsDetectorSoftware/src/DetectorImpl.cpp
+++ b/slsDetectorSoftware/src/DetectorImpl.cpp
@@ -1217,10 +1217,14 @@ int DetectorImpl::acquire() {
 
         if (acquisition_finished != nullptr) {
             // status
-            runStatus status = IDLE;
             auto statusList = Parallel(&Module::getRunStatus, {});
-            status = statusList.squash(ERROR);
-            // difference, but none error
+            // if any slave still waiting, wait up to 1s (gotthard)
+            for (int i = 0; i != 20 && statusList.any(WAITING); ++i) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(50));
+                statusList = Parallel(&Module::getRunStatus, {});
+            }
+            runStatus status = statusList.squash(ERROR);
+            // inconsistent status (squash error), but none of them in error
             if (status == ERROR && (!statusList.any(ERROR))) {
                 // handle jf sync issue (master idle, slaves stopped)
                 if (statusList.contains_only(IDLE, STOPPED)) {
@@ -1315,9 +1319,9 @@ void DetectorImpl::startAcquisition(const bool blocking, Positions pos) {
         if (blocking) {
             Parallel(&Module::startAndReadAll, masters);
             // ensure all status normal (slaves not blocking)
-            // to catch those slaves that are still 'waiting'
+            // to catch those slaves that are still 'waiting' 
             auto status = Parallel(&Module::getRunStatus, pos);
-            // if any slave still waiting, wait up to 1s
+            // if any slave still waiting, wait up to 1s (gotthard)
             for (int i = 0; i != 20 && status.any(WAITING); ++i) {
                 std::this_thread::sleep_for(std::chrono::milliseconds(50));
                 status = Parallel(&Module::getRunStatus, pos);

--- a/slsDetectorSoftware/src/DetectorImpl.cpp
+++ b/slsDetectorSoftware/src/DetectorImpl.cpp
@@ -1320,13 +1320,13 @@ void DetectorImpl::startAcquisition(const bool blocking, Positions pos) {
             Parallel(&Module::startAndReadAll, masters);
             // ensure all status normal (slaves not blocking)
             // to catch those slaves that are still 'waiting' 
-            auto status = Parallel(&Module::getRunStatus, pos);
+            auto statusList = Parallel(&Module::getRunStatus, pos);
             // if any slave still waiting, wait up to 1s (gotthard)
-            for (int i = 0; i != 20 && status.any(WAITING); ++i) {
+            for (int i = 0; i != 20 && statusList.any(WAITING); ++i) {
                 std::this_thread::sleep_for(std::chrono::milliseconds(50));
-                status = Parallel(&Module::getRunStatus, pos);
+                statusList = Parallel(&Module::getRunStatus, pos);
             }
-            if (!status.contains_only(IDLE, STOPPED, RUN_FINISHED)) {
+            if (!statusList.contains_only(IDLE, STOPPED, RUN_FINISHED)) {
                 throw RuntimeError("Acquisition not successful. "
                                    "Unexpected detector status");
             }


### PR DESCRIPTION
acq finish call back gets status squashed with default error but before that need to wait for gotthard slaves to catch up from waiting to stopped