### PR TITLE
900: gui: missing packets label in

### DIFF
--- a/slsDetectorGui/forms/form_plot.ui
+++ b/slsDetectorGui/forms/form_plot.ui
@@ -457,7 +457,7 @@
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If sub images have missing packets&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="text">
-      <string>Complete Image</string>
+      <string/>
      </property>
      <property name="alignment">
       <set>Qt::AlignCenter</set>
@@ -523,6 +523,7 @@
      </property>
      <property name="font">
       <font>
+       <family>Cantarell</family>
        <pointsize>10</pointsize>
       </font>
      </property>

--- a/slsDetectorGui/include/qDrawPlot.h
+++ b/slsDetectorGui/include/qDrawPlot.h
@@ -123,7 +123,7 @@ class qDrawPlot : public QWidget, private Ui::PlotObject {
     QString zTitle2d{"Intensity"};
     QString plotTitle{""};
     QString indexTitle{""};
-    bool completeImage{false};
+    bool completeImage{true};
     bool xyRangeChanged{false};
     double xyRange[4]{0, 0, 0, 0};
     bool isXYRange[4]{false, false, false, false};

--- a/slsDetectorGui/src/qDrawPlot.cpp
+++ b/slsDetectorGui/src/qDrawPlot.cpp
@@ -107,7 +107,7 @@ void qDrawPlot::SetupPlots() {
     LOG(logINFO) << "nPixelsY:" << nPixelsY;
 
     widgetStatistics->hide();
-    lblCompleteImage->hide();
+    lblCompleteImage->show();
     lblInCompleteImage->hide();
     lblRxRoiEnabled->hide();
 

--- a/slsDetectorSoftware/src/DetectorImpl.cpp
+++ b/slsDetectorSoftware/src/DetectorImpl.cpp
@@ -557,7 +557,7 @@ void DetectorImpl::readFrameFromReceiver() {
             memset(multiframe.get(), 0xFF, multisize);
         }
 
-        completeImage = (numZmqRunning == (int)zmqSocket.size());
+        completeImage = true;
 
         // get each frame
         for (unsigned int isocket = 0; isocket < zmqSocket.size(); ++isocket) {
@@ -574,7 +574,6 @@ void DetectorImpl::readFrameFromReceiver() {
                         // parse error, version error or end of acquisition for
                         // socket
                         runningList[isocket] = false;
-                        completeImage = false;
                         --numZmqRunning;
                         continue;
                     }


### PR DESCRIPTION
[…](gui: hide 'complete image' and just show 'missing packets' when there) are missing packets in that image form the receiver