### PR TITLE
bug fixes related to file saving (#931)

### DIFF
--- a/slsDetectorGui/src/qTabMeasurement.cpp
+++ b/slsDetectorGui/src/qTabMeasurement.cpp
@@ -839,8 +839,8 @@ void qTabMeasurement::UpdateProgress() {
 int qTabMeasurement::VerifyOutputDirectoryError() {
     try {
         auto retval = det->getFilePath();
-        for (auto &it : retval) {
-            det->setFilePath(it);
+        for (size_t i = 0; i < retval.size(); i++) {
+            det->setFilePath(retval[i], {i});
         }
         return slsDetectorDefs::OK;
     }

--- a/slsReceiverSoftware/src/HDF5DataFile.cpp
+++ b/slsReceiverSoftware/src/HDF5DataFile.cpp
@@ -186,7 +186,7 @@ void HDF5DataFile::CreateFile() {
         // property list
         H5::DSetCreatPropList plist;
         H5::DSetCreatPropList plistPara;
-        int fill_value = -1;
+        uint64_t fill_value = -1;
         plist.setFillValue(dataType, &fill_value);
         // plistPara.setFillValue(dataType, &fill_value);
         plist.setChunk(DATA_RANK, dimsChunk);

--- a/slsReceiverSoftware/src/MasterFileUtility.cpp
+++ b/slsReceiverSoftware/src/MasterFileUtility.cpp
@@ -215,7 +215,7 @@ std::string CreateVirtualHDF5File(
 
         // property list
         H5::DSetCreatPropList plist;
-        int fill_value = -1;
+        uint64_t fill_value = -1;
         plist.setFillValue(dataType, &fill_value);
         std::vector<H5::DSetCreatPropList> plistPara(paraSize);
         // ignoring last fill (string)


### PR DESCRIPTION
* fix the file path resetting issue of GUI in the case where different modules have different fpath setting.

* fix stack-buffer-overflow issue when using HDF5 HDF5DataFile::parameterDataTypes have 64bit type (i.e. STD_U64LE), the size of fill_value should be at least 8 bytes.

* change the type of fill_value to uint64_t