### PR TITLE
Remove CALLER in test names

### DIFF
--- a/slsDetectorSoftware/tests/Caller/test-Caller-chiptestboard.cpp
+++ b/slsDetectorSoftware/tests/Caller/test-Caller-chiptestboard.cpp
@@ -19,7 +19,7 @@ using test::PUT;
 
 /* dacs */
 
-TEST_CASE("CALLER::dacname", "[.cmdcall]") {
+TEST_CASE("dacname", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -54,7 +54,7 @@ TEST_CASE("CALLER::dacname", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::dacindex", "[.cmdcall]") {
+TEST_CASE("dacindex", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -80,7 +80,7 @@ TEST_CASE("CALLER::dacindex", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::adclist", "[.cmdcall]") {
+TEST_CASE("adclist", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -113,7 +113,7 @@ TEST_CASE("CALLER::adclist", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::adcname", "[.cmdcall]") {
+TEST_CASE("adcname", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -148,7 +148,7 @@ TEST_CASE("CALLER::adcname", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::adcindex", "[.cmdcall]") {
+TEST_CASE("adcindex", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -174,7 +174,7 @@ TEST_CASE("CALLER::adcindex", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::signallist", "[.cmdcall]") {
+TEST_CASE("signallist", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -207,7 +207,7 @@ TEST_CASE("CALLER::signallist", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::signalname", "[.cmdcall]") {
+TEST_CASE("signalname", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -242,7 +242,7 @@ TEST_CASE("CALLER::signalname", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::signalindex", "[.cmdcall]") {
+TEST_CASE("signalindex", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -269,7 +269,7 @@ TEST_CASE("CALLER::signalindex", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::powerlist", "[.cmdcall]") {
+TEST_CASE("powerlist", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -302,7 +302,7 @@ TEST_CASE("CALLER::powerlist", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::powername", "[.cmdcall]") {
+TEST_CASE("powername", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -337,7 +337,7 @@ TEST_CASE("CALLER::powername", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::powerindex", "[.cmdcall]") {
+TEST_CASE("powerindex", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -364,7 +364,7 @@ TEST_CASE("CALLER::powerindex", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::powervalues", "[.cmdcall]") {
+TEST_CASE("powervalues", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -377,7 +377,7 @@ TEST_CASE("CALLER::powervalues", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::slowadcvalues", "[.cmdcall]") {
+TEST_CASE("slowadcvalues", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -390,7 +390,7 @@ TEST_CASE("CALLER::slowadcvalues", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::slowadclist", "[.cmdcall]") {
+TEST_CASE("slowadclist", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -423,7 +423,7 @@ TEST_CASE("CALLER::slowadclist", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::slowadcname", "[.cmdcall]") {
+TEST_CASE("slowadcname", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -459,7 +459,7 @@ TEST_CASE("CALLER::slowadcname", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::slowadcindex", "[.cmdcall]") {
+TEST_CASE("slowadcindex", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -488,7 +488,7 @@ TEST_CASE("CALLER::slowadcindex", "[.cmdcall]") {
 
 /* dacs */
 
-TEST_CASE("CALLER::dac", "[.cmdcall][.dacs]") {
+TEST_CASE("dac", "[.cmdcall][.dacs]") {
     // dac 0 to dac 17
 
     Detector det;
@@ -573,7 +573,7 @@ TEST_CASE("CALLER::dac", "[.cmdcall][.dacs]") {
     }
 }
 
-TEST_CASE("CALLER::adcvpp", "[.cmdcall]") {
+TEST_CASE("adcvpp", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -605,7 +605,7 @@ TEST_CASE("CALLER::adcvpp", "[.cmdcall]") {
 
 /* CTB Specific */
 
-TEST_CASE("CALLER::samples", "[.cmdcall]") {
+TEST_CASE("samples", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -649,7 +649,7 @@ TEST_CASE("CALLER::samples", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::asamples", "[.cmdcall]") {
+TEST_CASE("asamples", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -680,7 +680,7 @@ TEST_CASE("CALLER::asamples", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::adcclk", "[.cmdcall]") {
+TEST_CASE("adcclk", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -711,7 +711,7 @@ TEST_CASE("CALLER::adcclk", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::runclk", "[.cmdcall]") {
+TEST_CASE("runclk", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -742,7 +742,7 @@ TEST_CASE("CALLER::runclk", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::syncclk", "[.cmdcall]") {
+TEST_CASE("syncclk", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -754,7 +754,7 @@ TEST_CASE("CALLER::syncclk", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::v_limit", "[.cmdcall]") {
+TEST_CASE("v_limit", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -793,7 +793,7 @@ TEST_CASE("CALLER::v_limit", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::adcenable", "[.cmdcall]") {
+TEST_CASE("adcenable", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -823,7 +823,7 @@ TEST_CASE("CALLER::adcenable", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::adcenable10g", "[.cmdcall]") {
+TEST_CASE("adcenable10g", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -854,7 +854,7 @@ TEST_CASE("CALLER::adcenable10g", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::transceiverenable", "[.cmdcall]") {
+TEST_CASE("transceiverenable", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -887,7 +887,7 @@ TEST_CASE("CALLER::transceiverenable", "[.cmdcall]") {
 
 /* CTB Specific */
 
-TEST_CASE("CALLER::dsamples", "[.cmdcall]") {
+TEST_CASE("dsamples", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -918,7 +918,7 @@ TEST_CASE("CALLER::dsamples", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::tsamples", "[.cmdcall]") {
+TEST_CASE("tsamples", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -949,7 +949,7 @@ TEST_CASE("CALLER::tsamples", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::romode", "[.cmdcall]") {
+TEST_CASE("romode", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -1003,7 +1003,7 @@ TEST_CASE("CALLER::romode", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::dbitclk", "[.cmdcall]") {
+TEST_CASE("dbitclk", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -1034,7 +1034,7 @@ TEST_CASE("CALLER::dbitclk", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::v_a", "[.cmdcall]") {
+TEST_CASE("v_a", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -1056,7 +1056,7 @@ TEST_CASE("CALLER::v_a", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::v_b", "[.cmdcall]") {
+TEST_CASE("v_b", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -1078,7 +1078,7 @@ TEST_CASE("CALLER::v_b", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::v_c", "[.cmdcall]") {
+TEST_CASE("v_c", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -1100,7 +1100,7 @@ TEST_CASE("CALLER::v_c", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::v_d", "[.cmdcall]") {
+TEST_CASE("v_d", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -1122,7 +1122,7 @@ TEST_CASE("CALLER::v_d", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::v_io", "[.cmdcall]") {
+TEST_CASE("v_io", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -1135,7 +1135,7 @@ TEST_CASE("CALLER::v_io", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::v_chip", "[.cmdcall]") {
+TEST_CASE("v_chip", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -1147,7 +1147,7 @@ TEST_CASE("CALLER::v_chip", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::vm_a", "[.cmdcall]") {
+TEST_CASE("vm_a", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -1158,7 +1158,7 @@ TEST_CASE("CALLER::vm_a", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::vm_b", "[.cmdcall]") {
+TEST_CASE("vm_b", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -1169,7 +1169,7 @@ TEST_CASE("CALLER::vm_b", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::vm_c", "[.cmdcall]") {
+TEST_CASE("vm_c", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -1180,7 +1180,7 @@ TEST_CASE("CALLER::vm_c", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::vm_d", "[.cmdcall]") {
+TEST_CASE("vm_d", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -1191,7 +1191,7 @@ TEST_CASE("CALLER::vm_d", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::vm_io", "[.cmdcall]") {
+TEST_CASE("vm_io", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -1202,7 +1202,7 @@ TEST_CASE("CALLER::vm_io", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::im_a", "[.cmdcall]") {
+TEST_CASE("im_a", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -1213,7 +1213,7 @@ TEST_CASE("CALLER::im_a", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::im_b", "[.cmdcall]") {
+TEST_CASE("im_b", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -1224,7 +1224,7 @@ TEST_CASE("CALLER::im_b", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::im_c", "[.cmdcall]") {
+TEST_CASE("im_c", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -1235,7 +1235,7 @@ TEST_CASE("CALLER::im_c", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::im_d", "[.cmdcall]") {
+TEST_CASE("im_d", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -1246,7 +1246,7 @@ TEST_CASE("CALLER::im_d", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::im_io", "[.cmdcall]") {
+TEST_CASE("im_io", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -1257,7 +1257,7 @@ TEST_CASE("CALLER::im_io", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::slowadc", "[.cmdcall]") {
+TEST_CASE("slowadc", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -1273,7 +1273,7 @@ TEST_CASE("CALLER::slowadc", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::extsampling", "[.cmdcall]") {
+TEST_CASE("extsampling", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -1303,7 +1303,7 @@ TEST_CASE("CALLER::extsampling", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::extsamplingsrc", "[.cmdcall]") {
+TEST_CASE("extsamplingsrc", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -1334,7 +1334,7 @@ TEST_CASE("CALLER::extsamplingsrc", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::diodelay", "[.cmdcall]") {
+TEST_CASE("diodelay", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -1357,7 +1357,7 @@ TEST_CASE("CALLER::diodelay", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::led", "[.cmdcall]") {
+TEST_CASE("led", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();

--- a/slsDetectorSoftware/tests/Caller/test-Caller-eiger.cpp
+++ b/slsDetectorSoftware/tests/Caller/test-Caller-eiger.cpp
@@ -19,7 +19,7 @@ using test::PUT;
 
 /** temperature */
 
-TEST_CASE("CALLER::temp_fpgaext", "[.cmdcall]") {
+TEST_CASE("temp_fpgaext", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -34,7 +34,7 @@ TEST_CASE("CALLER::temp_fpgaext", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::temp_10ge", "[.cmdcall]") {
+TEST_CASE("temp_10ge", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -49,7 +49,7 @@ TEST_CASE("CALLER::temp_10ge", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::temp_dcdc", "[.cmdcall]") {
+TEST_CASE("temp_dcdc", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -64,7 +64,7 @@ TEST_CASE("CALLER::temp_dcdc", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::temp_sodl", "[.cmdcall]") {
+TEST_CASE("temp_sodl", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -79,7 +79,7 @@ TEST_CASE("CALLER::temp_sodl", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::temp_sodr", "[.cmdcall]") {
+TEST_CASE("temp_sodr", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -94,7 +94,7 @@ TEST_CASE("CALLER::temp_sodr", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::temp_fpgafl", "[.cmdcall]") {
+TEST_CASE("temp_fpgafl", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -109,7 +109,7 @@ TEST_CASE("CALLER::temp_fpgafl", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::temp_fpgafr", "[.cmdcall]") {
+TEST_CASE("temp_fpgafr", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -126,7 +126,7 @@ TEST_CASE("CALLER::temp_fpgafr", "[.cmdcall]") {
 
 /* dacs */
 
-TEST_CASE("CALLER::Setting and reading back EIGER dacs", "[.cmdcall][.dacs]") {
+TEST_CASE("Setting and reading back EIGER dacs", "[.cmdcall][.dacs]") {
     // vsvp, vtr, vrf, vrs, vsvn, vtgstv, vcmp_ll, vcmp_lr, vcal, vcmp_rl,
     // rxb_rb, rxb_lb, vcmp_rr, vcp, vcn, vis, vthreshold
     Detector det;
@@ -241,7 +241,7 @@ TEST_CASE("CALLER::Setting and reading back EIGER dacs", "[.cmdcall][.dacs]") {
 
 /* Network Configuration (Detector<->Receiver) */
 
-TEST_CASE("CALLER::txdelay_left", "[.cmdcall]") {
+TEST_CASE("txdelay_left", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -262,7 +262,7 @@ TEST_CASE("CALLER::txdelay_left", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::txdelay_right", "[.cmdcall]") {
+TEST_CASE("txdelay_right", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -285,7 +285,7 @@ TEST_CASE("CALLER::txdelay_right", "[.cmdcall]") {
 
 /* Eiger Specific */
 
-TEST_CASE("CALLER::subexptime", "[.cmdcall]") {
+TEST_CASE("subexptime", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
 
@@ -306,7 +306,7 @@ TEST_CASE("CALLER::subexptime", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::subdeadtime", "[.cmdcall]") {
+TEST_CASE("subdeadtime", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
 
@@ -327,7 +327,7 @@ TEST_CASE("CALLER::subdeadtime", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::overflow", "[.cmdcall]") {
+TEST_CASE("overflow", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -348,7 +348,7 @@ TEST_CASE("CALLER::overflow", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::ratecorr", "[.cmdcall]") {
+TEST_CASE("ratecorr", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -382,7 +382,7 @@ TEST_CASE("CALLER::ratecorr", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::interruptsubframe", "[.cmdcall]") {
+TEST_CASE("interruptsubframe", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -406,7 +406,7 @@ TEST_CASE("CALLER::interruptsubframe", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::measuredperiod", "[.cmdcall]") {
+TEST_CASE("measuredperiod", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -443,7 +443,7 @@ TEST_CASE("CALLER::measuredperiod", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::measuredsubperiod", "[.cmdcall]") {
+TEST_CASE("measuredsubperiod", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -483,7 +483,7 @@ TEST_CASE("CALLER::measuredsubperiod", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::activate", "[.cmdcall]") {
+TEST_CASE("activate", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -514,7 +514,7 @@ TEST_CASE("CALLER::activate", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::partialreset", "[.cmdcall]") {
+TEST_CASE("partialreset", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -536,7 +536,7 @@ TEST_CASE("CALLER::partialreset", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::pulse", "[.cmdcall]") {
+TEST_CASE("pulse", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -551,7 +551,7 @@ TEST_CASE("CALLER::pulse", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::pulsenmove", "[.cmdcall]") {
+TEST_CASE("pulsenmove", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -566,7 +566,7 @@ TEST_CASE("CALLER::pulsenmove", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::pulsechip", "[.cmdcall]") {
+TEST_CASE("pulsechip", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -581,7 +581,7 @@ TEST_CASE("CALLER::pulsechip", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::quad", "[.cmdcall]") {
+TEST_CASE("quad", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -597,7 +597,7 @@ TEST_CASE("CALLER::quad", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::datastream", "[.cmdcall]") {
+TEST_CASE("datastream", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -637,7 +637,7 @@ TEST_CASE("CALLER::datastream", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::top", "[.cmdcall]") {
+TEST_CASE("top", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();

--- a/slsDetectorSoftware/tests/Caller/test-Caller-gotthard.cpp
+++ b/slsDetectorSoftware/tests/Caller/test-Caller-gotthard.cpp
@@ -19,7 +19,7 @@ using test::PUT;
 
 /* dacs */
 
-TEST_CASE("Caller::Setting and reading back GOTTHARD dacs",
+TEST_CASE("Setting and reading back GOTTHARD dacs",
           "[.cmdcall][.dacs]") {
     // vref_ds, vcascn_pb, vcascp_pb, vout_cm, vcasc_out, vin_cm, vref_comp,
     // ib_test_c
@@ -110,7 +110,7 @@ TEST_CASE("Caller::Setting and reading back GOTTHARD dacs",
 
 /* Gotthard Specific */
 
-TEST_CASE("Caller::roi", "[.cmdcall]") {
+TEST_CASE("roi", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -141,7 +141,7 @@ TEST_CASE("Caller::roi", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::clearroi", "[.cmdcall]") {
+TEST_CASE("clearroi", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -161,7 +161,7 @@ TEST_CASE("Caller::clearroi", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::exptimel", "[.cmdcall]") {
+TEST_CASE("exptimel", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();

--- a/slsDetectorSoftware/tests/Caller/test-Caller-gotthard2.cpp
+++ b/slsDetectorSoftware/tests/Caller/test-Caller-gotthard2.cpp
@@ -18,7 +18,7 @@ using test::GET;
 using test::PUT;
 
 // time specific measurements for gotthard2
-TEST_CASE("Caller::timegotthard2", "[.cmdcall]") {
+TEST_CASE("timegotthard2", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -106,7 +106,7 @@ TEST_CASE("Caller::timegotthard2", "[.cmdcall]") {
 }
 /* dacs */
 
-TEST_CASE("Caller::Setting and reading back GOTTHARD2 dacs",
+TEST_CASE("Setting and reading back GOTTHARD2 dacs",
           "[.cmdcall][.dacs]") {
     // vref_h_adc,   vb_comp_fe, vb_comp_adc,  vcom_cds,
     // vref_restore, vb_opa_1st, vref_comp_fe, vcom_adc1,
@@ -216,7 +216,7 @@ TEST_CASE("Caller::Setting and reading back GOTTHARD2 dacs",
 
 /* on chip dacs */
 
-TEST_CASE("Caller::vchip_comp_fe", "[.cmdcall][.onchipdacs]") {
+TEST_CASE("vchip_comp_fe", "[.cmdcall][.onchipdacs]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -229,7 +229,7 @@ TEST_CASE("Caller::vchip_comp_fe", "[.cmdcall][.onchipdacs]") {
     }
 }
 
-TEST_CASE("Caller::vchip_opa_1st", "[.cmdcall][.onchipdacs]") {
+TEST_CASE("vchip_opa_1st", "[.cmdcall][.onchipdacs]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -242,7 +242,7 @@ TEST_CASE("Caller::vchip_opa_1st", "[.cmdcall][.onchipdacs]") {
     }
 }
 
-TEST_CASE("Caller::vchip_opa_fd", "[.cmdcall][.onchipdacs]") {
+TEST_CASE("vchip_opa_fd", "[.cmdcall][.onchipdacs]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -255,7 +255,7 @@ TEST_CASE("Caller::vchip_opa_fd", "[.cmdcall][.onchipdacs]") {
     }
 }
 
-TEST_CASE("Caller::vchip_comp_adc", "[.cmdcall][.onchipdacs]") {
+TEST_CASE("vchip_comp_adc", "[.cmdcall][.onchipdacs]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -268,7 +268,7 @@ TEST_CASE("Caller::vchip_comp_adc", "[.cmdcall][.onchipdacs]") {
     }
 }
 
-TEST_CASE("Caller::vchip_ref_comp_fe", "[.cmdcall][.onchipdacs]") {
+TEST_CASE("vchip_ref_comp_fe", "[.cmdcall][.onchipdacs]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -282,7 +282,7 @@ TEST_CASE("Caller::vchip_ref_comp_fe", "[.cmdcall][.onchipdacs]") {
     }
 }
 
-TEST_CASE("Caller::vchip_cs", "[.cmdcall][.onchipdacs]") {
+TEST_CASE("vchip_cs", "[.cmdcall][.onchipdacs]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -297,7 +297,7 @@ TEST_CASE("Caller::vchip_cs", "[.cmdcall][.onchipdacs]") {
 
 /* Gotthard2 Specific */
 
-TEST_CASE("Caller::bursts", "[.cmdcall]") {
+TEST_CASE("bursts", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -371,7 +371,7 @@ TEST_CASE("Caller::bursts", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::burstperiod", "[.cmdcall]") {
+TEST_CASE("burstperiod", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -393,7 +393,7 @@ TEST_CASE("Caller::burstperiod", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::burstsl", "[.cmdcall]") {
+TEST_CASE("burstsl", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -404,7 +404,7 @@ TEST_CASE("Caller::burstsl", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::inj_ch", "[.cmdcall]") {
+TEST_CASE("inj_ch", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -429,7 +429,7 @@ TEST_CASE("Caller::inj_ch", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::vetophoton", "[.cmdcall]") {
+TEST_CASE("vetophoton", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -451,7 +451,7 @@ TEST_CASE("Caller::vetophoton", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::vetoref", "[.cmdcall]") {
+TEST_CASE("vetoref", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -466,7 +466,7 @@ TEST_CASE("Caller::vetoref", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::vetofile", "[.cmdcall]") {
+TEST_CASE("vetofile", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -480,7 +480,7 @@ TEST_CASE("Caller::vetofile", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::burstmode", "[.cmdcall]") {
+TEST_CASE("burstmode", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -511,7 +511,7 @@ TEST_CASE("Caller::burstmode", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::cdsgain", "[.cmdcall]") {
+TEST_CASE("cdsgain", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -541,7 +541,7 @@ TEST_CASE("Caller::cdsgain", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::timingsource", "[.cmdcall]") {
+TEST_CASE("timingsource", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -571,7 +571,7 @@ TEST_CASE("Caller::timingsource", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::veto", "[.cmdcall]") {
+TEST_CASE("veto", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -601,7 +601,7 @@ TEST_CASE("Caller::veto", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::vetostream", "[.cmdcall]") {
+TEST_CASE("vetostream", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -647,7 +647,7 @@ TEST_CASE("Caller::vetostream", "[.cmdcall]") {
     REQUIRE_THROWS(caller.call("vetostream", {"dfgd"}, -1, GET));
 }
 
-TEST_CASE("Caller::vetoalg", "[.cmdcall]") {
+TEST_CASE("vetoalg", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -703,7 +703,7 @@ TEST_CASE("Caller::vetoalg", "[.cmdcall]") {
     REQUIRE_THROWS(caller.call("vetoalg", {"dfgd"}, -1, GET));
 }
 
-TEST_CASE("Caller::confadc", "[.cmdcall]") {
+TEST_CASE("confadc", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();

--- a/slsDetectorSoftware/tests/Caller/test-Caller-jungfrau.cpp
+++ b/slsDetectorSoftware/tests/Caller/test-Caller-jungfrau.cpp
@@ -17,7 +17,7 @@ using test::PUT;
 
 /* dacs */
 
-TEST_CASE("Caller::Setting and reading back Jungfrau dacs",
+TEST_CASE("Setting and reading back Jungfrau dacs",
           "[.cmdcall][.dacs]") {
     // vb_comp, vdd_prot, vin_com, vref_prech, vb_pixbuf, vb_ds, vref_ds,
     // vref_comp
@@ -105,7 +105,7 @@ TEST_CASE("Caller::Setting and reading back Jungfrau dacs",
 
 /* Network Configuration (Detector<->Receiver) */
 
-TEST_CASE("Caller::selinterface", "[.cmdcall]") {
+TEST_CASE("selinterface", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -136,7 +136,7 @@ TEST_CASE("Caller::selinterface", "[.cmdcall]") {
 
 /* Jungfrau/moench Specific */
 
-TEST_CASE("Caller::temp_threshold", "[.cmdcall]") {
+TEST_CASE("temp_threshold", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -166,7 +166,7 @@ TEST_CASE("Caller::temp_threshold", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::chipversion", "[.cmdcall]") {
+TEST_CASE("chipversion", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -178,7 +178,7 @@ TEST_CASE("Caller::chipversion", "[.cmdcall]") {
     REQUIRE_THROWS(caller.call("chipversion", {"0"}, -1, PUT));
 }
 
-TEST_CASE("Caller::temp_control", "[.cmdcall]") {
+TEST_CASE("temp_control", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -208,7 +208,7 @@ TEST_CASE("Caller::temp_control", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::temp_event", "[.cmdcall]") {
+TEST_CASE("temp_event", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -229,7 +229,7 @@ TEST_CASE("Caller::temp_event", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::autocompdisable", "[.cmdcall]") {
+TEST_CASE("autocompdisable", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -259,7 +259,7 @@ TEST_CASE("Caller::autocompdisable", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::compdisabletime", "[.cmdcall]") {
+TEST_CASE("compdisabletime", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -290,7 +290,7 @@ TEST_CASE("Caller::compdisabletime", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::extrastoragecells", "[.cmdcall]") {
+TEST_CASE("extrastoragecells", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -333,7 +333,7 @@ TEST_CASE("Caller::extrastoragecells", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::storagecell_start", "[.cmdcall]") {
+TEST_CASE("storagecell_start", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -378,7 +378,7 @@ TEST_CASE("Caller::storagecell_start", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::storagecell_delay", "[.cmdcall]") {
+TEST_CASE("storagecell_delay", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -419,7 +419,7 @@ TEST_CASE("Caller::storagecell_delay", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::gainmode", "[.cmdcall]") {
+TEST_CASE("gainmode", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -468,7 +468,7 @@ TEST_CASE("Caller::gainmode", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::filtercells", "[.cmdcall]") {
+TEST_CASE("filtercells", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -512,7 +512,7 @@ TEST_CASE("Caller::filtercells", "[.cmdcall]") {
         REQUIRE_THROWS(caller.call("filtercells", {"0"}, -1, PUT));
     }
 }
-TEST_CASE("Caller::pedestalmode", "[.cmdcall]") {
+TEST_CASE("pedestalmode", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -667,7 +667,7 @@ TEST_CASE("Caller::pedestalmode", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::timing_info_decoder", "[.cmdcall]") {
+TEST_CASE("timing_info_decoder", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     if (det.getDetectorType().squash() == defs::JUNGFRAU) {
@@ -695,7 +695,7 @@ TEST_CASE("Caller::timing_info_decoder", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::collectionmode", "[.cmdcall]") {
+TEST_CASE("collectionmode", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     if (det.getDetectorType().squash() == defs::JUNGFRAU) {
@@ -723,7 +723,7 @@ TEST_CASE("Caller::collectionmode", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::sync", "[.cmdcall]") {
+TEST_CASE("sync", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();

--- a/slsDetectorSoftware/tests/Caller/test-Caller-moench.cpp
+++ b/slsDetectorSoftware/tests/Caller/test-Caller-moench.cpp
@@ -17,7 +17,7 @@ using test::PUT;
 
 /* dacs */
 
-TEST_CASE("Caller::Setting and reading back moench dacs", "[.cmdcall][.dacs]") {
+TEST_CASE("Setting and reading back moench dacs", "[.cmdcall][.dacs]") {
     // vbp_colbuf, vipre, vin_cm, vb_sda, vcasc_sfp, vout_cm, vipre_cds,
     // ibias_sfp
     Detector det;

--- a/slsDetectorSoftware/tests/Caller/test-Caller-mythen3.cpp
+++ b/slsDetectorSoftware/tests/Caller/test-Caller-mythen3.cpp
@@ -19,7 +19,7 @@ using test::PUT;
 
 /* dacs */
 
-TEST_CASE("Caller::Setting and reading back MYTHEN3 dacs",
+TEST_CASE("Setting and reading back MYTHEN3 dacs",
           "[.cmdcall][.dacs]") {
     // vcassh, vth2, vshaper, vshaperneg, vipre_out, vth3, vth1,
     // vicin, vcas, vpreamp, vpl, vipre, viinsh, vph, vtrim, vdcsh,
@@ -185,7 +185,7 @@ TEST_CASE("Caller::Setting and reading back MYTHEN3 dacs",
 
 /* acquisition */
 
-TEST_CASE("Caller::readout", "[.cmdcall]") {
+TEST_CASE("readout", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     // PUT only command
@@ -202,7 +202,7 @@ TEST_CASE("Caller::readout", "[.cmdcall]") {
 
 /* Mythen3 Specific */
 
-TEST_CASE("Caller::counters", "[.cmdcall]") {
+TEST_CASE("counters", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -234,7 +234,7 @@ TEST_CASE("Caller::counters", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::gates", "[.cmdcall]") {
+TEST_CASE("gates", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -264,7 +264,7 @@ TEST_CASE("Caller::gates", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::exptime1", "[.cmdcall]") {
+TEST_CASE("exptime1", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -293,7 +293,7 @@ TEST_CASE("Caller::exptime1", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::exptime2", "[.cmdcall]") {
+TEST_CASE("exptime2", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -322,7 +322,7 @@ TEST_CASE("Caller::exptime2", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::exptime3", "[.cmdcall]") {
+TEST_CASE("exptime3", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -351,7 +351,7 @@ TEST_CASE("Caller::exptime3", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::gatedelay", "[.cmdcall]") {
+TEST_CASE("gatedelay", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -387,7 +387,7 @@ TEST_CASE("Caller::gatedelay", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::gatedelay1", "[.cmdcall]") {
+TEST_CASE("gatedelay1", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -416,7 +416,7 @@ TEST_CASE("Caller::gatedelay1", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::gatedelay2", "[.cmdcall]") {
+TEST_CASE("gatedelay2", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -445,7 +445,7 @@ TEST_CASE("Caller::gatedelay2", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::gatedelay3", "[.cmdcall]") {
+TEST_CASE("gatedelay3", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -474,7 +474,7 @@ TEST_CASE("Caller::gatedelay3", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::polarity", "[.cmdcall]") {
+TEST_CASE("polarity", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     if (det.getDetectorType().squash() == defs::MYTHEN3) {
@@ -502,7 +502,7 @@ TEST_CASE("Caller::polarity", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::interpolation", "[.cmdcall]") {
+TEST_CASE("interpolation", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     if (det.getDetectorType().squash() == defs::MYTHEN3) {
@@ -556,7 +556,7 @@ TEST_CASE("Caller::interpolation", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::pumpprobe", "[.cmdcall]") {
+TEST_CASE("pumpprobe", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     if (det.getDetectorType().squash() == defs::MYTHEN3) {
@@ -633,7 +633,7 @@ TEST_CASE("Caller::pumpprobe", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::apulse", "[.cmdcall]") {
+TEST_CASE("apulse", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     if (det.getDetectorType().squash() == defs::MYTHEN3) {
@@ -661,7 +661,7 @@ TEST_CASE("Caller::apulse", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::dpulse", "[.cmdcall]") {
+TEST_CASE("dpulse", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     if (det.getDetectorType().squash() == defs::MYTHEN3) {

--- a/slsDetectorSoftware/tests/Caller/test-Caller-pattern.cpp
+++ b/slsDetectorSoftware/tests/Caller/test-Caller-pattern.cpp
@@ -19,7 +19,7 @@ using test::PUT;
 
 /* Pattern */
 
-TEST_CASE("Caller::patfname", "[.cmdcall]") {
+TEST_CASE("patfname", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -32,7 +32,7 @@ TEST_CASE("Caller::patfname", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::pattern", "[.cmdcall]") {
+TEST_CASE("pattern", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -45,7 +45,7 @@ TEST_CASE("Caller::pattern", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::savepattern", "[.cmdcall]") {
+TEST_CASE("savepattern", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -63,7 +63,7 @@ TEST_CASE("Caller::savepattern", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::defaultpattern", "[.cmdcall]") {
+TEST_CASE("defaultpattern", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -76,7 +76,7 @@ TEST_CASE("Caller::defaultpattern", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::patioctrl", "[.cmdcall]") {
+TEST_CASE("patioctrl", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -107,7 +107,7 @@ TEST_CASE("Caller::patioctrl", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::patword", "[.cmdcall]") {
+TEST_CASE("patword", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -149,7 +149,7 @@ TEST_CASE("Caller::patword", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::patlimits", "[.cmdcall]") {
+TEST_CASE("patlimits", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -176,7 +176,7 @@ TEST_CASE("Caller::patlimits", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::patloop", "[.cmdcall]") {
+TEST_CASE("patloop", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -225,7 +225,7 @@ TEST_CASE("Caller::patloop", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::patnloop", "[.cmdcall]") {
+TEST_CASE("patnloop", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -271,7 +271,7 @@ TEST_CASE("Caller::patnloop", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::patwait", "[.cmdcall]") {
+TEST_CASE("patwait", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -317,7 +317,7 @@ TEST_CASE("Caller::patwait", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::patwaittime", "[.cmdcall]") {
+TEST_CASE("patwaittime", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -363,7 +363,7 @@ TEST_CASE("Caller::patwaittime", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::patmask", "[.cmdcall]") {
+TEST_CASE("patmask", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -389,7 +389,7 @@ TEST_CASE("Caller::patmask", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::patsetbit", "[.cmdcall]") {
+TEST_CASE("patsetbit", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -415,7 +415,7 @@ TEST_CASE("Caller::patsetbit", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::patternstart", "[.cmdcall]") {
+TEST_CASE("patternstart", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     REQUIRE_THROWS(caller.call("patternstart", {}, -1, GET));

--- a/slsDetectorSoftware/tests/Caller/test-Caller-rx.cpp
+++ b/slsDetectorSoftware/tests/Caller/test-Caller-rx.cpp
@@ -24,7 +24,7 @@ python/scripts/list_tested_cmd.py to check if all commands are covered
 
 /* configuration */
 
-TEST_CASE("Caller::rx_version", "[.cmdcall][.rx]") {
+TEST_CASE("rx_version", "[.cmdcall][.rx]") {
     Detector det;
     Caller caller(&det);
     std::ostringstream oss;
@@ -38,7 +38,7 @@ TEST_CASE("Caller::rx_version", "[.cmdcall][.rx]") {
 }
 
 /* acquisition */
-TEST_CASE("Caller::rx_start", "[.cmdcall][.rx]") {
+TEST_CASE("rx_start", "[.cmdcall][.rx]") {
     Detector det;
     Caller caller(&det);
     det.setFileWrite(false); // avoid writing or error on file creation
@@ -56,7 +56,7 @@ TEST_CASE("Caller::rx_start", "[.cmdcall][.rx]") {
     }
 }
 
-TEST_CASE("Caller::rx_stop", "[.cmdcall][.rx]") {
+TEST_CASE("rx_stop", "[.cmdcall][.rx]") {
     Detector det;
     Caller caller(&det);
     // PUT only command
@@ -73,7 +73,7 @@ TEST_CASE("Caller::rx_stop", "[.cmdcall][.rx]") {
     }
 }
 
-TEST_CASE("Caller::rx_status", "[.cmdcall][.rx]") {
+TEST_CASE("rx_status", "[.cmdcall][.rx]") {
     Detector det;
     Caller caller(&det);
     det.setFileWrite(false); // avoid writing or error on file creation
@@ -91,7 +91,7 @@ TEST_CASE("Caller::rx_status", "[.cmdcall][.rx]") {
     }
 }
 
-TEST_CASE("Caller::rx_framescaught", "[.cmdcall][.rx]") {
+TEST_CASE("rx_framescaught", "[.cmdcall][.rx]") {
     Detector det;
     Caller caller(&det);
     // This ensures 0 caught frames
@@ -125,7 +125,7 @@ TEST_CASE("Caller::rx_framescaught", "[.cmdcall][.rx]") {
     }
 }
 
-TEST_CASE("Caller::rx_missingpackets", "[.cmdcall][.rx]") {
+TEST_CASE("rx_missingpackets", "[.cmdcall][.rx]") {
     Detector det;
     Caller caller(&det);
     auto prev_val = det.getFileWrite();
@@ -170,7 +170,7 @@ TEST_CASE("Caller::rx_missingpackets", "[.cmdcall][.rx]") {
     det.setNumberOfFrames(prev_frames);
 }
 
-TEST_CASE("Caller::rx_frameindex", "[.cmdcall][.rx]") {
+TEST_CASE("rx_frameindex", "[.cmdcall][.rx]") {
     Detector det;
     Caller caller(&det);
     caller.call("rx_frameindex", {}, -1, GET);
@@ -181,7 +181,7 @@ TEST_CASE("Caller::rx_frameindex", "[.cmdcall][.rx]") {
 
 /* Network Configuration (Detector<->Receiver) */
 
-TEST_CASE("Caller::rx_printconfig", "[.cmdcall][.rx]") {
+TEST_CASE("rx_printconfig", "[.cmdcall][.rx]") {
     Detector det;
     Caller caller(&det);
     REQUIRE_NOTHROW(caller.call("rx_printconfig", {}, -1, GET));
@@ -189,7 +189,7 @@ TEST_CASE("Caller::rx_printconfig", "[.cmdcall][.rx]") {
 
 /* Receiver Config */
 
-TEST_CASE("Caller::rx_hostname", "[.cmdcall][.rx]") {
+TEST_CASE("rx_hostname", "[.cmdcall][.rx]") {
     Detector det;
     Caller caller(&det);
     auto prev_val = det.getRxHostname();
@@ -221,7 +221,7 @@ TEST_CASE("Caller::rx_hostname", "[.cmdcall][.rx]") {
     }
 }
 
-TEST_CASE("Caller::rx_tcpport", "[.cmdcall][.rx]") {
+TEST_CASE("rx_tcpport", "[.cmdcall][.rx]") {
     Detector det;
     Caller caller(&det);
     auto prev_val = det.getRxPort();
@@ -260,7 +260,7 @@ TEST_CASE("Caller::rx_tcpport", "[.cmdcall][.rx]") {
     }
 }
 
-TEST_CASE("Caller::rx_fifodepth", "[.cmdcall][.rx]") {
+TEST_CASE("rx_fifodepth", "[.cmdcall][.rx]") {
     Detector det;
     Caller caller(&det);
     auto prev_val = det.getRxFifoDepth();
@@ -284,7 +284,7 @@ TEST_CASE("Caller::rx_fifodepth", "[.cmdcall][.rx]") {
     }
 }
 
-TEST_CASE("Caller::rx_silent", "[.cmdcall][.rx]") {
+TEST_CASE("rx_silent", "[.cmdcall][.rx]") {
     Detector det;
     Caller caller(&det);
     auto prev_val = det.getRxSilentMode();
@@ -308,7 +308,7 @@ TEST_CASE("Caller::rx_silent", "[.cmdcall][.rx]") {
     }
 }
 
-TEST_CASE("Caller::rx_discardpolicy", "[.cmdcall][.rx]") {
+TEST_CASE("rx_discardpolicy", "[.cmdcall][.rx]") {
     Detector det;
     Caller caller(&det);
     auto prev_val = det.getRxFrameDiscardPolicy();
@@ -337,7 +337,7 @@ TEST_CASE("Caller::rx_discardpolicy", "[.cmdcall][.rx]") {
     }
 }
 
-TEST_CASE("Caller::rx_padding", "[.cmdcall][.rx]") {
+TEST_CASE("rx_padding", "[.cmdcall][.rx]") {
     Detector det;
     Caller caller(&det);
     auto prev_val = det.getPartialFramesPadding();
@@ -361,7 +361,7 @@ TEST_CASE("Caller::rx_padding", "[.cmdcall][.rx]") {
     }
 }
 
-TEST_CASE("Caller::rx_udpsocksize", "[.cmdcall][.rx]") {
+TEST_CASE("rx_udpsocksize", "[.cmdcall][.rx]") {
     Detector det;
     Caller caller(&det);
     int64_t prev_val = det.getRxUDPSocketBufferSize().tsquash(
@@ -381,7 +381,7 @@ TEST_CASE("Caller::rx_udpsocksize", "[.cmdcall][.rx]") {
     det.setRxUDPSocketBufferSize(prev_val);
 }
 
-TEST_CASE("Caller::rx_realudpsocksize", "[.cmdcall][.rx]") {
+TEST_CASE("rx_realudpsocksize", "[.cmdcall][.rx]") {
     Detector det;
     Caller caller(&det);
     uint64_t val = 0;
@@ -400,7 +400,7 @@ TEST_CASE("Caller::rx_realudpsocksize", "[.cmdcall][.rx]") {
     }
 }
 
-TEST_CASE("Caller::rx_lock", "[.cmdcall][.rx]") {
+TEST_CASE("rx_lock", "[.cmdcall][.rx]") {
     Detector det;
     Caller caller(&det);
     auto prev_val = det.getRxLock();
@@ -424,7 +424,7 @@ TEST_CASE("Caller::rx_lock", "[.cmdcall][.rx]") {
     }
 }
 
-TEST_CASE("Caller::rx_lastclient", "[.cmdcall][.rx]") {
+TEST_CASE("rx_lastclient", "[.cmdcall][.rx]") {
     Detector det;
     Caller caller(&det);
     std::ostringstream oss;
@@ -434,14 +434,14 @@ TEST_CASE("Caller::rx_lastclient", "[.cmdcall][.rx]") {
     }
 }
 
-TEST_CASE("Caller::rx_threads", "[.cmdcall][.rx]") {
+TEST_CASE("rx_threads", "[.cmdcall][.rx]") {
     Detector det;
     Caller caller(&det);
     std::ostringstream oss;
     REQUIRE_NOTHROW(caller.call("rx_threads", {}, -1, GET, oss));
 }
 
-TEST_CASE("Caller::rx_arping", "[.cmdcall][.rx]") {
+TEST_CASE("rx_arping", "[.cmdcall][.rx]") {
     Detector det;
     Caller caller(&det);
     auto prev_val = det.getRxArping();
@@ -465,7 +465,7 @@ TEST_CASE("Caller::rx_arping", "[.cmdcall][.rx]") {
     }
 }
 
-TEST_CASE("Caller::rx_roi", "[.cmdcall]") {
+TEST_CASE("rx_roi", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -527,7 +527,7 @@ TEST_CASE("Caller::rx_roi", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::rx_clearroi", "[.cmdcall]") {
+TEST_CASE("rx_clearroi", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -549,7 +549,7 @@ TEST_CASE("Caller::rx_clearroi", "[.cmdcall]") {
 
 /* File */
 
-TEST_CASE("Caller::fformat", "[.cmdcall]") {
+TEST_CASE("fformat", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto prev_val = det.getFileFormat();
@@ -568,7 +568,7 @@ TEST_CASE("Caller::fformat", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::fpath", "[.cmdcall]") {
+TEST_CASE("fpath", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto prev_val = det.getFilePath();
@@ -587,7 +587,7 @@ TEST_CASE("Caller::fpath", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::fname", "[.cmdcall]") {
+TEST_CASE("fname", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto prev_val = det.getFileNamePrefix();
@@ -614,7 +614,7 @@ TEST_CASE("Caller::fname", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::findex", "[.cmdcall]") {
+TEST_CASE("findex", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto prev_val = det.getAcquisitionIndex();
@@ -638,7 +638,7 @@ TEST_CASE("Caller::findex", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::fwrite", "[.cmdcall]") {
+TEST_CASE("fwrite", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto prev_val = det.getFileWrite();
@@ -662,7 +662,7 @@ TEST_CASE("Caller::fwrite", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::fmaster", "[.cmdcall]") {
+TEST_CASE("fmaster", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto prev_val = det.getMasterFileWrite();
@@ -684,7 +684,7 @@ TEST_CASE("Caller::fmaster", "[.cmdcall]") {
     det.setMasterFileWrite(prev_val);
 }
 
-TEST_CASE("Caller::foverwrite", "[.cmdcall]") {
+TEST_CASE("foverwrite", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto prev_val = det.getFileOverWrite();
@@ -708,7 +708,7 @@ TEST_CASE("Caller::foverwrite", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("Caller::rx_framesperfile", "[.cmdcall][.rx]") {
+TEST_CASE("rx_framesperfile", "[.cmdcall][.rx]") {
     Detector det;
     Caller caller(&det);
     auto prev_val = det.getFramesPerFile();
@@ -739,7 +739,7 @@ TEST_CASE("Caller::rx_framesperfile", "[.cmdcall][.rx]") {
 
 /* ZMQ Streaming Parameters (Receiver<->Client) */
 
-TEST_CASE("Caller::rx_zmqstream", "[.cmdcall][.rx]") {
+TEST_CASE("rx_zmqstream", "[.cmdcall][.rx]") {
     Detector det;
     Caller caller(&det);
     auto prev_val = det.getRxZmqDataStream();
@@ -765,7 +765,7 @@ TEST_CASE("Caller::rx_zmqstream", "[.cmdcall][.rx]") {
     }
 }
 
-TEST_CASE("Caller::rx_zmqfreq", "[.cmdcall][.rx]") {
+TEST_CASE("rx_zmqfreq", "[.cmdcall][.rx]") {
     Detector det;
     Caller caller(&det);
     auto prev_val = det.getRxZmqFrequency();
@@ -789,7 +789,7 @@ TEST_CASE("Caller::rx_zmqfreq", "[.cmdcall][.rx]") {
     }
 }
 
-TEST_CASE("Caller::rx_zmqstartfnum", "[.cmdcall][.rx]") {
+TEST_CASE("rx_zmqstartfnum", "[.cmdcall][.rx]") {
     Detector det;
     Caller caller(&det);
     auto prev_val = det.getRxZmqStartingFrame();
@@ -813,7 +813,7 @@ TEST_CASE("Caller::rx_zmqstartfnum", "[.cmdcall][.rx]") {
     }
 }
 
-TEST_CASE("Caller::rx_zmqport", "[.cmdcall][.rx]") {
+TEST_CASE("rx_zmqport", "[.cmdcall][.rx]") {
     Detector det;
     Caller caller(&det);
     auto prev_val_zmqport = det.getRxZmqPort();
@@ -861,7 +861,7 @@ TEST_CASE("Caller::rx_zmqport", "[.cmdcall][.rx]") {
     }
 }
 
-TEST_CASE("Caller::rx_zmqhwm", "[.cmdcall]") {
+TEST_CASE("rx_zmqhwm", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto prev_val =
@@ -891,7 +891,7 @@ TEST_CASE("Caller::rx_zmqhwm", "[.cmdcall]") {
 
 /* CTB Specific */
 
-TEST_CASE("Caller::rx_dbitlist", "[.cmdcall][.rx]") {
+TEST_CASE("rx_dbitlist", "[.cmdcall][.rx]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -921,7 +921,7 @@ TEST_CASE("Caller::rx_dbitlist", "[.cmdcall][.rx]") {
     }
 }
 
-TEST_CASE("Caller::rx_dbitoffset", "[.cmdcall][.rx]") {
+TEST_CASE("rx_dbitoffset", "[.cmdcall][.rx]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -956,7 +956,7 @@ TEST_CASE("Caller::rx_dbitoffset", "[.cmdcall][.rx]") {
     }
 }
 
-TEST_CASE("Caller::rx_jsonaddheader", "[.cmdcall][.rx]") {
+TEST_CASE("rx_jsonaddheader", "[.cmdcall][.rx]") {
     Detector det;
     Caller caller(&det);
     auto prev_val = det.getAdditionalJsonHeader();
@@ -982,7 +982,7 @@ TEST_CASE("Caller::rx_jsonaddheader", "[.cmdcall][.rx]") {
     }
 }
 
-TEST_CASE("Caller::rx_jsonpara", "[.cmdcall][.rx]") {
+TEST_CASE("rx_jsonpara", "[.cmdcall][.rx]") {
     Detector det;
     Caller caller(&det);
     auto prev_val = det.getAdditionalJsonHeader();

--- a/slsDetectorSoftware/tests/Caller/test-Caller-xilinx-chiptestboard.cpp
+++ b/slsDetectorSoftware/tests/Caller/test-Caller-xilinx-chiptestboard.cpp
@@ -19,7 +19,7 @@ using test::PUT;
 
 /* dacs */
 
-TEST_CASE("CALLER::configtransceiver", "[.cmdcall]") {
+TEST_CASE("configtransceiver", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();

--- a/slsDetectorSoftware/tests/Caller/test-Caller.cpp
+++ b/slsDetectorSoftware/tests/Caller/test-Caller.cpp
@@ -18,7 +18,7 @@ namespace sls {
 using test::GET;
 using test::PUT;
 
-TEST_CASE("CALLER::Caller::Calling help doesn't throw or cause segfault") {
+TEST_CASE("Calling help doesn't throw or cause segfault") {
     // Dont add [.cmdcall] tag this should run with normal tests
     Caller caller(nullptr);
     std::ostringstream os;
@@ -27,7 +27,7 @@ TEST_CASE("CALLER::Caller::Calling help doesn't throw or cause segfault") {
             caller.call(cmd, {}, -1, slsDetectorDefs::HELP_ACTION, os));
 }
 
-TEST_CASE("CALLER::Unknown command", "[.cmdcall]") {
+TEST_CASE("Unknown command", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     REQUIRE_THROWS(caller.call("vsaevrreavv", {}, -1, PUT));
@@ -35,7 +35,7 @@ TEST_CASE("CALLER::Unknown command", "[.cmdcall]") {
 
 /* configuration */
 
-TEST_CASE("CALLER::config", "[.cmdcall]") {
+TEST_CASE("config", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     // put only
@@ -44,7 +44,7 @@ TEST_CASE("CALLER::config", "[.cmdcall]") {
 
 // free: not testing
 
-TEST_CASE("CALLER::parameters", "[.cmdcall]") {
+TEST_CASE("parameters", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     // put only
@@ -70,13 +70,13 @@ TEST_CASE("CALLER::parameters", "[.cmdcall]") {
         */
 }
 
-TEST_CASE("CALLER::hostname", "[.cmdcall]") {
+TEST_CASE("hostname", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     REQUIRE_NOTHROW(caller.call("hostname", {}, -1, GET));
 }
 
-TEST_CASE("CALLER::virtual", "[.cmdcall]") {
+TEST_CASE("virtual", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     REQUIRE_THROWS(caller.call("virtual", {}, -1, GET));
@@ -84,56 +84,56 @@ TEST_CASE("CALLER::virtual", "[.cmdcall]") {
     REQUIRE_THROWS(caller.call("virtual", {"3", "65534"}, -1, PUT));
 }
 
-TEST_CASE("CALLER::versions", "[.cmdcall]") {
+TEST_CASE("versions", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     REQUIRE_NOTHROW(caller.call("versions", {}, -1, GET));
     REQUIRE_THROWS(caller.call("versions", {"0"}, -1, PUT));
 }
 
-TEST_CASE("CALLER::packageversion", "[.cmdcall]") {
+TEST_CASE("packageversion", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     REQUIRE_NOTHROW(caller.call("packageversion", {}, -1, GET));
     REQUIRE_THROWS(caller.call("packageversion", {"0"}, -1, PUT));
 }
 
-TEST_CASE("CALLER::clientversion", "[.cmdcall]") {
+TEST_CASE("clientversion", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     REQUIRE_NOTHROW(caller.call("clientversion", {}, -1, GET));
     REQUIRE_THROWS(caller.call("clientversion", {"0"}, -1, PUT));
 }
 
-TEST_CASE("CALLER::firmwareversion", "[.cmdcall]") {
+TEST_CASE("firmwareversion", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     REQUIRE_NOTHROW(caller.call("firmwareversion", {}, -1, GET));
     REQUIRE_THROWS(caller.call("firmwareversion", {"0"}, -1, PUT));
 }
 
-TEST_CASE("CALLER::detectorserverversion", "[.cmdcall]") {
+TEST_CASE("detectorserverversion", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     REQUIRE_NOTHROW(caller.call("detectorserverversion", {}, -1, GET));
     REQUIRE_THROWS(caller.call("detectorserverversion", {"0"}, -1, PUT));
 }
 
-TEST_CASE("CALLER::hardwareversion", "[.cmdcall]") {
+TEST_CASE("hardwareversion", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     REQUIRE_NOTHROW(caller.call("hardwareversion", {}, -1, GET));
     REQUIRE_THROWS(caller.call("hardwareversion", {"0"}, -1, PUT));
 }
 
-TEST_CASE("CALLER::kernelversion", "[.cmdcall]") {
+TEST_CASE("kernelversion", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     REQUIRE_NOTHROW(caller.call("kernelversion", {}, -1, GET));
     REQUIRE_THROWS(caller.call("kernelversion", {"0"}, -1, PUT));
 }
 
-TEST_CASE("CALLER::serialnumber", "[.cmdcall]") {
+TEST_CASE("serialnumber", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -144,7 +144,7 @@ TEST_CASE("CALLER::serialnumber", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::moduleid", "[.cmdcall]") {
+TEST_CASE("moduleid", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -157,7 +157,7 @@ TEST_CASE("CALLER::moduleid", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::type", "[.cmdcall]") {
+TEST_CASE("type", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto dt = det.getDetectorType().squash();
@@ -169,13 +169,13 @@ TEST_CASE("CALLER::type", "[.cmdcall]") {
     // REQUIRE(dt == test::type);
 }
 
-TEST_CASE("CALLER::detsize", "[.cmdcall]") {
+TEST_CASE("detsize", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     REQUIRE_NOTHROW(caller.call("detsize", {}, -1, GET));
 }
 
-TEST_CASE("CALLER::settingslist", "[.cmdcall]") {
+TEST_CASE("settingslist", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -188,7 +188,7 @@ TEST_CASE("CALLER::settingslist", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::settings", "[.cmdcall]") {
+TEST_CASE("settings", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -286,7 +286,7 @@ TEST_CASE("CALLER::settings", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::threshold", "[.cmdcall]") {
+TEST_CASE("threshold", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
 
@@ -365,7 +365,7 @@ TEST_CASE("CALLER::threshold", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::thresholdnotb", "[.cmdcall]") {
+TEST_CASE("thresholdnotb", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
 
@@ -445,7 +445,7 @@ TEST_CASE("CALLER::thresholdnotb", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::settingspath", "[.cmdcall]") {
+TEST_CASE("settingspath", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto prev_val = det.getSettingsPath();
@@ -461,13 +461,13 @@ TEST_CASE("CALLER::settingspath", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::trimbits", "[.cmdcall]") {
+TEST_CASE("trimbits", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     REQUIRE_THROWS(caller.call("trimbits", {}, -1, GET));
 }
 
-TEST_CASE("CALLER::trimval", "[.cmdcall]") {
+TEST_CASE("trimval", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -501,7 +501,7 @@ TEST_CASE("CALLER::trimval", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::trimen", "[.cmdcall][.this]") {
+TEST_CASE("trimen", "[.cmdcall][.this]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -523,7 +523,7 @@ TEST_CASE("CALLER::trimen", "[.cmdcall][.this]") {
     }
 }
 
-TEST_CASE("CALLER::gappixels", "[.cmdcall]") {
+TEST_CASE("gappixels", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -573,7 +573,7 @@ TEST_CASE("CALLER::gappixels", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::fliprows", "[.cmdcall]") {
+TEST_CASE("fliprows", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -608,7 +608,7 @@ TEST_CASE("CALLER::fliprows", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::master", "[.cmdcall]") {
+TEST_CASE("master", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -653,7 +653,7 @@ TEST_CASE("CALLER::master", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::badchannels", "[.cmdcall]") {
+TEST_CASE("badchannels", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -723,7 +723,7 @@ TEST_CASE("CALLER::badchannels", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::row", "[.cmdcall]") {
+TEST_CASE("row", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto prev_val = det.getRow()[0];
@@ -746,7 +746,7 @@ TEST_CASE("CALLER::row", "[.cmdcall]") {
     det.setRow(prev_val, {0});
 }
 
-TEST_CASE("CALLER::column", "[.cmdcall]") {
+TEST_CASE("column", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto prev_val = det.getColumn()[0];
@@ -773,7 +773,7 @@ TEST_CASE("CALLER::column", "[.cmdcall]") {
 
 // acquire: not testing
 
-TEST_CASE("CALLER::frames", "[.cmdcall]") {
+TEST_CASE("frames", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto prev_val =
@@ -797,7 +797,7 @@ TEST_CASE("CALLER::frames", "[.cmdcall]") {
     det.setNumberOfFrames(prev_val);
 }
 
-TEST_CASE("CALLER::triggers", "[.cmdcall]") {
+TEST_CASE("triggers", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto prev_val =
@@ -821,7 +821,7 @@ TEST_CASE("CALLER::triggers", "[.cmdcall]") {
     det.setNumberOfTriggers(prev_val);
 }
 
-TEST_CASE("CALLER::exptime", "[.cmdcall][.time]") {
+TEST_CASE("exptime", "[.cmdcall][.time]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -871,7 +871,7 @@ TEST_CASE("CALLER::exptime", "[.cmdcall][.time]") {
     det.setExptime(-1, prev_val);
 }
 
-TEST_CASE("CALLER::period", "[.cmdcall]") {
+TEST_CASE("period", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto prev_val = det.getPeriod();
@@ -895,7 +895,7 @@ TEST_CASE("CALLER::period", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::delay", "[.cmdcall]") {
+TEST_CASE("delay", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -928,7 +928,7 @@ TEST_CASE("CALLER::delay", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::framesl", "[.cmdcall]") {
+TEST_CASE("framesl", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -939,7 +939,7 @@ TEST_CASE("CALLER::framesl", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::triggersl", "[.cmdcall]") {
+TEST_CASE("triggersl", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -950,7 +950,7 @@ TEST_CASE("CALLER::triggersl", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::delayl", "[.cmdcall]") {
+TEST_CASE("delayl", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -964,7 +964,7 @@ TEST_CASE("CALLER::delayl", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::periodl", "[.cmdcall]") {
+TEST_CASE("periodl", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -978,7 +978,7 @@ TEST_CASE("CALLER::periodl", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::dr", "[.cmdcall]") {
+TEST_CASE("dr", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -1020,14 +1020,14 @@ TEST_CASE("CALLER::dr", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::drlist", "[.cmdcall]") {
+TEST_CASE("drlist", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     REQUIRE_NOTHROW(caller.call("drlist", {}, -1, GET));
     REQUIRE_THROWS(caller.call("drlist", {}, -1, PUT));
 }
 
-TEST_CASE("CALLER::timing", "[.cmdcall]") {
+TEST_CASE("timing", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -1089,14 +1089,14 @@ TEST_CASE("CALLER::timing", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::timinglist", "[.cmdcall]") {
+TEST_CASE("timinglist", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     REQUIRE_NOTHROW(caller.call("timinglist", {}, -1, GET));
     REQUIRE_THROWS(caller.call("timinglist", {}, -1, PUT));
 }
 
-TEST_CASE("CALLER::readoutspeed", "[.cmdcall]") {
+TEST_CASE("readoutspeed", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -1186,7 +1186,7 @@ TEST_CASE("CALLER::readoutspeed", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::readoutspeedlist", "[.cmdcall]") {
+TEST_CASE("readoutspeedlist", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -1200,7 +1200,7 @@ TEST_CASE("CALLER::readoutspeedlist", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::adcphase", "[.cmdcall]") {
+TEST_CASE("adcphase", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -1239,7 +1239,7 @@ TEST_CASE("CALLER::adcphase", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::maxadcphaseshift", "[.cmdcall]") {
+TEST_CASE("maxadcphaseshift", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -1253,7 +1253,7 @@ TEST_CASE("CALLER::maxadcphaseshift", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::dbitphase", "[.cmdcall]") {
+TEST_CASE("dbitphase", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -1282,7 +1282,7 @@ TEST_CASE("CALLER::dbitphase", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::maxdbitphaseshift", "[.cmdcall]") {
+TEST_CASE("maxdbitphaseshift", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -1295,7 +1295,7 @@ TEST_CASE("CALLER::maxdbitphaseshift", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::clkfreq", "[.cmdcall]") {
+TEST_CASE("clkfreq", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -1315,7 +1315,7 @@ TEST_CASE("CALLER::clkfreq", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::clkphase", "[.cmdcall]") {
+TEST_CASE("clkphase", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -1365,7 +1365,7 @@ TEST_CASE("CALLER::clkphase", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::clkdiv", "[.cmdcall]") {
+TEST_CASE("clkdiv", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -1400,7 +1400,7 @@ TEST_CASE("CALLER::clkdiv", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::maxclkphaseshift", "[.cmdcall]") {
+TEST_CASE("maxclkphaseshift", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -1420,7 +1420,7 @@ TEST_CASE("CALLER::maxclkphaseshift", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::highvoltage", "[.cmdcall]") {
+TEST_CASE("highvoltage", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -1523,7 +1523,7 @@ TEST_CASE("CALLER::highvoltage", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::powerchip", "[.cmdcall]") {
+TEST_CASE("powerchip", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -1575,7 +1575,7 @@ TEST_CASE("CALLER::powerchip", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::imagetest", "[.cmdcall]") {
+TEST_CASE("imagetest", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -1606,7 +1606,7 @@ TEST_CASE("CALLER::imagetest", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::extsig", "[.cmdcall]") {
+TEST_CASE("extsig", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -1685,7 +1685,7 @@ TEST_CASE("CALLER::extsig", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::parallel", "[.cmdcall]") {
+TEST_CASE("parallel", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -1716,7 +1716,7 @@ TEST_CASE("CALLER::parallel", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::filterresistor", "[.cmdcall]") {
+TEST_CASE("filterresistor", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -1760,7 +1760,7 @@ TEST_CASE("CALLER::filterresistor", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::dbitpipeline", "[.cmdcall]") {
+TEST_CASE("dbitpipeline", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -1810,7 +1810,7 @@ TEST_CASE("CALLER::dbitpipeline", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::readnrows", "[.cmdcall]") {
+TEST_CASE("readnrows", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -1862,7 +1862,7 @@ TEST_CASE("CALLER::readnrows", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::currentsource", "[.cmdcall]") {
+TEST_CASE("currentsource", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -2004,21 +2004,21 @@ TEST_CASE("CALLER::currentsource", "[.cmdcall]") {
 
 /** temperature */
 
-TEST_CASE("CALLER::templist", "[.cmdcall]") {
+TEST_CASE("templist", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     REQUIRE_NOTHROW(caller.call("templist", {}, -1, GET));
     REQUIRE_THROWS(caller.call("templist", {}, -1, PUT));
 }
 
-TEST_CASE("CALLER::tempvalues", "[.cmdcall]") {
+TEST_CASE("tempvalues", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     REQUIRE_NOTHROW(caller.call("tempvalues", {}, -1, GET));
     REQUIRE_THROWS(caller.call("tempvalues", {}, -1, PUT));
 }
 
-TEST_CASE("CALLER::temp_adc", "[.cmdcall]") {
+TEST_CASE("temp_adc", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -2034,7 +2034,7 @@ TEST_CASE("CALLER::temp_adc", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::temp_fpga", "[.cmdcall]") {
+TEST_CASE("temp_fpga", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -2051,7 +2051,7 @@ TEST_CASE("CALLER::temp_fpga", "[.cmdcall]") {
 
 /* list */
 
-TEST_CASE("CALLER::daclist", "[.cmdcall]") {
+TEST_CASE("daclist", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -2087,14 +2087,14 @@ TEST_CASE("CALLER::daclist", "[.cmdcall]") {
 
 /* dacs */
 
-TEST_CASE("CALLER::dacvalues", "[.cmdcall]") {
+TEST_CASE("dacvalues", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     REQUIRE_NOTHROW(caller.call("dacvalues", {}, -1, GET));
     REQUIRE_THROWS(caller.call("dacvalues", {}, -1, PUT));
 }
 
-TEST_CASE("CALLER::defaultdac", "[.cmdcall]") {
+TEST_CASE("defaultdac", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -2154,7 +2154,7 @@ TEST_CASE("CALLER::defaultdac", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::resetdacs", "[.cmdcall]") {
+TEST_CASE("resetdacs", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -2179,7 +2179,7 @@ TEST_CASE("CALLER::resetdacs", "[.cmdcall]") {
 
 /* acquisition */
 
-TEST_CASE("CALLER::trigger", "[.cmdcall]") {
+TEST_CASE("trigger", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     REQUIRE_THROWS(caller.call("trigger", {}, -1, GET));
@@ -2222,7 +2222,7 @@ TEST_CASE("CALLER::trigger", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::blockingtrigger", "[.cmdcall]") {
+TEST_CASE("blockingtrigger", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     REQUIRE_THROWS(caller.call("blockingtrigger", {}, -1, GET));
@@ -2266,7 +2266,7 @@ TEST_CASE("CALLER::blockingtrigger", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::clearbusy", "[.cmdcall]") {
+TEST_CASE("clearbusy", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     REQUIRE_NOTHROW(caller.call("clearbusy", {}, -1, PUT));
@@ -2274,7 +2274,7 @@ TEST_CASE("CALLER::clearbusy", "[.cmdcall]") {
     REQUIRE_THROWS(caller.call("clearbusy", {}, -1, GET));
 }
 
-TEST_CASE("CALLER::start", "[.cmdcall]") {
+TEST_CASE("start", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     // PUT only command
@@ -2313,7 +2313,7 @@ TEST_CASE("CALLER::start", "[.cmdcall]") {
     det.setNumberOfFrames(prev_frames);
 }
 
-TEST_CASE("CALLER::stop", "[.cmdcall]") {
+TEST_CASE("stop", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     // PUT only command
@@ -2358,7 +2358,7 @@ TEST_CASE("CALLER::stop", "[.cmdcall]") {
     det.setNumberOfFrames(prev_frames);
 }
 
-TEST_CASE("CALLER::status", "[.cmdcall]") {
+TEST_CASE("status", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -2397,7 +2397,7 @@ TEST_CASE("CALLER::status", "[.cmdcall]") {
     det.setNumberOfFrames(prev_frames);
 }
 
-TEST_CASE("CALLER::nextframenumber", "[.cmdcall]") {
+TEST_CASE("nextframenumber", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -2464,7 +2464,7 @@ TEST_CASE("CALLER::nextframenumber", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::scan", "[.cmdcall]") {
+TEST_CASE("scan", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     defs::dacIndex ind = defs::DAC_0;
@@ -2594,7 +2594,7 @@ TEST_CASE("CALLER::scan", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::scanerrmsg", "[.cmdcall]") {
+TEST_CASE("scanerrmsg", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     REQUIRE_NOTHROW(caller.call("scanerrmsg", {}, -1, GET));
@@ -2603,7 +2603,7 @@ TEST_CASE("CALLER::scanerrmsg", "[.cmdcall]") {
 
 /* Network Configuration (Detector<->Receiver) */
 
-TEST_CASE("CALLER::numinterfaces", "[.cmdcall]") {
+TEST_CASE("numinterfaces", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -2643,7 +2643,7 @@ TEST_CASE("CALLER::numinterfaces", "[.cmdcall]") {
     REQUIRE_THROWS(caller.call("numinterfaces", {"0"}, -1, PUT));
 }
 
-TEST_CASE("CALLER::udp_srcip", "[.cmdcall]") {
+TEST_CASE("udp_srcip", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto prev_val = det.getSourceUDPIP();
@@ -2658,7 +2658,7 @@ TEST_CASE("CALLER::udp_srcip", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::udp_dstlist", "[.cmdcall]") {
+TEST_CASE("udp_dstlist", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -2674,7 +2674,7 @@ TEST_CASE("CALLER::udp_dstlist", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::udp_numdst", "[.cmdcall]") {
+TEST_CASE("udp_numdst", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -2687,7 +2687,7 @@ TEST_CASE("CALLER::udp_numdst", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::udp_cleardst", "[.cmdcall]") {
+TEST_CASE("udp_cleardst", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     REQUIRE_THROWS(caller.call("udp_cleardst", {}, -1, GET));
@@ -2695,7 +2695,7 @@ TEST_CASE("CALLER::udp_cleardst", "[.cmdcall]") {
     /*REQUIRE_NOTHROW(caller.call("udp_cleardst", {}, -1, PUT));*/
 }
 
-TEST_CASE("CALLER::udp_firstdst", "[.cmdcall]") {
+TEST_CASE("udp_firstdst", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -2729,13 +2729,13 @@ TEST_CASE("CALLER::udp_firstdst", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::udp_dstip", "[.cmdcall]") {
+TEST_CASE("udp_dstip", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     REQUIRE_THROWS(caller.call("udp_dstip", {"0.0.0.0"}, -1, PUT));
 }
 
-TEST_CASE("CALLER::udp_srcmac", "[.cmdcall]") {
+TEST_CASE("udp_srcmac", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto prev_val = det.getSourceUDPMAC();
@@ -2752,13 +2752,13 @@ TEST_CASE("CALLER::udp_srcmac", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::udp_dstmac", "[.cmdcall]") {
+TEST_CASE("udp_dstmac", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     REQUIRE_THROWS(caller.call("udp_dstmac", {"00:00:00:00:00:00"}, -1, PUT));
 }
 
-TEST_CASE("CALLER::udp_dstport", "[.cmdcall]") {
+TEST_CASE("udp_dstport", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto prev_val = det.getDestinationUDPPort();
@@ -2779,7 +2779,7 @@ TEST_CASE("CALLER::udp_dstport", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::udp_srcip2", "[.cmdcall]") {
+TEST_CASE("udp_srcip2", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -2801,7 +2801,7 @@ TEST_CASE("CALLER::udp_srcip2", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::udp_dstip2", "[.cmdcall]") {
+TEST_CASE("udp_dstip2", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -2813,7 +2813,7 @@ TEST_CASE("CALLER::udp_dstip2", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::udp_srcmac2", "[.cmdcall]") {
+TEST_CASE("udp_srcmac2", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -2837,7 +2837,7 @@ TEST_CASE("CALLER::udp_srcmac2", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::udp_dstmac2", "[.cmdcall]") {
+TEST_CASE("udp_dstmac2", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -2850,7 +2850,7 @@ TEST_CASE("CALLER::udp_dstmac2", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::udp_dstport2", "[.cmdcall]") {
+TEST_CASE("udp_dstport2", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -2879,21 +2879,21 @@ TEST_CASE("CALLER::udp_dstport2", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::udp_reconfigure", "[.cmdcall]") {
+TEST_CASE("udp_reconfigure", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     REQUIRE_THROWS(caller.call("udp_reconfigure", {}, -1, GET));
     REQUIRE_NOTHROW(caller.call("udp_reconfigure", {}, -1, PUT));
 }
 
-TEST_CASE("CALLER::udp_validate", "[.cmdcall]") {
+TEST_CASE("udp_validate", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     REQUIRE_THROWS(caller.call("udp_validate", {}, -1, GET));
     REQUIRE_NOTHROW(caller.call("udp_validate", {}, -1, PUT));
 }
 
-TEST_CASE("CALLER::tengiga", "[.cmdcall]") {
+TEST_CASE("tengiga", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
 
@@ -2917,7 +2917,7 @@ TEST_CASE("CALLER::tengiga", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::flowcontrol10g", "[.cmdcall]") {
+TEST_CASE("flowcontrol10g", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -2948,7 +2948,7 @@ TEST_CASE("CALLER::flowcontrol10g", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::txdelay_frame", "[.cmdcall]") {
+TEST_CASE("txdelay_frame", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -2976,7 +2976,7 @@ TEST_CASE("CALLER::txdelay_frame", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::txdelay", "[.cmdcall]") {
+TEST_CASE("txdelay", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -3052,7 +3052,7 @@ TEST_CASE("CALLER::txdelay", "[.cmdcall]") {
 
 /* ZMQ Streaming Parameters (Receiver<->Client) */
 
-TEST_CASE("CALLER::zmqport", "[.cmdcall]") {
+TEST_CASE("zmqport", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
 
@@ -3107,7 +3107,7 @@ TEST_CASE("CALLER::zmqport", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::zmqip", "[.cmdcall]") {
+TEST_CASE("zmqip", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     std::ostringstream oss1, oss2;
@@ -3123,7 +3123,7 @@ TEST_CASE("CALLER::zmqip", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::zmqhwm", "[.cmdcall]") {
+TEST_CASE("zmqhwm", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto prev_val = det.getClientZmqHwm();
@@ -3152,7 +3152,7 @@ TEST_CASE("CALLER::zmqhwm", "[.cmdcall]") {
 
 /* Advanced */
 
-TEST_CASE("CALLER::adcpipeline", "[.cmdcall]") {
+TEST_CASE("adcpipeline", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -3187,7 +3187,7 @@ TEST_CASE("CALLER::adcpipeline", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::programfpga", "[.cmdcall]") {
+TEST_CASE("programfpga", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -3203,7 +3203,7 @@ TEST_CASE("CALLER::programfpga", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::resetfpga", "[.cmdcall]") {
+TEST_CASE("resetfpga", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -3219,7 +3219,7 @@ TEST_CASE("CALLER::resetfpga", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::updatekernel", "[.cmdcall]") {
+TEST_CASE("updatekernel", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -3238,7 +3238,7 @@ TEST_CASE("CALLER::updatekernel", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::rebootcontroller", "[.cmdcall]") {
+TEST_CASE("rebootcontroller", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -3255,7 +3255,7 @@ TEST_CASE("CALLER::rebootcontroller", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::update", "[.cmdcall]") {
+TEST_CASE("update", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -3273,7 +3273,7 @@ TEST_CASE("CALLER::update", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::reg", "[.cmdcall]") {
+TEST_CASE("reg", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -3305,7 +3305,7 @@ TEST_CASE("CALLER::reg", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::adcreg", "[.cmdcall]") {
+TEST_CASE("adcreg", "[.cmdcall]") {
     // TODO! what is a safe value to use?
     Detector det;
     Caller caller(&det);
@@ -3323,7 +3323,7 @@ TEST_CASE("CALLER::adcreg", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::setbit", "[.cmdcall]") {
+TEST_CASE("setbit", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -3347,7 +3347,7 @@ TEST_CASE("CALLER::setbit", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::clearbit", "[.cmdcall]") {
+TEST_CASE("clearbit", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -3371,7 +3371,7 @@ TEST_CASE("CALLER::clearbit", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::getbit", "[.cmdcall]") {
+TEST_CASE("getbit", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -3395,7 +3395,7 @@ TEST_CASE("CALLER::getbit", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::firmwaretest", "[.cmdcall]") {
+TEST_CASE("firmwaretest", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -3413,7 +3413,7 @@ TEST_CASE("CALLER::firmwaretest", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::bustest", "[.cmdcall]") {
+TEST_CASE("bustest", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -3430,7 +3430,7 @@ TEST_CASE("CALLER::bustest", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::initialchecks", "[.cmdcall]") {
+TEST_CASE("initialchecks", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto check = det.getInitialChecks();
@@ -3452,7 +3452,7 @@ TEST_CASE("CALLER::initialchecks", "[.cmdcall]") {
     det.setInitialChecks(check);
 }
 
-TEST_CASE("CALLER::adcinvert", "[.cmdcall]") {
+TEST_CASE("adcinvert", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -3480,7 +3480,7 @@ TEST_CASE("CALLER::adcinvert", "[.cmdcall]") {
 
 /* Insignificant */
 
-TEST_CASE("CALLER::port", "[.cmdcall]") {
+TEST_CASE("port", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto prev_val = det.getControlPort({0}).squash();
@@ -3504,7 +3504,7 @@ TEST_CASE("CALLER::port", "[.cmdcall]") {
     det.setControlPort(prev_val, {0});
 }
 
-TEST_CASE("CALLER::stopport", "[.cmdcall]") {
+TEST_CASE("stopport", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto prev_val = det.getStopPort({0}).squash();
@@ -3528,7 +3528,7 @@ TEST_CASE("CALLER::stopport", "[.cmdcall]") {
     det.setStopPort(prev_val, {0});
 }
 
-TEST_CASE("CALLER::lock", "[.cmdcall]") {
+TEST_CASE("lock", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto prev_val = det.getDetectorLock();
@@ -3552,13 +3552,13 @@ TEST_CASE("CALLER::lock", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::execcommand", "[.cmdcall]") {
+TEST_CASE("execcommand", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     REQUIRE_NOTHROW(caller.call("execcommand", {"ls *.txt"}, -1, PUT));
 }
 
-TEST_CASE("CALLER::framecounter", "[.cmdcall]") {
+TEST_CASE("framecounter", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     auto det_type = det.getDetectorType().squash();
@@ -3576,7 +3576,7 @@ TEST_CASE("CALLER::framecounter", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::runtime", "[.cmdcall]") {
+TEST_CASE("runtime", "[.cmdcall]") {
     // TODO! can we test this?
     Detector det;
     Caller caller(&det);
@@ -3594,7 +3594,7 @@ TEST_CASE("CALLER::runtime", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::frametime", "[.cmdcall]") {
+TEST_CASE("frametime", "[.cmdcall]") {
     // TODO! can we test this?
     Detector det;
     Caller caller(&det);
@@ -3612,7 +3612,7 @@ TEST_CASE("CALLER::frametime", "[.cmdcall]") {
     }
 }
 
-TEST_CASE("CALLER::user", "[.cmdcall]") {
+TEST_CASE("user", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     caller.call("user", {}, -1, GET);
@@ -3622,7 +3622,7 @@ TEST_CASE("CALLER::user", "[.cmdcall]") {
     REQUIRE_NOTHROW(caller.call("user", {}, -1, GET));
 }
 
-TEST_CASE("CALLER::sleep", "[.cmdcall]") {
+TEST_CASE("sleep", "[.cmdcall]") {
     Detector det;
     Caller caller(&det);
     REQUIRE_NOTHROW(caller.call("sleep", {"1"}, -1, PUT));


### PR DESCRIPTION
removed 'Caller/CALLER' from test names as there is only one command line now