### PR TITLE
Dev/proper free

### DIFF
--- a/python/src/detector.cpp
+++ b/python/src/detector.cpp
@@ -21,11 +21,13 @@ void init_det(py::module &m) {
     using sls::Positions;
     using sls::Result;
 
+    m.def("freeSharedMemory",
+          (void (*)(const int, const int)) & sls::freeSharedMemory,
+          py::arg() = 0, py::arg() = -1);
+
     py::class_<Detector> CppDetectorApi(m, "CppDetectorApi");
     CppDetectorApi.def(py::init<int>());
 
-    CppDetectorApi.def("freeSharedMemory",
-                       (void (Detector::*)()) & Detector::freeSharedMemory);
     CppDetectorApi.def("loadConfig",
                        (void (Detector::*)(const std::string &)) &
                            Detector::loadConfig,

--- a/python/src/detector_in.cpp
+++ b/python/src/detector_in.cpp
@@ -18,8 +18,10 @@ void init_det(py::module &m) {
     using sls::Positions;
     using sls::Result;
 
+    m.def("freeSharedMemory", (void (*)(const int, const int)) &sls::freeSharedMemory, py::arg() = 0, py::arg() = -1);
+    
     py::class_<Detector> CppDetectorApi(m, "CppDetectorApi");
     CppDetectorApi.def(py::init<int>());
-
+    
         [[FUNCTIONS]]
 }

--- a/slsDetectorSoftware/generator/readme.md
+++ b/slsDetectorSoftware/generator/readme.md
@@ -28,7 +28,7 @@ The dump.json is the AST of the file `slsDetectorPackage/slsSupportLib/src/ToStr
 ```sh
 # to generate the dump.json file
 cd slsSupportLib/src
-clang++ -Xclang -ast-dump=json -Xclang -ast-dump-filter -Xclang StringTo  -c ToString.cpp -I ../include/ -std=gnu++11 > ../../slsDetectorSoftware/generator/autocomplete/dump.json 
+clang++ -Xclang -ast-dump=json -Xclang -ast-dump-filter -Xclang StringTo -c ToString.cpp -I ../include/ -std=gnu++11 > ../../slsDetectorSoftware/generator/autocomplete/dump.json 
 # clang version used: 14.0.0-1ubuntu1.1
 ```
 

--- a/slsDetectorSoftware/include/sls/Detector.h
+++ b/slsDetectorSoftware/include/sls/Detector.h
@@ -45,11 +45,6 @@ class Detector {
      */
     Detector(int shm_id = 0);
     ~Detector();
-
-    /** Free the shared memory of this detector and all modules
-    belonging to it */
-    void freeSharedMemory();
-
     /** Frees shared memory before loading configuration file. Set up once
     normally */
     void loadConfig(const std::string &fname);

--- a/slsDetectorSoftware/include/sls/Detector.h
+++ b/slsDetectorSoftware/include/sls/Detector.h
@@ -20,7 +20,7 @@ class IpAddr;
 // Free function to avoid dependence on class
 // and avoid the option to free another objects
 // shm by mistake
-void freeSharedMemory(int detectorIndex, int moduleIndex = -1);
+void freeSharedMemory(const int detectorIndex = 0, const int moduleIndex = -1);
 
 /**
  * \class Detector

--- a/slsDetectorSoftware/include/sls/Detector.h
+++ b/slsDetectorSoftware/include/sls/Detector.h
@@ -45,6 +45,15 @@ class Detector {
      */
     Detector(int shm_id = 0);
     ~Detector();
+
+    // Disable copy since SharedMemory object is unique in DetectorImpl
+    Detector(const Detector& other) = delete;
+    Detector& operator=(const Detector& other) = delete;
+
+    // Move constructor and assignment operator
+    Detector(Detector&& other) noexcept;
+    Detector& operator=(Detector&& other) noexcept;
+
     /** Frees shared memory before loading configuration file. Set up once
     normally */
     void loadConfig(const std::string &fname);

--- a/slsDetectorSoftware/include/sls/Detector.h
+++ b/slsDetectorSoftware/include/sls/Detector.h
@@ -47,12 +47,12 @@ class Detector {
     ~Detector();
 
     // Disable copy since SharedMemory object is unique in DetectorImpl
-    Detector(const Detector& other) = delete;
-    Detector& operator=(const Detector& other) = delete;
+    Detector(const Detector &other) = delete;
+    Detector &operator=(const Detector &other) = delete;
 
     // Move constructor and assignment operator
-    Detector(Detector&& other) noexcept;
-    Detector& operator=(Detector&& other) noexcept;
+    Detector(Detector &&other) noexcept;
+    Detector &operator=(Detector &&other) noexcept;
 
     /** Frees shared memory before loading configuration file. Set up once
     normally */

--- a/slsDetectorSoftware/src/Detector.cpp
+++ b/slsDetectorSoftware/src/Detector.cpp
@@ -59,6 +59,13 @@ using defs = slsDetectorDefs;
 
 Detector::Detector(int shm_id) : pimpl(make_unique<DetectorImpl>(shm_id)) {}
 Detector::~Detector() = default;
+
+// Move constructor
+Detector::Detector(Detector&& other) noexcept = default;
+
+// Move assignment operator
+Detector& Detector::operator=(Detector&& other) noexcept = default;
+
 // Configuration
 
 void Detector::loadConfig(const std::string &fname) {

--- a/slsDetectorSoftware/src/Detector.cpp
+++ b/slsDetectorSoftware/src/Detector.cpp
@@ -58,15 +58,12 @@ void freeSharedMemory(int detectorIndex, int moduleIndex) {
 using defs = slsDetectorDefs;
 
 Detector::Detector(int shm_id) : pimpl(make_unique<DetectorImpl>(shm_id)) {}
-
 Detector::~Detector() = default;
-
 // Configuration
-void Detector::freeSharedMemory() { pimpl->freeSharedMemory(); }
 
 void Detector::loadConfig(const std::string &fname) {
     int shm_id = getShmId();
-    freeSharedMemory();
+    freeSharedMemory(shm_id);
     pimpl = make_unique<DetectorImpl>(shm_id);
     LOG(logINFO) << "Loading configuration file: " << fname;
     loadParameters(fname);
@@ -105,13 +102,30 @@ Result<std::string> Detector::getHostname(Positions pos) const {
 }
 
 void Detector::setHostname(const std::vector<std::string> &hostname) {
+    if (pimpl->hasModulesInSharedMemory()) {
+        LOG(logWARNING) << "There are already module(s) in shared memory."
+                           "Freeing Shared memory now.";
+        auto numChannels = getDetectorSize();
+        auto initialChecks = getInitialChecks();
+        freeSharedMemory(getShmId());
+        pimpl = make_unique<DetectorImpl>(getShmId());
+        setDetectorSize(numChannels);
+        setInitialChecks(initialChecks);
+    }
     pimpl->setHostname(hostname);
 }
 
 void Detector::setVirtualDetectorServers(int numServers,
                                          uint16_t startingPort) {
     validatePortRange(startingPort, numServers * 2);
-    pimpl->setVirtualDetectorServers(numServers, startingPort);
+
+    std::vector<std::string> hostnames;
+    for (int i = 0; i < numServers; ++i) {
+        // * 2 is for control and stop port
+        hostnames.push_back(std::string("localhost:") +
+                            std::to_string(startingPort + i * 2));
+    }
+    setHostname(hostnames);
 }
 
 int Detector::getShmId() const { return pimpl->getDetectorIndex(); }

--- a/slsDetectorSoftware/src/Detector.cpp
+++ b/slsDetectorSoftware/src/Detector.cpp
@@ -23,7 +23,7 @@
 
 namespace sls {
 
-void freeSharedMemory(int detectorIndex, int moduleIndex) {
+void freeSharedMemory(const int detectorIndex, const int moduleIndex) {
 
     // single module
     if (moduleIndex >= 0) {
@@ -34,10 +34,10 @@ void freeSharedMemory(int detectorIndex, int moduleIndex) {
         return;
     }
 
-    // detector - multi module - get number of detectors from shm
-    SharedMemory<sharedDetector> detectorShm(detectorIndex, -1);
     int numDetectors = 0;
 
+    // detector - multi module - get number of detectors from shm
+    SharedMemory<sharedDetector> detectorShm(detectorIndex, -1);
     if (detectorShm.exists()) {
         detectorShm.openSharedMemory(false);
         numDetectors = detectorShm()->totalNumberOfModules;

--- a/slsDetectorSoftware/src/Detector.cpp
+++ b/slsDetectorSoftware/src/Detector.cpp
@@ -61,10 +61,10 @@ Detector::Detector(int shm_id) : pimpl(make_unique<DetectorImpl>(shm_id)) {}
 Detector::~Detector() = default;
 
 // Move constructor
-Detector::Detector(Detector&& other) noexcept = default;
+Detector::Detector(Detector &&other) noexcept = default;
 
 // Move assignment operator
-Detector& Detector::operator=(Detector&& other) noexcept = default;
+Detector &Detector::operator=(Detector &&other) noexcept = default;
 
 // Configuration
 

--- a/slsDetectorSoftware/src/DetectorImpl.cpp
+++ b/slsDetectorSoftware/src/DetectorImpl.cpp
@@ -37,8 +37,6 @@ DetectorImpl::DetectorImpl(int detector_index, bool verify, bool update)
     setupDetector(verify, update);
 }
 
-DetectorImpl::~DetectorImpl() = default;
-
 void DetectorImpl::setupDetector(bool verify, bool update) {
     initSharedMemory(verify);
     initializeMembers(verify);

--- a/slsDetectorSoftware/src/DetectorImpl.cpp
+++ b/slsDetectorSoftware/src/DetectorImpl.cpp
@@ -234,7 +234,8 @@ void DetectorImpl::addModule(const std::string &name) {
 
     // gotthard cannot have more than 2 modules (50um=1, 25um=2
     if ((type == GOTTHARD || type == GOTTHARD2) && modules.size() > 2) {
-        throw RuntimeError("Gotthard cannot have more than 2 modules. Please free the shared memory and start again.");
+        throw RuntimeError("Gotthard cannot have more than 2 modules. Please "
+                           "free the shared memory and start again.");
     }
 
     auto pos = modules.size();

--- a/slsDetectorSoftware/src/DetectorImpl.h
+++ b/slsDetectorSoftware/src/DetectorImpl.h
@@ -79,11 +79,7 @@ class DetectorImpl : public virtual slsDetectorDefs {
     explicit DetectorImpl(int detector_index = 0, bool verify = true,
                           bool update = true);
 
-    /**
-     * Destructor
-     */
     virtual ~DetectorImpl();
-
     template <class CT> struct NonDeduced { using type = CT; };
     template <typename RT, typename... CT>
     Result<RT> Parallel(RT (Module::*somefunc)(CT...),
@@ -198,14 +194,6 @@ class DetectorImpl : public virtual slsDetectorDefs {
     /** return detector index in shared memory */
     int getDetectorIndex() const;
 
-    /** Free specific shared memory from the command line without creating
-     * object */
-    static void freeSharedMemory(int detectorIndex, int detPos = -1);
-
-    /** Free all modules from current multi Id shared memory and delete members
-     */
-    void freeSharedMemory();
-
     /** Get user details of shared memory */
     std::string getUserDetails();
 
@@ -215,13 +203,8 @@ class DetectorImpl : public virtual slsDetectorDefs {
      * default enabled */
     void setInitialChecks(const bool value);
 
-    /**
-     * Connect to Virtual Detector Servers at local host
-     * @param numdet number of modules
-     * @param port starting port number
-     */
-    void setVirtualDetectorServers(const int numdet, const uint16_t port);
-
+    bool hasModulesInSharedMemory();
+    
     /** Sets the hostname of all sls modules in shared memory and updates
      * local cache */
     void setHostname(const std::vector<std::string> &name);

--- a/slsDetectorSoftware/src/DetectorImpl.h
+++ b/slsDetectorSoftware/src/DetectorImpl.h
@@ -4,8 +4,8 @@
 
 #include "CtbConfig.h"
 #include "SharedMemory.h"
-#include "sls/ZmqSocket.h"
 #include "sls/Result.h"
+#include "sls/ZmqSocket.h"
 #include "sls/logger.h"
 #include "sls/sls_detector_defs.h"
 

--- a/slsDetectorSoftware/src/DetectorImpl.h
+++ b/slsDetectorSoftware/src/DetectorImpl.h
@@ -204,7 +204,7 @@ class DetectorImpl : public virtual slsDetectorDefs {
     void setInitialChecks(const bool value);
 
     bool hasModulesInSharedMemory();
-    
+
     /** Sets the hostname of all sls modules in shared memory and updates
      * local cache */
     void setHostname(const std::vector<std::string> &name);

--- a/slsDetectorSoftware/src/DetectorImpl.h
+++ b/slsDetectorSoftware/src/DetectorImpl.h
@@ -4,6 +4,7 @@
 
 #include "CtbConfig.h"
 #include "SharedMemory.h"
+#include "sls/ZmqSocket.h"
 #include "sls/Result.h"
 #include "sls/logger.h"
 #include "sls/sls_detector_defs.h"
@@ -19,7 +20,6 @@
 
 namespace sls {
 
-class ZmqSocket;
 class detectorData;
 class Module;
 
@@ -79,7 +79,6 @@ class DetectorImpl : public virtual slsDetectorDefs {
     explicit DetectorImpl(int detector_index = 0, bool verify = true,
                           bool update = true);
 
-    virtual ~DetectorImpl();
     template <class CT> struct NonDeduced { using type = CT; };
     template <typename RT, typename... CT>
     Result<RT> Parallel(RT (Module::*somefunc)(CT...),

--- a/slsDetectorSoftware/src/Module.cpp
+++ b/slsDetectorSoftware/src/Module.cpp
@@ -52,15 +52,7 @@ Module::Module(int det_id, int module_index, bool verify)
     detectorType type = getDetectorTypeFromShm(det_id, verify);
     initSharedMemory(type, det_id, verify);
 }
-
 Module::~Module() = default;
-
-void Module::freeSharedMemory() {
-    if (shm.exists()) {
-        shm.removeSharedMemory();
-    }
-}
-
 bool Module::isFixedPatternSharedMemoryCompatible() const {
     return (shm()->shmversion >= MODULE_SHMAPIVERSION);
 }

--- a/slsDetectorSoftware/src/Module.cpp
+++ b/slsDetectorSoftware/src/Module.cpp
@@ -53,7 +53,6 @@ Module::Module(int det_id, int module_index, bool verify)
     initSharedMemory(type, det_id, verify);
 }
 
-
 bool Module::isFixedPatternSharedMemoryCompatible() const {
     return (shm()->shmversion >= MODULE_SHMAPIVERSION);
 }

--- a/slsDetectorSoftware/src/Module.cpp
+++ b/slsDetectorSoftware/src/Module.cpp
@@ -52,7 +52,8 @@ Module::Module(int det_id, int module_index, bool verify)
     detectorType type = getDetectorTypeFromShm(det_id, verify);
     initSharedMemory(type, det_id, verify);
 }
-Module::~Module() = default;
+
+
 bool Module::isFixedPatternSharedMemoryCompatible() const {
     return (shm()->shmversion >= MODULE_SHMAPIVERSION);
 }

--- a/slsDetectorSoftware/src/Module.h
+++ b/slsDetectorSoftware/src/Module.h
@@ -74,13 +74,7 @@ class Module : public virtual slsDetectorDefs {
     /** opening existing shared memory
     verify is if shared memory version matches existing one */
     explicit Module(int det_id = 0, int module_index = 0, bool verify = true);
-
     virtual ~Module();
-
-    /** Frees shared memory and deletes shared memory structure
-    Safe to call only if detector shm also deleted or its numberOfModules is
-    updated */
-    void freeSharedMemory();
     bool isFixedPatternSharedMemoryCompatible() const;
     std::string getHostname() const;
 

--- a/slsDetectorSoftware/src/Module.h
+++ b/slsDetectorSoftware/src/Module.h
@@ -74,7 +74,7 @@ class Module : public virtual slsDetectorDefs {
     /** opening existing shared memory
     verify is if shared memory version matches existing one */
     explicit Module(int det_id = 0, int module_index = 0, bool verify = true);
-    virtual ~Module();
+
     bool isFixedPatternSharedMemoryCompatible() const;
     std::string getHostname() const;
 

--- a/slsDetectorSoftware/tests/CMakeLists.txt
+++ b/slsDetectorSoftware/tests/CMakeLists.txt
@@ -33,6 +33,7 @@ target_sources(tests PRIVATE
 target_include_directories(tests 
     PUBLIC 
         "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../src>"
+        "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include/sls>"
     PRIVATE
     ${SLS_INTERNAL_RAPIDJSON_DIR}
 )

--- a/slsDetectorSoftware/tests/test-Module.cpp
+++ b/slsDetectorSoftware/tests/test-Module.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-or-other
 // Copyright (C) 2021 Contributors to the SLS Detector Package
+#include "Detector.h"
 #include "Module.h"
 #include "SharedMemory.h"
 #include "catch.hpp"
@@ -10,7 +11,9 @@ using dt = slsDetectorDefs::detectorType;
 TEST_CASE("Construction with a defined detector type") {
     Module m(dt::EIGER);
     REQUIRE(m.getDetectorType() == dt::EIGER);
-    m.freeSharedMemory(); // clean up
+    freeSharedMemory(0, 0); // clean up
+    SharedMemory<sharedModule> moduleShm(0, 0);
+    REQUIRE(moduleShm.exists() == false);
 }
 
 TEST_CASE("Read back detector type from shm") {
@@ -23,7 +26,9 @@ TEST_CASE("Read back detector type from shm") {
 
     // Now both objects point to the same shm so we can only
     // free one!
-    m2.freeSharedMemory();
+    freeSharedMemory(0, 0);
+    SharedMemory<sharedModule> moduleShm(0, 0);
+    REQUIRE(moduleShm.exists() == false);
 }
 
 TEST_CASE("Is shm fixed pattern shm compatible") {
@@ -41,25 +46,33 @@ TEST_CASE("Is shm fixed pattern shm compatible") {
     // Should fail since version is set to 0
     REQUIRE(m.isFixedPatternSharedMemoryCompatible() == false);
 
-    m.freeSharedMemory();
+    freeSharedMemory(0, 0);
+    SharedMemory<sharedModule> moduleShm(0, 0);
+    REQUIRE(moduleShm.exists() == false);
 }
 
 TEST_CASE("Get default control port") {
     Module m(dt::MYTHEN3);
     REQUIRE(m.getControlPort() == 1952);
-    m.freeSharedMemory();
+    freeSharedMemory(0, 0);
+    SharedMemory<sharedModule> moduleShm(0, 0);
+    REQUIRE(moduleShm.exists() == false);
 }
 
 TEST_CASE("Get default stop port") {
     Module m(dt::GOTTHARD2);
     REQUIRE(m.getStopPort() == 1953);
-    m.freeSharedMemory();
+    freeSharedMemory(0, 0);
+    SharedMemory<sharedModule> moduleShm(0, 0);
+    REQUIRE(moduleShm.exists() == false);
 }
 
 TEST_CASE("Get default receiver TCP port") {
     Module m(dt::MYTHEN3);
     REQUIRE(m.getReceiverPort() == 1954);
-    m.freeSharedMemory();
+    freeSharedMemory(0, 0);
+    SharedMemory<sharedModule> moduleShm(0, 0);
+    REQUIRE(moduleShm.exists() == false);
 }
 
 } // namespace sls

--- a/slsSupportLib/include/sls/versionAPI.h
+++ b/slsSupportLib/include/sls/versionAPI.h
@@ -10,5 +10,5 @@
 #define APIMYTHEN3   "developer 0x241001"
 #define APIJUNGFRAU  "developer 0x241001"
 #define APIGOTTHARD2 "developer 0x241007"
-#define APILIB       "developer 0x241014"
 #define APIRECEIVER  "developer 0x241014"
+#define APILIB "developer 0x241021"


### PR DESCRIPTION
- removed class member function freeSharedmemory for both Detector and Module
- made the free function freeSharedmemory accessible to python interface
- setHostname if there is already a module in shm will recreate the Detector object while freeing shm completely and keeping detsize and intitialchecks
- sethostname called from DetectorClass in virtual command to have one point of entry
- testing Module class frees shared memory using free function
- Detector class: added copy and move constructor and assignmentoperators due to explicit destructor (DetectorImpl fwd declared)
- DetectorImpl class: included ZmqSocket to remove destructor (should not be virtual in any case)
- Module class: removed explciit destructor to allow compiler generated constructor and operators