### PR TITLE
Dev/server malloc check

### DIFF
--- a/slsDetectorServers/ctbDetectorServer/slsDetectorFunctionList.c
+++ b/slsDetectorServers/ctbDetectorServer/slsDetectorFunctionList.c
@@ -51,12 +51,12 @@ int dataBytes = 0;
 int analogDataBytes = 0;
 int digitalDataBytes = 0;
 int transceiverDataBytes = 0;
-char *analogData = 0;
-char *digitalData = 0;
-char *transceiverData = 0;
-char volatile *analogDataPtr = 0;
-char volatile *digitalDataPtr = 0;
-char volatile *transceiverDataPtr = 0;
+char *analogData = NULL;
+char *digitalData = NULL;
+char *transceiverData = NULL;
+char volatile *analogDataPtr = NULL;
+char volatile *digitalDataPtr = NULL;
+char volatile *transceiverDataPtr = NULL;
 char udpPacketData[UDP_PACKET_DATA_BYTES + sizeof(sls_detector_header)];
 uint32_t adcEnableMask_1g = BIT32_MSK;
 // 10g readout
@@ -475,21 +475,15 @@ void setupDetector() {
     analogDataBytes = 0;
     digitalDataBytes = 0;
     transceiverDataBytes = 0;
-    if (analogData) {
-        free(analogData);
-        analogData = 0;
-    }
-    if (digitalData) {
-        free(digitalData);
-        digitalData = 0;
-    }
-    if (transceiverData) {
-        free(transceiverData);
-        transceiverData = 0;
-    }
-    analogDataPtr = 0;
-    digitalDataPtr = 0;
-    transceiverData = 0;
+    free(analogData);
+    analogData = NULL;
+    free(digitalData);
+    digitalData = NULL;
+    free(transceiverData);
+    transceiverData = NULL;
+    analogDataPtr = NULL;
+    digitalDataPtr = NULL;
+    transceiverData = NULL;
     {
         for (int i = 0; i < NUM_CLOCKS; ++i) {
             clkPhase[i] = 0;
@@ -640,22 +634,15 @@ int updateDatabytesandAllocateRAM() {
         return FAIL;
     }
     // clear RAM
-    if (analogData) {
-        free(analogData);
-        analogData = 0;
-    }
-    if (digitalData) {
-        free(digitalData);
-        digitalData = 0;
-    }
-    if (transceiverData) {
-        free(transceiverData);
-        transceiverData = 0;
-    }
+    free(analogData);
+    analogData = NULL;
+    free(digitalData);
+    digitalData = NULL;
+    free(transceiverData);
+    transceiverData = NULL;
     // allocate RAM
     if (analogDataBytes) {
         analogData = malloc(analogDataBytes);
-        // cannot malloc
         if (analogData == NULL) {
             LOG(logERROR, ("Can not allocate analog data RAM for even 1 frame. "
                            "Probable cause: Memory Leak.\n"));
@@ -665,7 +652,6 @@ int updateDatabytesandAllocateRAM() {
     }
     if (digitalDataBytes) {
         digitalData = malloc(digitalDataBytes);
-        // cannot malloc
         if (digitalData == NULL) {
             LOG(logERROR,
                 ("Can not allocate digital data RAM for even 1 frame. "
@@ -677,7 +663,6 @@ int updateDatabytesandAllocateRAM() {
     }
     if (transceiverDataBytes) {
         transceiverData = malloc(transceiverDataBytes);
-        // cannot malloc
         if (transceiverData == NULL) {
             LOG(logERROR,
                 ("Can not allocate transceiver data RAM for even 1 frame. "

--- a/slsDetectorServers/eigerDetectorServer/Beb.c
+++ b/slsDetectorServers/eigerDetectorServer/Beb.c
@@ -52,7 +52,7 @@ int Beb_Beb() {
 
     Beb_send_data_raw =
         malloc((Beb_send_buffer_size + 1) * sizeof(unsigned int));
-    if(Beb_send_data_raw == NULL) {
+    if (Beb_send_data_raw == NULL) {
         LOG(logERROR, ("Could not allocate memory for beb (send_data_raw)\n"));
         return 0;
     }
@@ -63,7 +63,7 @@ int Beb_Beb() {
 
     Beb_recv_data_raw =
         malloc((Beb_recv_buffer_size + 1) * sizeof(unsigned int));
-    if(Beb_recv_data_raw == NULL) {
+    if (Beb_recv_data_raw == NULL) {
         LOG(logERROR, ("Could not allocate memory for beb (recv_data_raw)\n"));
         return 0;
     }

--- a/slsDetectorServers/eigerDetectorServer/Beb.c
+++ b/slsDetectorServers/eigerDetectorServer/Beb.c
@@ -46,17 +46,27 @@ int Beb_deactivated_left_datastream = 1;
 int Beb_deactivated_right_datastream = 1;
 int Beb_deactivated_num_destinations = 1;
 
-void Beb_Beb() {
+int Beb_Beb() {
     Beb_send_ndata = 0;
     Beb_send_buffer_size = 1026;
+
     Beb_send_data_raw =
         malloc((Beb_send_buffer_size + 1) * sizeof(unsigned int));
+    if(Beb_send_data_raw == NULL) {
+        LOG(logERROR, ("Could not allocate memory for beb (send_data_raw)\n"));
+        return 0;
+    }
     Beb_send_data = &Beb_send_data_raw[1];
 
     Beb_recv_ndata = 0;
     Beb_recv_buffer_size = 1026;
+
     Beb_recv_data_raw =
         malloc((Beb_recv_buffer_size + 1) * sizeof(unsigned int));
+    if(Beb_recv_data_raw == NULL) {
+        LOG(logERROR, ("Could not allocate memory for beb (recv_data_raw)\n"));
+        return 0;
+    }
     Beb_recv_data = &Beb_recv_data_raw[1];
 
     udp_header = (struct udp_header_type){
@@ -83,6 +93,7 @@ void Beb_Beb() {
     Beb_ClearHeaderData(1);
 
     Beb_bit_mode = 4;
+    return 1;
 }
 
 void Beb_ClearHeaderData(int ten_gig) {

--- a/slsDetectorServers/eigerDetectorServer/Beb.h
+++ b/slsDetectorServers/eigerDetectorServer/Beb.h
@@ -6,7 +6,7 @@
 #include "slsDetectorServer_defs.h"
 #include <stdlib.h>
 
-void Beb_Beb();
+int Beb_Beb();
 void Beb_ClearHeaderData(int ten_gig);
 int Beb_SetUpUDPHeader(unsigned int header_number, int ten_gig,
                        uint64_t src_mac, uint32_t src_ip, uint16_t src_port,

--- a/slsDetectorServers/eigerDetectorServer/FebControl.c
+++ b/slsDetectorServers/eigerDetectorServer/FebControl.c
@@ -57,11 +57,17 @@ int Feb_Control_FebControl(int normal) {
     Feb_Control_externalEnableMode = 0;
     Feb_Control_subFrameMode = 0;
     Feb_Control_trimbit_size = 263680;
+
     Feb_Control_last_downloaded_trimbits =
         malloc(Feb_Control_trimbit_size * sizeof(int));
+    if (Feb_Control_last_downloaded_trimbits == NULL) {
+        LOG(logERROR, ("Could not allocate memory for last downloaded trimbits\n"));
+        return 0;
+    }
 
     Feb_Control_normal = normal;
-    Feb_Interface_SetAddress(Feb_Control_rightAddress, Feb_Control_leftAddress);
+    if (!Feb_Interface_SetAddress(Feb_Control_rightAddress, Feb_Control_leftAddress))
+        return 0;
     if (Feb_Control_activated) {
         return Feb_Interface_SetByteOrder();
     }

--- a/slsDetectorServers/eigerDetectorServer/FebControl.c
+++ b/slsDetectorServers/eigerDetectorServer/FebControl.c
@@ -61,12 +61,14 @@ int Feb_Control_FebControl(int normal) {
     Feb_Control_last_downloaded_trimbits =
         malloc(Feb_Control_trimbit_size * sizeof(int));
     if (Feb_Control_last_downloaded_trimbits == NULL) {
-        LOG(logERROR, ("Could not allocate memory for last downloaded trimbits\n"));
+        LOG(logERROR,
+            ("Could not allocate memory for last downloaded trimbits\n"));
         return 0;
     }
 
     Feb_Control_normal = normal;
-    if (!Feb_Interface_SetAddress(Feb_Control_rightAddress, Feb_Control_leftAddress))
+    if (!Feb_Interface_SetAddress(Feb_Control_rightAddress,
+                                  Feb_Control_leftAddress))
         return 0;
     if (Feb_Control_activated) {
         return Feb_Interface_SetByteOrder();

--- a/slsDetectorServers/eigerDetectorServer/FebInterface.c
+++ b/slsDetectorServers/eigerDetectorServer/FebInterface.c
@@ -22,34 +22,54 @@ unsigned int Feb_Interface_recv_buffer_size;
 unsigned int *Feb_Interface_recv_data_raw;
 unsigned int *Feb_Interface_recv_data;
 
-void Feb_Interface_FebInterface() {
+int Feb_Interface_FebInterface() {
     ll = &ll_local;
     Feb_Interface_nfebs = 0;
     Feb_Interface_feb_numb = 0;
 
     Feb_Interface_send_ndata = 0;
     Feb_Interface_send_buffer_size = 1026;
+
     Feb_Interface_send_data_raw =
         malloc((Feb_Interface_send_buffer_size + 1) * sizeof(unsigned int));
+    if (Feb_Interface_send_data_raw == NULL) {
+        LOG(logERROR, ("Could not allocate memory for feb interface (send_data_raw)\n"));
+        return 0;
+    }
     Feb_Interface_send_data = &Feb_Interface_send_data_raw[1];
 
     Feb_Interface_recv_ndata = 0;
     Feb_Interface_recv_buffer_size = 1026;
+
     Feb_Interface_recv_data_raw =
         malloc((Feb_Interface_recv_buffer_size + 1) * sizeof(unsigned int));
+    if (Feb_Interface_recv_data_raw == NULL) {
+        LOG(logERROR, ("Could not allocate memory for feb interface (recv_data_raw)\n"));
+
+        return 0;   
+    }
     Feb_Interface_recv_data = &Feb_Interface_recv_data_raw[1];
 
     Local_LocalLinkInterface(
         ll, XPAR_PLB_LL_FIFO_AURORA_DUAL_CTRL_FEB_RIGHT_BASEADDR);
+    
+    return 1;
 }
 
-void Feb_Interface_SetAddress(unsigned int leftAddr, unsigned int rightAddr) {
-    if (Feb_Interface_feb_numb)
-        free(Feb_Interface_feb_numb);
+int Feb_Interface_SetAddress(unsigned int leftAddr, unsigned int rightAddr) {
+    free(Feb_Interface_feb_numb);
     Feb_Interface_nfebs = 2;
+
     Feb_Interface_feb_numb = malloc(2 * sizeof(unsigned int));
+    if (Feb_Interface_feb_numb == NULL) {
+        LOG(logERROR, ("Could not allocate memory for feb interface (feb_numb)\n"));
+        Feb_Interface_nfebs = 0;
+        return 0;
+    }
+
     Feb_Interface_feb_numb[0] = leftAddr;
     Feb_Interface_feb_numb[1] = rightAddr;
+    return 1;
 }
 
 int Feb_Interface_WriteTo(unsigned int ch) {

--- a/slsDetectorServers/eigerDetectorServer/FebInterface.c
+++ b/slsDetectorServers/eigerDetectorServer/FebInterface.c
@@ -33,7 +33,8 @@ int Feb_Interface_FebInterface() {
     Feb_Interface_send_data_raw =
         malloc((Feb_Interface_send_buffer_size + 1) * sizeof(unsigned int));
     if (Feb_Interface_send_data_raw == NULL) {
-        LOG(logERROR, ("Could not allocate memory for feb interface (send_data_raw)\n"));
+        LOG(logERROR,
+            ("Could not allocate memory for feb interface (send_data_raw)\n"));
         return 0;
     }
     Feb_Interface_send_data = &Feb_Interface_send_data_raw[1];
@@ -44,15 +45,16 @@ int Feb_Interface_FebInterface() {
     Feb_Interface_recv_data_raw =
         malloc((Feb_Interface_recv_buffer_size + 1) * sizeof(unsigned int));
     if (Feb_Interface_recv_data_raw == NULL) {
-        LOG(logERROR, ("Could not allocate memory for feb interface (recv_data_raw)\n"));
+        LOG(logERROR,
+            ("Could not allocate memory for feb interface (recv_data_raw)\n"));
 
-        return 0;   
+        return 0;
     }
     Feb_Interface_recv_data = &Feb_Interface_recv_data_raw[1];
 
     Local_LocalLinkInterface(
         ll, XPAR_PLB_LL_FIFO_AURORA_DUAL_CTRL_FEB_RIGHT_BASEADDR);
-    
+
     return 1;
 }
 
@@ -62,7 +64,8 @@ int Feb_Interface_SetAddress(unsigned int leftAddr, unsigned int rightAddr) {
 
     Feb_Interface_feb_numb = malloc(2 * sizeof(unsigned int));
     if (Feb_Interface_feb_numb == NULL) {
-        LOG(logERROR, ("Could not allocate memory for feb interface (feb_numb)\n"));
+        LOG(logERROR,
+            ("Could not allocate memory for feb interface (feb_numb)\n"));
         Feb_Interface_nfebs = 0;
         return 0;
     }

--- a/slsDetectorServers/eigerDetectorServer/FebInterface.h
+++ b/slsDetectorServers/eigerDetectorServer/FebInterface.h
@@ -4,8 +4,8 @@
 
 int Feb_Interface_WriteTo(unsigned int ch);
 int Feb_Interface_ReadFrom(unsigned int ch, unsigned int ntrys);
-void Feb_Interface_FebInterface();
-void Feb_Interface_SetAddress(unsigned int leftAddr, unsigned int rightAddr);
+int Feb_Interface_FebInterface();
+int Feb_Interface_SetAddress(unsigned int leftAddr, unsigned int rightAddr);
 int Feb_Interface_SetByteOrder();
 int Feb_Interface_ReadRegister(unsigned int sub_num, unsigned int reg_num,
                                unsigned int *value_read);

--- a/slsDetectorServers/eigerDetectorServer/slsDetectorFunctionList.c
+++ b/slsDetectorServers/eigerDetectorServer/slsDetectorFunctionList.c
@@ -662,7 +662,15 @@ int checkCommandLineConfiguration() {
 #ifndef VIRTUAL
 void setupFebBeb() {
     sharedMemory_lockLocalLink();
-    Feb_Interface_FebInterface();
+    if (!Feb_Interface_FebInterface()) {
+        initError = FAIL;
+        sprintf(initErrorMessage,
+                "Could not intitalize eiger detector sever: feb interface\n");
+        LOG(logERROR, (initErrorMessage));
+        initCheckDone = 1;
+        sharedMemory_unlockLocalLink();
+        return;
+    }
     if (!Feb_Control_FebControl(normal)) {
         initError = FAIL;
         sprintf(initErrorMessage,
@@ -686,7 +694,14 @@ void setupFebBeb() {
     LOG(logDEBUG1, ("%s server: FEB Initialization done\n",
                     isControlServer ? "Control" : "Stop"));
     Beb_SetTopVariable(top);
-    Beb_Beb();
+    if (!Beb_Beb()) {
+        initError = FAIL;
+        sprintf(initErrorMessage,
+                "Could not intitalize eiger detector sever: beb\n");
+        LOG(logERROR, (initErrorMessage));
+        initCheckDone = 1;
+        return;
+    }
     LOG(logDEBUG1, ("%s server: BEB Initialization done\n",
                     isControlServer ? "Control" : "Stop"));
 
@@ -724,17 +739,22 @@ void setupFebBeb() {
 }
 #endif
 
-void allocateDetectorStructureMemory() {
-    LOG(logINFO, ("This Server is for 1 Eiger half module (250k)\n\n"));
-
-    // Allocation of memory
+int allocateDetectorStructureMemory() {
     detectorModules = malloc(sizeof(sls_detector_module));
     detectorChans = malloc(NCHIP * NCHAN * sizeof(int));
     detectorDacs = malloc(NDAC * sizeof(int));
+    if (detectorModules == NULL || detectorChans == NULL ||
+        detectorDacs == NULL) {
+        initError = FAIL;
+        strcpy(initErrorMessage, "Could not allocate memory for dacs or channels in detector\n");
+        LOG(logERROR, (initErrorMessage));
+        return FAIL;
+    }
     LOG(logDEBUG1,
         ("modules from 0x%x to 0x%x\n", detectorModules, detectorModules));
     LOG(logDEBUG1, ("chans from 0x%x to 0x%x\n", detectorChans, detectorChans));
     LOG(logDEBUG1, ("dacs from 0x%x to 0x%x\n", detectorDacs, detectorDacs));
+
     detectorModules->dacs = detectorDacs;
     detectorModules->chanregs = detectorChans;
     detectorModules->ndac = NDAC;
@@ -748,14 +768,20 @@ void allocateDetectorStructureMemory() {
     detectorModules->eV[2] = -1;
     thisSettings = UNINITIALIZED;
 
-    // if trimval requested, should return -1 to acknowledge unknown
+    // initialize (trimbits at -1 for unknown)
+    for (int idac = 0; idac < (detectorModules)->ndac; ++idac) {
+        detectorDacs[idac] = 0;
+    }
     for (int ichan = 0; ichan < (detectorModules->nchan); ichan++) {
         *((detectorModules->chanregs) + ichan) = -1;
     }
 }
 
 void setupDetector() {
-    allocateDetectorStructureMemory();
+    LOG(logINFO, ("This Server is for 1 Eiger half module (250k)\n\n"));
+
+    if (allocateDetectorStructureMemory() == FAIL)
+        return;
 
     // force top or master if in config file
     if (readConfigFile() == FAIL)

--- a/slsDetectorServers/eigerDetectorServer/slsDetectorFunctionList.c
+++ b/slsDetectorServers/eigerDetectorServer/slsDetectorFunctionList.c
@@ -746,7 +746,8 @@ int allocateDetectorStructureMemory() {
     if (detectorModules == NULL || detectorChans == NULL ||
         detectorDacs == NULL) {
         initError = FAIL;
-        strcpy(initErrorMessage, "Could not allocate memory for dacs or channels in detector\n");
+        strcpy(initErrorMessage,
+               "Could not allocate memory for dacs or channels in detector\n");
         LOG(logERROR, (initErrorMessage));
         return FAIL;
     }

--- a/slsDetectorServers/eigerDetectorServer/slsDetectorFunctionList.c
+++ b/slsDetectorServers/eigerDetectorServer/slsDetectorFunctionList.c
@@ -775,6 +775,7 @@ int allocateDetectorStructureMemory() {
     for (int ichan = 0; ichan < (detectorModules->nchan); ichan++) {
         *((detectorModules->chanregs) + ichan) = -1;
     }
+    return OK;
 }
 
 void setupDetector() {

--- a/slsDetectorServers/gotthard2DetectorServer/slsDetectorFunctionList.c
+++ b/slsDetectorServers/gotthard2DetectorServer/slsDetectorFunctionList.c
@@ -3326,11 +3326,12 @@ int *getBadChannels(int *numChannels) {
     if (*numChannels > 0) {
         // get list of bad channels
         retvals = malloc(*numChannels * sizeof(int));
-        memset(retvals, 0, *numChannels * sizeof(int));
         if (retvals == NULL) {
+            LOG(logERROR, ("Could not allocate memory to get bad channels\n"));
             *numChannels = -1;
             return NULL;
         }
+        memset(retvals, 0, *numChannels * sizeof(int));
         int chIndex = 0;
         int numAddr = MASK_STRIP_NUM_REGS;
         // loop through registers

--- a/slsDetectorServers/mythen3DetectorServer/slsDetectorFunctionList.c
+++ b/slsDetectorServers/mythen3DetectorServer/slsDetectorFunctionList.c
@@ -442,6 +442,7 @@ int allocateDetectorStructureMemory() {
         *((detectorModules->chanregs) + ichan) = 0;
     }
     memset(badChannelMask, 0, NCHAN_PER_MODULE * sizeof(char));
+    return OK;
 }
 
 void setupDetector() {

--- a/slsDetectorServers/mythen3DetectorServer/slsDetectorFunctionList.c
+++ b/slsDetectorServers/mythen3DetectorServer/slsDetectorFunctionList.c
@@ -404,18 +404,23 @@ void initStopServer() {
 
 /* set up detector */
 
-void allocateDetectorStructureMemory() {
-    // Allocation of memory
+int allocateDetectorStructureMemory() {
     detectorModules = malloc(sizeof(sls_detector_module));
     detectorChans = malloc(NCHAN_PER_MODULE * sizeof(int));
-    badChannelMask = malloc(NCHAN_PER_MODULE * sizeof(char));
-    memset(badChannelMask, 0, NCHAN_PER_MODULE * sizeof(char));
     detectorDacs = malloc(NDAC * sizeof(int));
-
+    badChannelMask = malloc(NCHAN_PER_MODULE * sizeof(char));
+    if (detectorModules == NULL || detectorChans == NULL ||
+        detectorDacs == NULL || badChannelMask == NULL) {
+        initError = FAIL;
+        strcpy(initErrorMessage, "Could not allocate memory for dacs, channels or bad channel mask in detector\n");
+        LOG(logERROR, (initErrorMessage));
+        return FAIL;
+    }
     LOG(logDEBUG1,
         ("modules from 0x%x to 0x%x\n", detectorModules, detectorModules));
     LOG(logDEBUG1, ("chans from 0x%x to 0x%x\n", detectorChans, detectorChans));
     LOG(logDEBUG1, ("dacs from 0x%x to 0x%x\n", detectorDacs, detectorDacs));
+    
     (detectorModules)->dacs = detectorDacs;
     (detectorModules)->chanregs = detectorChans;
     (detectorModules)->ndac = NDAC;
@@ -429,21 +434,21 @@ void allocateDetectorStructureMemory() {
     (detectorModules)->eV[2] = 0;
     thisSettings = UNINITIALIZED;
 
-    // initialize dacs
+    // initialize
     for (int idac = 0; idac < (detectorModules)->ndac; ++idac) {
         detectorDacs[idac] = 0;
     }
-
-    // trimbits start at 0
     for (int ichan = 0; ichan < (detectorModules->nchan); ichan++) {
         *((detectorModules->chanregs) + ichan) = 0;
     }
+    memset(badChannelMask, 0, NCHAN_PER_MODULE * sizeof(char));
 }
 
 void setupDetector() {
     LOG(logINFO, ("This Server is for 1 Mythen3 module \n"));
 
-    allocateDetectorStructureMemory();
+    if (allocateDetectorStructureMemory() == FAIL)
+        return;
 
     if (checkCommandLineConfiguration() == FAIL)
         return;
@@ -1412,6 +1417,10 @@ int setTrimbits(int *trimbits) {
 int setAllTrimbits(int val) {
     LOG(logINFO, ("Setting all trimbits to %d\n", val));
     int *trimbits = malloc(sizeof(int) * ((detectorModules)->nchan));
+    if (trimbits == NULL) {
+        LOG(logERROR, ("Could not allocate memory to set all trimbits\n"));
+        return FAIL;
+    }
     for (int ichan = 0; ichan < ((detectorModules)->nchan); ++ichan) {
         trimbits[ichan] = val;
     }
@@ -2469,11 +2478,12 @@ int *getBadChannels(int *numChannels) {
     }
     if (*numChannels > 0) {
         retvals = malloc(*numChannels * sizeof(int));
-        memset(retvals, 0, *numChannels * sizeof(int));
         if (retvals == NULL) {
+            LOG(logERROR, ("Could not allocate memory to get bad channels\n"));
             *numChannels = -1;
             return NULL;
         }
+        memset(retvals, 0, *numChannels * sizeof(int));
         // return only 1 channel for all counters
         int ich = 0;
         for (int i = 0; i != NCHAN_PER_MODULE; i = i + NCOUNTERS) {

--- a/slsDetectorServers/mythen3DetectorServer/slsDetectorFunctionList.c
+++ b/slsDetectorServers/mythen3DetectorServer/slsDetectorFunctionList.c
@@ -412,7 +412,8 @@ int allocateDetectorStructureMemory() {
     if (detectorModules == NULL || detectorChans == NULL ||
         detectorDacs == NULL || badChannelMask == NULL) {
         initError = FAIL;
-        strcpy(initErrorMessage, "Could not allocate memory for dacs, channels or bad channel mask in detector\n");
+        strcpy(initErrorMessage, "Could not allocate memory for dacs, channels "
+                                 "or bad channel mask in detector\n");
         LOG(logERROR, (initErrorMessage));
         return FAIL;
     }
@@ -420,7 +421,7 @@ int allocateDetectorStructureMemory() {
         ("modules from 0x%x to 0x%x\n", detectorModules, detectorModules));
     LOG(logDEBUG1, ("chans from 0x%x to 0x%x\n", detectorChans, detectorChans));
     LOG(logDEBUG1, ("dacs from 0x%x to 0x%x\n", detectorDacs, detectorDacs));
-    
+
     (detectorModules)->dacs = detectorDacs;
     (detectorModules)->chanregs = detectorChans;
     (detectorModules)->ndac = NDAC;

--- a/slsDetectorServers/slsDetectorServer/include/slsDetectorFunctionList.h
+++ b/slsDetectorServers/slsDetectorServer/include/slsDetectorFunctionList.h
@@ -140,7 +140,7 @@ void checkVirtual9MFlag();
 void setupFebBeb();
 #endif
 #if defined(EIGERD) || defined(MYTHEN3D)
-void allocateDetectorStructureMemory();
+int allocateDetectorStructureMemory();
 #endif
 void setupDetector();
 #if defined(CHIPTESTBOARDD)

--- a/slsDetectorServers/slsDetectorServer/include/slsDetectorServer_funcs.h
+++ b/slsDetectorServers/slsDetectorServer/include/slsDetectorServer_funcs.h
@@ -11,7 +11,8 @@
 // initialization functions
 int updateModeAllowedFunction(int file_des);
 int printSocketReadError();
-int sendMemoryAllocationError(int file_des);
+int sendError(int file_des);
+void setMemoryAllocationErrorMessage();
 void init_detector();
 int decode_function(int);
 const char *getRetName();

--- a/slsDetectorServers/slsDetectorServer/include/slsDetectorServer_funcs.h
+++ b/slsDetectorServers/slsDetectorServer/include/slsDetectorServer_funcs.h
@@ -11,6 +11,7 @@
 // initialization functions
 int updateModeAllowedFunction(int file_des);
 int printSocketReadError();
+int sendMemoryAllocationError(int file_des);
 void init_detector();
 int decode_function(int);
 const char *getRetName();

--- a/slsDetectorServers/slsDetectorServer/src/communication_funcs.c
+++ b/slsDetectorServers/slsDetectorServer/src/communication_funcs.c
@@ -592,7 +592,7 @@ int Server_SendResult(int fileDes, intType itype, void *retval,
         // send error message
         if (strlen(mess)) {
             sendData(fileDes, mess, MAX_STR_LENGTH, OTHER);
-            usleep(0);// test
+            usleep(0); // test
         }
         // debugging feature. should not happen.
         else {

--- a/slsDetectorServers/slsDetectorServer/src/communication_funcs.c
+++ b/slsDetectorServers/slsDetectorServer/src/communication_funcs.c
@@ -590,13 +590,16 @@ int Server_SendResult(int fileDes, intType itype, void *retval,
     sendData(fileDes, &ret1, sizeof(ret1), INT32);
     if (ret == FAIL) {
         // send error message
-        if (strlen(mess))
+        if (strlen(mess)) {
             sendData(fileDes, mess, MAX_STR_LENGTH, OTHER);
+            usleep(0);// test
+        }
         // debugging feature. should not happen.
-        else
+        else {
             LOG(logERROR, ("No error message provided for this failure in %s "
                            "server. Will mess up TCP.\n",
                            (isControlServer ? "control" : "stop")));
+        }
     }
     // send return value
     sendData(fileDes, retval, retvalSize, itype);

--- a/slsDetectorServers/slsDetectorServer/src/slsDetectorServer_funcs.c
+++ b/slsDetectorServers/slsDetectorServer/src/slsDetectorServer_funcs.c
@@ -125,11 +125,15 @@ int sendError(int file_des) {
 void setMemoryAllocationErrorMessage() {
     struct sysinfo info;
     sysinfo(&info);
-    sprintf(mess, "Memory allocation error (%s). Available space: %d MB. Please reboot", getFunctionNameFromEnum((enum detFuncs)fnum), (int)(info.freeram / (1024 * 1024)));
+    sprintf(
+        mess,
+        "Memory allocation error (%s). Available space: %d MB. Please reboot",
+        getFunctionNameFromEnum((enum detFuncs)fnum),
+        (int)(info.freeram / (1024 * 1024)));
 #ifdef EIGERD
-        strcat(mess, ".\n");
+    strcat(mess, ".\n");
 #else
-        sprintf(mess, " using sls_detector_put rebootcontroller.\n");
+    sprintf(mess, " using sls_detector_put rebootcontroller.\n");
 #endif
 }
 
@@ -1767,7 +1771,7 @@ int get_module(int file_des) {
         free(myChan);
         setMemoryAllocationErrorMessage();
         return sendError(file_des);
-    } 
+    }
     module.dacs = myDac;
     module.ndac = ndac;
     module.chanregs = myChan;
@@ -1811,7 +1815,7 @@ int set_module(int file_des) {
         free(myChan);
         setMemoryAllocationErrorMessage();
         return sendError(file_des);
-    } 
+    }
     module.dacs = myDac;
     module.ndac = ndac;
     module.chanregs = myChan;
@@ -1831,7 +1835,7 @@ int set_module(int file_des) {
     // should at least have a dac
     if (ts <= (int)sizeof(sls_detector_module)) {
         strcpy(mess, "Cannot set module. Received incorrect number of "
-                        "dacs or channels\n");
+                     "dacs or channels\n");
         free(myChan);
         free(myDac);
         return sendError(file_des);
@@ -6548,13 +6552,14 @@ int set_veto_photon(int file_des) {
     int *values = malloc(sizeof(int) * numChannels);
     if (gainIndices == NULL || values == NULL) {
         free(gainIndices);
-        free(values);       
+        free(values);
         setMemoryAllocationErrorMessage();
         return sendError(file_des);
-    } 
+    }
 
     if ((receiveData(file_des, gainIndices, sizeof(int) * numChannels, INT32) <
-        0)|| (receiveData(file_des, values, sizeof(int) * numChannels, INT32)) < 0) {
+         0) ||
+        (receiveData(file_des, values, sizeof(int) * numChannels, INT32)) < 0) {
         free(gainIndices);
         free(values);
         return printSocketReadError();
@@ -6630,15 +6635,14 @@ int get_veto_photon(int file_des) {
         return printSocketReadError();
     LOG(logDEBUG1, ("Getting veto photon [chip Index:%d]\n", arg));
 
-
     int *retvals = malloc(sizeof(int) * NCHAN);
     int *gainRetvals = malloc(sizeof(int) * NCHAN);
     if (gainRetvals == NULL || retvals == NULL) {
         free(gainRetvals);
-        free(retvals);       
+        free(retvals);
         setMemoryAllocationErrorMessage();
         return sendError(file_des);
-    } 
+    }
     memset(retvals, 0, sizeof(int) * NCHAN);
     memset(gainRetvals, 0, sizeof(int) * NCHAN);
 
@@ -6652,10 +6656,9 @@ int get_veto_photon(int file_des) {
     } else {
         ret = getVetoPhoton(chipIndex, retvals, gainRetvals);
         if (ret == FAIL) {
-            strcpy(mess,
-                    "Could not get veto photon for chipIndex -1. Not the "
-                    "same for all chips. Select specific chip index "
-                    "instead.\n");
+            strcpy(mess, "Could not get veto photon for chipIndex -1. Not the "
+                         "same for all chips. Select specific chip index "
+                         "instead.\n");
             LOG(logERROR, (mess));
         } else {
             for (int i = 0; i < NCHAN; ++i) {
@@ -8354,7 +8357,6 @@ int set_bad_channels(int file_des) {
         }
     }
     LOG(logDEBUG1, ("Setting %d bad channels\n", nargs));
-
 
     // only set
     if (Server_VerifyLock() == OK) {

--- a/slsDetectorServers/slsDetectorServer/src/slsDetectorServer_funcs.c
+++ b/slsDetectorServers/slsDetectorServer/src/slsDetectorServer_funcs.c
@@ -115,6 +115,18 @@ int printSocketReadError() {
     return FAIL;
 }
 
+int sendMemoryAllocationError(int file_des) {
+    ret = FAIL;
+    if (myDetectorType == EIGER) {
+        sprintf(mess, "Memory allocation error (%s). Please reboot.\n", getFunctionNameFromEnum((enum detFuncs)fnum));
+    } else {
+        sprintf(mess, "Memory allocation error (%s). Please reboot using sls_detector_put rebootcontroller.\n", getFunctionNameFromEnum((enum detFuncs)fnum));
+    }
+    LOG(logERROR, (mess));
+    Server_SendResult(file_des, INT32, NULL, 0);
+    return ret;
+}
+
 void init_detector() {
     memset(udpDetails, 0, sizeof(udpDetails));
 #ifdef VIRTUAL
@@ -2957,6 +2969,7 @@ int get_frames_left(int file_des) {
     retval = getNumFramesLeft();
     LOG(logDEBUG1, ("retval num frames left %lld\n", (long long int)retval));
 #endif
+
     return Server_SendResult(file_des, INT64, &retval, sizeof(retval));
 }
 
@@ -7864,6 +7877,9 @@ int set_pattern(int file_des) {
     functionNotImplemented();
 #else
     patternParameters *pat = malloc(sizeof(patternParameters));
+    if (pat == NULL) {
+        return sendMemoryAllocationError(file_des);
+    }
     memset(pat, 0, sizeof(patternParameters));
     // ignoring endianness for eiger
     if (receiveData(file_des, pat, sizeof(patternParameters), INT32) < 0) {

--- a/slsDetectorServers/slsDetectorServer/src/slsDetectorServer_funcs.c
+++ b/slsDetectorServers/slsDetectorServer/src/slsDetectorServer_funcs.c
@@ -8384,7 +8384,7 @@ int set_bad_channels(int file_des) {
                     free(args);
                     setMemoryAllocationErrorMessage();
                     return sendError(file_des);
-                } 
+                }
                 if (nretvals != nargs) {
                     ret = FAIL;
                     sprintf(mess,

--- a/slsDetectorServers/slsDetectorServer/src/slsDetectorServer_funcs.c
+++ b/slsDetectorServers/slsDetectorServer/src/slsDetectorServer_funcs.c
@@ -133,7 +133,7 @@ void setMemoryAllocationErrorMessage() {
 #ifdef EIGERD
     strcat(mess, ".\n");
 #else
-    sprintf(mess, " using sls_detector_put rebootcontroller.\n");
+    strcat(mess, " using sls_detector_put rebootcontroller.\n");
 #endif
 }
 
@@ -8314,7 +8314,7 @@ int get_bad_channels(int file_des) {
     // get only
     int nretvals = 0;
     int *retvals = getBadChannels(&nretvals);
-    if (retvals == NULL) {
+    if (nretvals == -1) {
         setMemoryAllocationErrorMessage();
         return sendError(file_des);
     }
@@ -8380,7 +8380,7 @@ int set_bad_channels(int file_des) {
             } else {
                 int nretvals = 0;
                 int *retvals = getBadChannels(&nretvals);
-                if (retvals == NULL) {
+                if (nretvals == -1) {
                     free(args);
                     setMemoryAllocationErrorMessage();
                     return sendError(file_des);

--- a/slsDetectorSoftware/src/Module.cpp
+++ b/slsDetectorSoftware/src/Module.cpp
@@ -161,6 +161,7 @@ Module::getTypeFromDetector(const std::string &hostname, uint16_t cport) {
     LOG(logDEBUG1) << "Getting Module type ";
     ClientSocket socket("Detector", hostname, cport);
     socket.Send(F_GET_DETECTOR_TYPE);
+    socket.setFnum(F_GET_DETECTOR_TYPE);
     if (socket.Receive<int>() == FAIL) {
         throw RuntimeError("Detector (" + hostname + ", " +
                            std::to_string(cport) +
@@ -555,6 +556,7 @@ void Module::setSynchronization(const bool value) {
 std::vector<int> Module::getBadChannels() const {
     auto client = DetectorSocket(shm()->hostname, shm()->controlPort);
     client.Send(F_GET_BAD_CHANNELS);
+    client.setFnum(F_GET_BAD_CHANNELS);
     if (client.Receive<int>() == FAIL) {
         throw DetectorError("Detector " + std::to_string(moduleIndex) +
                             " returned error: " + client.readErrorMessage());
@@ -576,6 +578,7 @@ void Module::setBadChannels(std::vector<int> list) {
     LOG(logDEBUG1) << "Sending bad channels to detector, nch:" << nch;
     auto client = DetectorSocket(shm()->hostname, shm()->controlPort);
     client.Send(F_SET_BAD_CHANNELS);
+    client.setFnum(F_SET_BAD_CHANNELS);
     client.Send(nch);
     if (nch > 0) {
         client.Send(list);
@@ -966,6 +969,7 @@ std::vector<int64_t> Module::getFramesCaughtByReceiver() const {
     if (shm()->useReceiverFlag) {
         auto client = ReceiverSocket(shm()->rxHostname, shm()->rxTCPPort);
         client.Send(F_GET_RECEIVER_FRAMES_CAUGHT);
+        client.setFnum(F_GET_RECEIVER_FRAMES_CAUGHT);
         if (client.Receive<int>() == FAIL) {
             throw ReceiverError(
                 "Receiver " + std::to_string(moduleIndex) +
@@ -988,6 +992,7 @@ std::vector<int64_t> Module::getNumMissingPackets() const {
     if (shm()->useReceiverFlag) {
         auto client = ReceiverSocket(shm()->rxHostname, shm()->rxTCPPort);
         client.Send(F_GET_NUM_MISSING_PACKETS);
+        client.setFnum(F_GET_NUM_MISSING_PACKETS);
         if (client.Receive<int>() == FAIL) {
             throw ReceiverError(
                 "Receiver " + std::to_string(moduleIndex) +
@@ -1010,6 +1015,7 @@ std::vector<int64_t> Module::getReceiverCurrentFrameIndex() const {
     if (shm()->useReceiverFlag) {
         auto client = ReceiverSocket(shm()->rxHostname, shm()->rxTCPPort);
         client.Send(F_GET_RECEIVER_FRAME_INDEX);
+        client.setFnum(F_GET_RECEIVER_FRAME_INDEX);
         if (client.Receive<int>() == FAIL) {
             throw ReceiverError(
                 "Receiver " + std::to_string(moduleIndex) +
@@ -1726,6 +1732,7 @@ void Module::sendReceiverRateCorrections(const std::vector<int64_t> &t) {
                   << ']';
     auto receiver = ReceiverSocket(shm()->rxHostname, shm()->rxTCPPort);
     receiver.Send(F_SET_RECEIVER_RATE_CORRECT);
+    receiver.setFnum(F_SET_RECEIVER_RATE_CORRECT);
     receiver.Send(static_cast<int>(t.size()));
     receiver.Send(t);
     if (receiver.Receive<int>() == FAIL) {
@@ -2022,6 +2029,7 @@ void Module::sendVetoPhoton(const int chipIndex,
     const int args[]{chipIndex, nch};
     auto client = DetectorSocket(shm()->hostname, shm()->controlPort);
     client.Send(F_SET_VETO_PHOTON);
+    client.setFnum(F_SET_VETO_PHOTON);
     client.Send(args);
     client.Send(gainIndices);
     client.Send(values);
@@ -2036,6 +2044,7 @@ void Module::getVetoPhoton(const int chipIndex,
     LOG(logDEBUG1) << "Getting veto photon [" << chipIndex << "]\n";
     auto client = DetectorSocket(shm()->hostname, shm()->controlPort);
     client.Send(F_GET_VETO_PHOTON);
+    client.setFnum(F_GET_VETO_PHOTON);
     client.Send(chipIndex);
     if (client.Receive<int>() == FAIL) {
         throw DetectorError("Detector " + std::to_string(moduleIndex) +
@@ -2542,6 +2551,7 @@ std::string Module::getPatterFileName() const {
 void Module::setPattern(const Pattern &pat, const std::string &fname) {
     auto client = DetectorSocket(shm()->hostname, shm()->controlPort);
     client.Send(F_SET_PATTERN);
+    client.setFnum(F_SET_PATTERN);
     client.Send(pat.data(), pat.size());
     char args[MAX_STR_LENGTH]{};
     strcpy_safe(args, fname.c_str());
@@ -2652,6 +2662,7 @@ std::map<std::string, std::string> Module::getAdditionalJsonHeader() const {
     }
     auto client = ReceiverSocket(shm()->rxHostname, shm()->rxTCPPort);
     client.Send(F_GET_ADDITIONAL_JSON_HEADER);
+    client.setFnum(F_GET_ADDITIONAL_JSON_HEADER);
     if (client.Receive<int>() == FAIL) {
         throw ReceiverError("Receiver " + std::to_string(moduleIndex) +
                             " returned error: " + client.readErrorMessage());
@@ -2697,6 +2708,7 @@ void Module::setAdditionalJsonHeader(
                   << ToString(jsonHeader);
     auto client = ReceiverSocket(shm()->rxHostname, shm()->rxTCPPort);
     client.Send(F_SET_ADDITIONAL_JSON_HEADER);
+    client.setFnum(F_SET_ADDITIONAL_JSON_HEADER);
     client.Send(size);
     if (size > 0)
         client.Send(&buff[0], buff.size());
@@ -2892,6 +2904,7 @@ std::string Module::executeCommand(const std::string &cmd) {
                  << "): Sending command " << cmd;
     auto client = DetectorSocket(shm()->hostname, shm()->controlPort);
     client.Send(F_EXEC_COMMAND);
+    client.setFnum(F_EXEC_COMMAND);
     client.Send(arg);
     if (client.Receive<int>() == FAIL) {
         std::cout << '\n';
@@ -3504,6 +3517,7 @@ void Module::setModule(sls_detector_module &module, bool trimbits) {
     }
     auto client = DetectorSocket(shm()->hostname, shm()->controlPort);
     client.Send(F_SET_MODULE);
+    client.setFnum(F_SET_MODULE);
     sendModule(&module, client);
     if (client.Receive<int>() == FAIL) {
         throw DetectorError("Module " + std::to_string(moduleIndex) +
@@ -3516,6 +3530,7 @@ sls_detector_module Module::getModule() {
     sls_detector_module module(shm()->detType);
     auto client = DetectorSocket(shm()->hostname, shm()->controlPort);
     client.Send(F_GET_MODULE);
+    client.setFnum(F_GET_MODULE);
     if (client.Receive<int>() == FAIL) {
         throw DetectorError("Module " + std::to_string(moduleIndex) +
                             " returned error: " + client.readErrorMessage());


### PR DESCRIPTION
-  Any malloc in the server is checked for failure and returns an appropriate error message wherever possible.
- pointer set to null for consistency (minor)
- removing the check to see if one can free before freeing as it s okay to free a null pointer
- usleep in communication to actually relay the err message of memory allocation to the client (weird but test for now)
- function in server to handle memory allcoation issues (updates mess, ret and sends it to the client and returns prior from function implementation
- setting fnum in client for the speicific functions that send to detector each argument separately, they need to remember the fnum else they throw with the incorrect fnum