### PR TITLE
Legal gain bit values are 0, 1, 3

### DIFF
--- a/slsDetectorServers/jungfrauDetectorServer/slsDetectorFunctionList.c
+++ b/slsDetectorServers/jungfrauDetectorServer/slsDetectorFunctionList.c
@@ -2730,9 +2730,9 @@ void *start_timer(void *arg) {
             }
 
             if ((i % 1024) < 300) {
-                gainVal = 1;
+                gainVal = 0;
             } else if ((i % 1024) < 600) {
-                gainVal = 2;
+                gainVal = 1;
             } else {
                 gainVal = 3;
             }


### PR DESCRIPTION
Partially resolves #1033

There are more gain values later in the packet generator, but I'll be looking at that separately to reduce the wall-clock execution time.