### PR TITLE
900 cmake_source_dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -316,7 +316,7 @@ if (SLS_USE_PYTHON)
     # https://github.com/pybind/pybind11/releases
         FetchContent_Declare(
             pybind11
-            URL ${CMAKE_SOURCE_DIR}/libs/pybind11/v2.13.0.tar.gz
+            URL ${CMAKE_CURRENT_LIST_DIR}/libs/pybind11/v2.13.0.tar.gz
             URL_HASH MD5=10cb1efba3aca997389d08bceb0ea767
         )
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.14)
 project(slsDetectorPackage)
 
 # Read VERSION file into project version
-set(VERSION_FILE "${CMAKE_CURRENT_LIST_DIR}/VERSION")
+set(VERSION_FILE "${CMAKE_CURRENT_SOURCE_DIR}/VERSION")
 file(READ "${VERSION_FILE}" VERSION_CONTENT)
 string(STRIP "${VERSION_CONTENT}" PROJECT_VERSION_STRING)
 set(PROJECT_VERSION ${PROJECT_VERSION_STRING})
@@ -316,7 +316,7 @@ if (SLS_USE_PYTHON)
     # https://github.com/pybind/pybind11/releases
         FetchContent_Declare(
             pybind11
-            URL ${CMAKE_CURRENT_LIST_DIR}/libs/pybind11/v2.13.0.tar.gz
+            URL ${CMAKE_CURRENT_SOURCE_DIR}/libs/pybind11/v2.13.0.tar.gz
             URL_HASH MD5=10cb1efba3aca997389d08bceb0ea767
         )
     endif()
@@ -357,4 +357,4 @@ if(SLS_MASTER_PROJECT)
     include(cmake/package_config.cmake)
 endif()
 
-install(FILES ${CMAKE_CURRENT_LIST_DIR}/VERSION DESTINATION ${CMAKE_INSTALL_PREFIX})
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/VERSION DESTINATION ${CMAKE_INSTALL_PREFIX})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -356,5 +356,3 @@ if(SLS_MASTER_PROJECT)
     set(PROJECT_LIBRARIES slsSupportShared slsDetectorShared slsReceiverShared)
     include(cmake/package_config.cmake)
 endif()
-
-install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/VERSION DESTINATION ${CMAKE_INSTALL_PREFIX})

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -64,7 +64,7 @@ configure_file( scripts/test_virtual.py
     ${CMAKE_BINARY_DIR}/test_virtual.py 
 )
 
-configure_file( ${CMAKE_CURRENT_LIST_DIR}/../VERSION  
+configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/../VERSION  
     ${CMAKE_BINARY_DIR}/bin/slsdet/VERSION
 )
 


### PR DESCRIPTION
- when package used as subdirectory (cmake-subfolder-example) it fails when python is used because the cmake_source_dir is now the one above package.
- also for finding VERSION file
- remove installation in root directory where its unecessary and maybe isntalled in system wide paths