### PR TITLE
910: multirxr dirty destruct leaving arping thread hanging + versioning (multi and framesync)

### DIFF
--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -109,6 +109,14 @@ This document describes the differences between v9.1.0 and v9.0.0
 
     *   Removed potentially unsafe str().c_str() calls.
 
+
+    *   slsMultiReceiver Ctrl + C
+        Now cleans up properly upon Ctrl + C, including exiting the Arping thread.
+
+    
+    *   slsMultiReceiver version
+        --version or -v now gives the version of slsMultiReceiver.
+
  
     ZMQ
     ---

--- a/slsReceiverSoftware/src/FrameSynchronizerApp.cpp
+++ b/slsReceiverSoftware/src/FrameSynchronizerApp.cpp
@@ -10,6 +10,7 @@
 #include "sls/container_utils.h"
 #include "sls/logger.h"
 #include "sls/sls_detector_defs.h"
+#include "sls/versionAPI.h"
 
 #include <csignal> //SIGINT
 #include <cstdio>
@@ -92,7 +93,9 @@ void cleanup() {
 std::string getHelpMessage() {
     std::ostringstream os;
     os << "\nUsage:\n"
-          "./slsFrameSynchronizer [start tcp port] [num recevers] [print "
+       << "./slsFrameSynchronizer --version or -v\n"
+       << "\t - Gets the slsFrameSynchronizer version\n\n"
+       << "./slsFrameSynchronizer [start tcp port] [num recevers] [print "
           "callback headers (optional)]\n"
        << "\t - tcp port has to be non-zero and 16 bit\n"
        << "\t - print callback headers option is 0 (disabled) by default\n";
@@ -505,6 +508,16 @@ void GetDataCallback(slsDetectorDefs::sls_receiver_header &header,
  *  	- Default Start TCP port is 1954
  */
 int main(int argc, char *argv[]) {
+
+    // version
+    if (argc == 2) {
+        std::string sargv1 = std::string(argv[1]);
+        if (sargv1 == "--version" || sargv1 == "-v") {
+            std::cout << "slsFrameSynchronizer Version: " << APIRECEIVER
+                      << std::endl;
+            exit(EXIT_SUCCESS);
+        }
+    }
 
     /**	- set default values */
     int numReceivers = 1;

--- a/slsReceiverSoftware/src/MultiReceiverApp.cpp
+++ b/slsReceiverSoftware/src/MultiReceiverApp.cpp
@@ -7,6 +7,7 @@
 #include "sls/container_utils.h"
 #include "sls/logger.h"
 #include "sls/sls_detector_defs.h"
+#include "sls/versionAPI.h"
 
 #include <csignal> //SIGINT
 #include <cstring>
@@ -160,6 +161,15 @@ void GetData(slsDetectorDefs::sls_receiver_header &header,
  */
 int main(int argc, char *argv[]) {
 
+    // version
+    if (argc == 2) {
+        std::string sargv1 = std::string(argv[1]);
+        if (sargv1 == "--version" || sargv1 == "-v") {
+            std::cout << "SLS Receiver Version: " << APIRECEIVER << std::endl;
+            exit(EXIT_SUCCESS);
+        }
+    }
+
     /**	- set default values */
     int numReceivers = 1;
     uint16_t startTCPPort = DEFAULT_TCP_RX_PORTNO;
@@ -242,40 +252,43 @@ int main(int argc, char *argv[]) {
         else if (pid == 0) {
             cprintf(BLUE, "Child process %d [ Tid: %ld ]\n", i, (long)gettid());
 
-            std::unique_ptr<sls::Receiver> receiver = nullptr;
             try {
-                receiver = sls::make_unique<sls::Receiver>(startTCPPort + i);
+                uint16_t port = startTCPPort + i;
+                sls::Receiver receiver(port);
+
+                /**	- register callbacks. remember to set file write enable
+                 * to 0 (using the client) if we should not write files and you
+                 * will write data using the callbacks */
+                if (withCallback) {
+
+                    /** - Call back for start acquisition */
+                    cprintf(BLUE, "Registering StartAcq()\n");
+                    receiver.registerCallBackStartAcquisition(StartAcq,
+                                                              nullptr);
+
+                    /** - Call back for acquisition finished */
+                    cprintf(BLUE, "Registering AcquisitionFinished()\n");
+                    receiver.registerCallBackAcquisitionFinished(
+                        AcquisitionFinished, nullptr);
+
+                    /* 	- Call back for raw data */
+                    cprintf(BLUE, "Registering GetData() \n");
+                    receiver.registerCallBackRawDataReady(GetData, nullptr);
+                }
+
+                /**	- as long as no Ctrl+C */
+                sem_wait(&semaphore);
+                sem_destroy(&semaphore);
+
             } catch (...) {
                 LOG(sls::logINFOBLUE)
                     << "Exiting Child Process [ Tid: " << gettid() << " ]";
                 throw;
             }
-            /**	- register callbacks. remember to set file write enable to 0
-             * (using the client) if we should not write files and you will
-             * write data using the callbacks */
-            if (withCallback) {
 
-                /** - Call back for start acquisition */
-                cprintf(BLUE, "Registering StartAcq()\n");
-                receiver->registerCallBackStartAcquisition(StartAcq, nullptr);
-
-                /** - Call back for acquisition finished */
-                cprintf(BLUE, "Registering AcquisitionFinished()\n");
-                receiver->registerCallBackAcquisitionFinished(
-                    AcquisitionFinished, nullptr);
-
-                /* 	- Call back for raw data */
-                cprintf(BLUE, "Registering GetData() \n");
-                receiver->registerCallBackRawDataReady(GetData, nullptr);
-            }
-
-            /**	- as long as no Ctrl+C */
-            sem_wait(&semaphore);
-            sem_destroy(&semaphore);
             cprintf(BLUE, "Exiting Child Process [ Tid: %ld ]\n",
                     (long)gettid());
             exit(EXIT_SUCCESS);
-            break;
         }
     }
 

--- a/slsReceiverSoftware/src/MultiReceiverApp.cpp
+++ b/slsReceiverSoftware/src/MultiReceiverApp.cpp
@@ -40,7 +40,9 @@ void sigInterruptHandler(int p) { sem_post(&semaphore); }
  */
 std::string getHelpMessage() {
     std::ostringstream os;
-    os << "\nUsage:\n"
+    os << "\nUsage:\n\n"
+       << "./slsMultiReceiver --version or -v\n"
+       << "\t - Gets the slsMultiReceiver version\n\n"
        << "./slsMultiReceiver [start tcp port] [num recevers] [call back "
           "option (optional)]\n"
        << "\t - tcp port has to be non-zero and 16 bit\n"
@@ -165,7 +167,8 @@ int main(int argc, char *argv[]) {
     if (argc == 2) {
         std::string sargv1 = std::string(argv[1]);
         if (sargv1 == "--version" || sargv1 == "-v") {
-            std::cout << "SLS Receiver Version: " << APIRECEIVER << std::endl;
+            std::cout << "slsMultiReceiver Version: " << APIRECEIVER
+                      << std::endl;
             exit(EXIT_SUCCESS);
         }
     }

--- a/slsReceiverSoftware/src/Receiver.cpp
+++ b/slsReceiverSoftware/src/Receiver.cpp
@@ -62,7 +62,7 @@ Receiver::Receiver(int argc, char *argv[]) : tcpipInterface(nullptr) {
         "\t                          started with privileges. \n\n";
 
     while (c != -1) {
-        c = getopt_long(argc, argv, "hvf:t:u:", long_options, &option_index);
+        c = getopt_long(argc, argv, "hvt:u:", long_options, &option_index);
 
         // Detect the end of the options.
         if (c == -1)
@@ -87,7 +87,7 @@ Receiver::Receiver(int argc, char *argv[]) : tcpipInterface(nullptr) {
             break;
 
         case 'v':
-            std::cout << "SLS Receiver Version: " << APIRECEIVER << std::endl;
+            std::cout << "slsReceiver Version: " << APIRECEIVER << std::endl;
             LOG(logINFOBLUE) << "Exiting [ Tid: " << gettid() << " ]";
             exit(EXIT_SUCCESS);
 


### PR DESCRIPTION
* multireceiverapp changed from pointer to destruct properly (or could) have used reset() before exit but kept this for consistency with slsReceiver and slsFrameSynchronizer
* added --version/ -v for slsMultiReciever and slsFramesynchronizer (in 10, could be done properly
* got rid of unnecessary break after an exit in multireceiverapp
* removed outdated f: command line option in slsReceiver used previously for config files
* updated version print out to print binary in slsReceiver version command