### PR TITLE
dev: documentation for order of hostname command

### DIFF
--- a/docs/src/quick_start_guide.rst
+++ b/docs/src/quick_start_guide.rst
@@ -128,6 +128,10 @@ For Multiple Modules
         # set file path
         fpath /tmp
 
+.. note ::   
+    The **hostname** and **detsize** command in a multi module system can affect the row and column values in the udp/zmq header. The modules are stacked row by row until they reach the y-axis limit set by detsize (if specified). Then, stacking continues in the next column and so on. 
+
+    
 Gui
 ----
 

--- a/docs/src/udpheader.rst
+++ b/docs/src/udpheader.rst
@@ -73,9 +73,9 @@ Description
 
 * **modId**: module ID picked up from det_id_[detector type].txt on the detector cpu.
 
-* **row**: row position of the module in the detector system. It is calculated by the order of the module in hostname command, as well as the detsize command.
+* **row**: row position of the module in the detector system. It is calculated by the order of the module in hostname command, as well as the detsize command. The modules are stacked row by row until they reach the y-axis limit set by detsize (if specified). Then, stacking continues in the next column and so on.
 
-* **column**: column position of the module in the detector system.  It is calculated by the order of the module in hostname command, as well as the detsize command.
+* **column**: column position of the module in the detector system.  It is calculated by the order of the module in hostname command, as well as the detsize command. The modules are stacked row by row until they reach the y-axis limit set by detsize (if specified). Then, stacking continues in the next column and so on.
 
 * **detType**: detector type from enum of detectorType in the package.
 

--- a/python/slsdet/detector.py
+++ b/python/slsdet/detector.py
@@ -151,6 +151,10 @@ class Detector(CppDetectorApi):
     def hostname(self):
         """Frees shared memory and sets hostname (or IP address) of all modules concatenated by + 
         Virtual servers can already use the port in hostname separated by ':' and ports incremented by 2 to accomodate the stop server as well.
+
+        Note
+        -----
+        The row and column values in the udp/zmq header are affected by the order in this command and the detsize command. The modules are stacked row by row until they reach the y-axis limit set by detsize (if specified). Then, stacking continues in the next column and so on. This only affects row and column in udp/zmq header.
         
         Example
         -------

--- a/slsDetectorSoftware/include/sls/Detector.h
+++ b/slsDetectorSoftware/include/sls/Detector.h
@@ -65,7 +65,12 @@ class Detector {
 
     Result<std::string> getHostname(Positions pos = {}) const;
 
-    /**Frees shared memory, adds detectors to the list. */
+    /**Frees shared memory, adds detectors to the list. The row and column
+     * values in the udp/zmq header are affected by the order in this command
+     * and the setDetectorSize function. The modules are stacked row by row
+     * until they reach the y-axis limit set by detsize (if specified). Then,
+     * stacking continues in the next column and so on. This only affects row
+     * and column in udp/zmq header.*/
     void setHostname(const std::vector<std::string> &hostname);
 
     /** connects to n servers at local host starting at specific control port.

--- a/slsDetectorSoftware/src/CallerSpecial.cpp
+++ b/slsDetectorSoftware/src/CallerSpecial.cpp
@@ -198,7 +198,12 @@ std::string Caller::hostname(int action) {
         os << "\n\tFrees shared memory and sets hostname (or IP address) of "
               "all modules concatenated by +.\n\t Virtual servers can already "
               "use the port in hostname separated by ':' and ports incremented "
-              "by 2 to accomodate the stop server as well."
+              "by 2 to accomodate the stop server as well. The row and column "
+              "values in the udp/zmq header are affected by the order in this "
+              "command and the detsize command. The modules are stacked row by "
+              "row until they reach the y-axis limit set by detsize (if "
+              "specified). Then, stacking continues in the next column and so "
+              "on. This only affects row and column in udp/zmq header."
            << '\n';
     } else if (action == defs::GET_ACTION) {
         if (!args.empty()) {


### PR DESCRIPTION
added documentation of order in hostname command in quick start guide, udp header format for row and column values and in command line hostname