### PR TITLE
Fpath created at acq start

### DIFF
--- a/python/slsdet/detector.py
+++ b/python/slsdet/detector.py
@@ -1043,7 +1043,7 @@ class Detector(CppDetectorApi):
         
         Note
         ----
-        If path does not exist, it will try to create it.
+        If path does not exist and fwrite enabled, it will try to create it at start of acquisition.
         
         Example
         --------
@@ -1059,7 +1059,7 @@ class Detector(CppDetectorApi):
     @property
     @element
     def fwrite(self):
-        """Enable or disable receiver file write. Default is enabled. """
+        """Enable or disable receiver file write. Default is disabled. """
         return self.getFileWrite()
 
     @fwrite.setter

--- a/slsDetectorSoftware/generator/commands.yaml
+++ b/slsDetectorSoftware/generator/commands.yaml
@@ -556,7 +556,7 @@ settingspath:
       arg_types: [ special::path ]
 
 fpath:
-  help: "[path]\n\tDirectory where output data files are written in receiver. Default is '/'. \n\tIf path does not exist, it will try to create it."
+  help: "[path]\n\tDirectory where output data files are written in receiver. Default is '/'. \n\tIf path does not exist and fwrite enabled, it will try to create it at start of acquisition."
   inherit_actions: STRING_COMMAND
   actions:
     GET:
@@ -985,7 +985,7 @@ findex:
       input_types: [ uint64_t ]
 
 fwrite:
-  help: "[0, 1]\n\tEnable or disable receiver file write. Default is 1."
+  help: "[0, 1]\n\tEnable or disable receiver file write. Default is 0."
   inherit_actions: INTEGER_COMMAND_VEC_ID
   actions:
     GET:

--- a/slsDetectorSoftware/generator/extended_commands.yaml
+++ b/slsDetectorSoftware/generator/extended_commands.yaml
@@ -3908,7 +3908,8 @@ fpath:
   command_name: fpath
   function_alias: fpath
   help: "[path]\n\tDirectory where output data files are written in receiver. Default\
-    \ is '/'. \n\tIf path does not exist, it will try to create it."
+    \ is '/'. \n\tIf path does not exist and fwrite enabled, it will try to create\
+    \ it at start of acquisition."
   infer_action: true
   template: true
 framecounter:
@@ -4101,7 +4102,7 @@ fwrite:
         store_result_in_t: false
   command_name: fwrite
   function_alias: fwrite
-  help: "[0, 1]\n\tEnable or disable receiver file write. Default is 1."
+  help: "[0, 1]\n\tEnable or disable receiver file write. Default is 0."
   infer_action: true
   template: true
 gaincaps:

--- a/slsDetectorSoftware/include/sls/Detector.h
+++ b/slsDetectorSoftware/include/sls/Detector.h
@@ -1004,7 +1004,8 @@ class Detector {
 
     Result<std::string> getFilePath(Positions pos = {}) const;
 
-    /** Default is "/"If path does not exist, it will try to create it */
+    /** Default is "/". If path does not exist and fwrite enabled, it will try
+     * to create it at start of acquisition. */
     void setFilePath(const std::string &fpath, Positions pos = {});
 
     Result<std::string> getFileNamePrefix(Positions pos = {}) const;
@@ -1025,7 +1026,7 @@ class Detector {
 
     Result<bool> getFileWrite(Positions pos = {}) const;
 
-    /** default enabled */
+    /** default disabled */
     void setFileWrite(bool value, Positions pos = {});
 
     bool getMasterFileWrite() const;

--- a/slsDetectorSoftware/src/Caller.cpp
+++ b/slsDetectorSoftware/src/Caller.cpp
@@ -5115,7 +5115,7 @@ std::string Caller::fpath(int action) {
         os << "Command: fpath" << std::endl;
         os << R"V0G0N([path]
 	Directory where output data files are written in receiver. Default is '/'. 
-	If path does not exist, it will try to create it. )V0G0N"
+	If path does not exist and fwrite enabled, it will try to create it at start of acquisition. )V0G0N"
            << std::endl;
         return os.str();
     }
@@ -5372,7 +5372,7 @@ std::string Caller::fwrite(int action) {
     if (action == slsDetectorDefs::HELP_ACTION) {
         os << "Command: fwrite" << std::endl;
         os << R"V0G0N([0, 1]
-	Enable or disable receiver file write. Default is 1. )V0G0N"
+	Enable or disable receiver file write. Default is 0. )V0G0N"
            << std::endl;
         return os.str();
     }

--- a/slsReceiverSoftware/src/Implementation.cpp
+++ b/slsReceiverSoftware/src/Implementation.cpp
@@ -530,10 +530,7 @@ void Implementation::setFileFormat(const fileFormat f) {
 std::string Implementation::getFilePath() const { return filePath; }
 
 void Implementation::setFilePath(const std::string &c) {
-    if (!c.empty()) {
-        mkdir_p(c); // throws if it can't create
-        filePath = c;
-    }
+    filePath = c;
     LOG(logINFO) << "File path: " << filePath;
 }
 
@@ -901,6 +898,9 @@ void Implementation::CreateUDPSockets() {
 
 void Implementation::SetupWriter() {
     try {
+        // check if folder exists and throw if it cant create
+        mkdir_p(filePath);
+        // create first files
         for (unsigned int i = 0; i < dataProcessor.size(); ++i) {
             std::ostringstream os;
             os << filePath << "/" << fileName << "_d"


### PR DESCRIPTION
rx: 
- moved creating fpath (if it doesnt exist) from setting file path to at the start of acquisition when creating file. This is done here so that it does not fail if fwrite is disabled anyway. 
- Fixed it in documentation. 
- Changed in documentation that the default for fwrite is disabled