### PR TITLE
zmq keep alive in receiver socket (publisher)

### DIFF
--- a/slsSupportLib/include/sls/ZmqSocket.h
+++ b/slsSupportLib/include/sls/ZmqSocket.h
@@ -109,6 +109,7 @@ class ZmqSocket {
     /**
      * Constructor for a server
      * Creates socket, context and connects to server
+     * socket option: keep alive added 
      * @param portnumber port number
      * @param ethip is the ip of the ethernet interface to stream zmq from
      */

--- a/slsSupportLib/src/ZmqSocket.cpp
+++ b/slsSupportLib/src/ZmqSocket.cpp
@@ -76,6 +76,32 @@ ZmqSocket::ZmqSocket(const uint16_t portnumber, const char *ethip)
     sockfd.serverAddress = oss.str();
     LOG(logDEBUG) << "zmq address: " << sockfd.serverAddress;
 
+    // Socket Options for keepalive
+    // enable TCP keepalive
+    int keepalive = 1;
+    if (zmq_setsockopt(sockfd.socketDescriptor, ZMQ_TCP_KEEPALIVE, &keepalive, sizeof(keepalive))) {
+        PrintError();
+        throw ZmqSocketError("Could set socket opt ZMQ_TCP_KEEPALIVE");
+    }
+    // set the number of keepalives before death
+    keepalive = 10;
+    if (zmq_setsockopt(sockfd.socketDescriptor, ZMQ_TCP_KEEPALIVE_CNT, &keepalive, sizeof(keepalive))) {
+        PrintError();
+        throw ZmqSocketError("Could set socket opt ZMQ_TCP_KEEPALIVE_CNT");
+    }
+    // set the time before the first keepalive
+    keepalive = 60;
+    if (zmq_setsockopt(sockfd.socketDescriptor, ZMQ_TCP_KEEPALIVE_IDLE, &keepalive, sizeof(keepalive))) {
+        PrintError();
+        throw ZmqSocketError("Could set socket opt ZMQ_TCP_KEEPALIVE_IDLE");
+    }
+    // set the interval between keepalives
+    keepalive = 1;
+    if (zmq_setsockopt(sockfd.socketDescriptor, ZMQ_TCP_KEEPALIVE_INTVL, &keepalive, sizeof(keepalive))) {
+        PrintError();
+        throw ZmqSocketError("Could set socket opt ZMQ_TCP_KEEPALIVE_INTVL");
+    }
+
     // bind address
     if (zmq_bind(sockfd.socketDescriptor, sockfd.serverAddress.c_str())) {
         PrintError();


### PR DESCRIPTION
added keepalive zmq socket option (after 60s of idle time, 10 probes every sec. Mainly because an issue at Max IV