### PR TITLE
Fix/dbitreorder should only be defined for chip and xilinx

### DIFF
--- a/slsReceiverSoftware/src/DataProcessor.cpp
+++ b/slsReceiverSoftware/src/DataProcessor.cpp
@@ -295,8 +295,6 @@ void DataProcessor::ThreadExecution() {
                        memImage->data);
     } catch (const std::exception &e) {
         fifo->FreeAddress(buffer);
-        LOG(logERROR) << "DataProcessor " << index << ": Failed to Process. "
-                      << e.what() << std::endl;
         throw RuntimeError(e.what());
     }
 

--- a/slsReceiverSoftware/src/DataProcessor.cpp
+++ b/slsReceiverSoftware/src/DataProcessor.cpp
@@ -295,7 +295,9 @@ void DataProcessor::ThreadExecution() {
                        memImage->data);
     } catch (const std::exception &e) {
         fifo->FreeAddress(buffer);
-        return;
+        LOG(logERROR) << "DataProcessor " << index << ": Failed to Process. "
+                      << e.what() << std::endl;
+        throw RuntimeError(e.what());
     }
 
     // stream (if time/freq to stream) or free

--- a/slsReceiverSoftware/src/DataProcessor.cpp
+++ b/slsReceiverSoftware/src/DataProcessor.cpp
@@ -72,14 +72,6 @@ void DataProcessor::SetStreamingStartFnum(uint32_t value) {
 
 void DataProcessor::SetFramePadding(bool enable) { framePadding = enable; }
 
-void DataProcessor::SetCtbDbitList(std::vector<int> value) {
-    ctbDbitList = value;
-}
-
-void DataProcessor::SetCtbDbitOffset(int value) { ctbDbitOffset = value; }
-
-void DataProcessor::SetCtbDbitReorder(bool value) { ctbDbitReorder = value; }
-
 void DataProcessor::SetQuadEnable(bool value) { quadEnable = value; }
 
 void DataProcessor::SetFlipRows(bool fd) {
@@ -361,13 +353,14 @@ void DataProcessor::ProcessAnImage(sls_receiver_header &header, size_t &size,
         PadMissingPackets(header, data);
 
     // rearrange ctb digital bits
-    if (!ctbDbitList.empty()) {
+    if (!generalData->ctbDbitList.empty()) {
         ArrangeDbitData(size, data);
-    } else if (ctbDbitReorder) {
-        ctbDbitList.resize(64);
+    } else if (generalData->ctbDbitReorder) {
+        std::vector<int> ctbDbitList(64);
         std::iota(ctbDbitList.begin(), ctbDbitList.end(), 0);
+        generalData->SetctbDbitList(ctbDbitList);
         ArrangeDbitData(size, data);
-    } else if (ctbDbitOffset > 0) {
+    } else if (generalData->ctbDbitOffset > 0) {
         RemoveTrailingBits(size, data);
     }
 
@@ -542,6 +535,7 @@ void DataProcessor::RemoveTrailingBits(size_t &size, char *data) {
     const size_t nDigitalDataBytes = generalData->GetNumberOfDigitalDatabytes();
     const size_t nTransceiverDataBytes =
         generalData->GetNumberOfTransceiverDatabytes();
+    const size_t ctbDbitOffset = generalData->ctbDbitOffset;
 
     const size_t ctbDigitalDataBytes = nDigitalDataBytes - ctbDbitOffset;
 
@@ -568,10 +562,14 @@ void DataProcessor::ArrangeDbitData(size_t &size, char *data) {
                                  std::to_string(generalData->detType));
     }
 
-    size_t nAnalogDataBytes = generalData->GetNumberOfAnalogDatabytes();
-    size_t nDigitalDataBytes = generalData->GetNumberOfDigitalDatabytes();
-    size_t nTransceiverDataBytes =
+    const size_t nAnalogDataBytes = generalData->GetNumberOfAnalogDatabytes();
+    const size_t nDigitalDataBytes = generalData->GetNumberOfDigitalDatabytes();
+    const size_t nTransceiverDataBytes =
         generalData->GetNumberOfTransceiverDatabytes();
+    const size_t ctbDbitOffset = generalData->ctbDbitOffset;
+    const bool ctbDbitReorder = generalData->ctbDbitReorder;
+    const auto ctbDbitList = generalData->ctbDbitList;
+
     // TODO! (Erik) Refactor and add tests
     int ctbDigitalDataBytes = nDigitalDataBytes - ctbDbitOffset;
 

--- a/slsReceiverSoftware/src/DataProcessor.h
+++ b/slsReceiverSoftware/src/DataProcessor.h
@@ -45,9 +45,6 @@ class DataProcessor : private virtual slsDetectorDefs, public ThreadObject {
     void SetStreamingTimerInMs(uint32_t value);
     void SetStreamingStartFnum(uint32_t value);
     void SetFramePadding(bool enable);
-    void SetCtbDbitList(std::vector<int> value);
-    void SetCtbDbitOffset(int value);
-    void SetCtbDbitReorder(bool value);
     void SetQuadEnable(bool value);
     void SetFlipRows(bool fd);
     void SetNumberofTotalFrames(uint64_t value);
@@ -171,11 +168,8 @@ class DataProcessor : private virtual slsDetectorDefs, public ThreadObject {
     uint32_t streamingTimerInMs;
     uint32_t streamingStartFnum;
     uint32_t currentFreqCount{0};
-    struct timespec timerbegin {};
+    struct timespec timerbegin{};
     bool framePadding;
-    std::vector<int> ctbDbitList{};
-    int ctbDbitOffset{0};
-    bool ctbDbitReorder{true};
     std::atomic<bool> startedFlag{false};
     std::atomic<uint64_t> firstIndex{0};
     bool quadEnable{false};

--- a/slsReceiverSoftware/src/GeneralData.h
+++ b/slsReceiverSoftware/src/GeneralData.h
@@ -52,6 +52,9 @@ class GeneralData {
     uint32_t nAnalogSamples{0};
     uint32_t nDigitalSamples{0};
     uint32_t nTransceiverSamples{0};
+    std::vector<int> ctbDbitList;
+    int ctbDbitOffset{0};
+    bool ctbDbitReorder{false};
     slsDetectorDefs::readoutMode readoutType{slsDetectorDefs::ANALOG_ONLY};
     uint32_t adcEnableMaskOneGiga{BIT32_MASK};
     uint32_t adcEnableMaskTenGiga{BIT32_MASK};
@@ -147,6 +150,18 @@ class GeneralData {
 
     virtual void SetTransceiverEnableMask(int n) {
         ThrowGenericError("SetTransceiverEnableMask");
+    };
+
+    virtual void SetctbDbitOffset(const int n) {
+        ThrowGenericError("SetctbDbitOffset");
+    };
+
+    virtual void SetctbDbitList(const std::vector<int> &value) {
+        ThrowGenericError("SetctbDbitList");
+    };
+
+    virtual void SetctbDbitReorder(const bool reorder) {
+        ThrowGenericError("SetctbDbitReorder");
     };
 };
 
@@ -387,6 +402,7 @@ class ChipTestBoardData : public GeneralData {
         framesPerFile = CTB_MAX_FRAMES_PER_FILE;
         fifoDepth = 2500;
         standardheader = true;
+        ctbDbitReorder = true;
         UpdateImageSize();
     };
 
@@ -411,6 +427,12 @@ class ChipTestBoardData : public GeneralData {
         nTransceiverSamples = n;
         UpdateImageSize();
     };
+
+    void SetctbDbitOffset(const int value) { ctbDbitOffset = value; }
+
+    void SetctbDbitList(const std::vector<int> &value) { ctbDbitList = value; }
+
+    void SetctbDbitReorder(const bool value) { ctbDbitReorder = value; }
 
     void SetOneGigaAdcEnableMask(int n) {
         adcEnableMaskOneGiga = n;
@@ -518,6 +540,7 @@ class XilinxChipTestBoardData : public GeneralData {
         dataSize = 8144;
         packetSize = headerSizeinPacket + dataSize;
         tengigaEnable = true;
+        ctbDbitReorder = true;
         UpdateImageSize();
     };
 
@@ -542,6 +565,12 @@ class XilinxChipTestBoardData : public GeneralData {
         nTransceiverSamples = n;
         UpdateImageSize();
     };
+
+    void SetctbDbitOffset(const int value) { ctbDbitOffset = value; }
+
+    void SetctbDbitList(const std::vector<int> &value) { ctbDbitList = value; }
+
+    void SetctbDbitReorder(const bool value) { ctbDbitReorder = value; }
 
     void SetOneGigaAdcEnableMask(int n) {
         adcEnableMaskOneGiga = n;

--- a/slsReceiverSoftware/src/GeneralData.h
+++ b/slsReceiverSoftware/src/GeneralData.h
@@ -52,7 +52,7 @@ class GeneralData {
     uint32_t nAnalogSamples{0};
     uint32_t nDigitalSamples{0};
     uint32_t nTransceiverSamples{0};
-    std::vector<int> ctbDbitList;
+    std::vector<int> ctbDbitList{};
     int ctbDbitOffset{0};
     bool ctbDbitReorder{false};
     slsDetectorDefs::readoutMode readoutType{slsDetectorDefs::ANALOG_ONLY};

--- a/slsReceiverSoftware/src/Implementation.cpp
+++ b/slsReceiverSoftware/src/Implementation.cpp
@@ -200,9 +200,6 @@ void Implementation::SetupDataProcessor(int i) {
     dataProcessor[i]->SetStreamingTimerInMs(streamingTimerInMs);
     dataProcessor[i]->SetStreamingStartFnum(streamingStartFnum);
     dataProcessor[i]->SetFramePadding(framePadding);
-    dataProcessor[i]->SetCtbDbitList(ctbDbitList);
-    dataProcessor[i]->SetCtbDbitOffset(ctbDbitOffset);
-    dataProcessor[i]->SetCtbDbitReorder(ctbDbitReorder);
     dataProcessor[i]->SetQuadEnable(quadEnable);
     dataProcessor[i]->SetFlipRows(flipRows);
     dataProcessor[i]->SetNumberofTotalFrames(numberOfTotalFrames);
@@ -991,11 +988,11 @@ void Implementation::StartMasterWriter() {
                     ? 1
                     : 0;
             masterAttributes.digitalSamples = generalData->nDigitalSamples;
-            masterAttributes.dbitoffset = ctbDbitOffset;
-            masterAttributes.dbitreorder = ctbDbitReorder;
+            masterAttributes.dbitoffset = generalData->ctbDbitOffset;
+            masterAttributes.dbitreorder = generalData->ctbDbitReorder;
             masterAttributes.dbitlist = 0;
 
-            for (auto &i : ctbDbitList) {
+            for (auto &i : generalData->ctbDbitList) {
                 masterAttributes.dbitlist |= (static_cast<uint64_t>(1) << i);
             }
             masterAttributes.transceiverSamples =
@@ -1751,31 +1748,29 @@ void Implementation::setTenGigaADCEnableMask(uint32_t mask) {
     LOG(logINFO) << "Packets per Frame: " << (generalData->packetsPerFrame);
 }
 
-std::vector<int> Implementation::getDbitList() const { return ctbDbitList; }
+std::vector<int> Implementation::getDbitList() const {
+    return generalData->ctbDbitList;
+}
 
 void Implementation::setDbitList(const std::vector<int> &v) {
-    ctbDbitList = v;
-    for (const auto &it : dataProcessor)
-        it->SetCtbDbitList(ctbDbitList);
-    LOG(logINFO) << "Dbit list: " << ToString(ctbDbitList);
+    generalData->SetctbDbitList(v);
+    LOG(logINFO) << "Dbit list: " << ToString(v);
 }
 
-int Implementation::getDbitOffset() const { return ctbDbitOffset; }
+int Implementation::getDbitOffset() const { return generalData->ctbDbitOffset; }
 
 void Implementation::setDbitOffset(const int s) {
-    ctbDbitOffset = s;
-    for (const auto &it : dataProcessor)
-        it->SetCtbDbitOffset(ctbDbitOffset);
-    LOG(logINFO) << "Dbit offset: " << ctbDbitOffset;
+    generalData->SetctbDbitOffset(s);
+    LOG(logINFO) << "Dbit offset: " << s;
 }
 
-bool Implementation::getDbitReorder() const { return ctbDbitReorder; }
+bool Implementation::getDbitReorder() const {
+    return generalData->ctbDbitReorder;
+}
 
 void Implementation::setDbitReorder(const bool reorder) {
-    ctbDbitReorder = reorder;
-    for (const auto &it : dataProcessor)
-        it->SetCtbDbitReorder(ctbDbitReorder);
-    LOG(logINFO) << "Dbit reorder: " << ctbDbitReorder;
+    generalData->SetctbDbitReorder(reorder);
+    LOG(logINFO) << "Dbit reorder: " << reorder;
 }
 
 uint32_t Implementation::getTransceiverEnableMask() const {

--- a/slsReceiverSoftware/src/Implementation.h
+++ b/slsReceiverSoftware/src/Implementation.h
@@ -370,9 +370,6 @@ class Implementation : private virtual slsDetectorDefs {
     int thresholdEnergyeV{-1};
     std::array<int, 3> thresholdAllEnergyeV = {{-1, -1, -1}};
     std::vector<int64_t> rateCorrections;
-    std::vector<int> ctbDbitList;
-    int ctbDbitOffset{0};
-    bool ctbDbitReorder{true};
 
     // callbacks
     void (*startAcquisitionCallBack)(const startCallbackHeader,

--- a/slsReceiverSoftware/tests/test-ArrangeDataBasedOnBitList.cpp
+++ b/slsReceiverSoftware/tests/test-ArrangeDataBasedOnBitList.cpp
@@ -73,8 +73,6 @@ class DataProcessorTestFixture {
         dataprocessor = new DataProcessorTest;
         generaldata = new GeneralDataTest;
 
-        // set_num_samples(num_samples);
-
         generaldata->SetNumberOfAnalogDatabytes(num_analog_bytes);
         generaldata->SetNumberOfTransceiverDatabytes(num_transceiver_bytes);
         generaldata->SetNumberOfDigitalDatabytes(num_digital_bytes +

--- a/slsReceiverSoftware/tests/test-ArrangeDataBasedOnBitList.cpp
+++ b/slsReceiverSoftware/tests/test-ArrangeDataBasedOnBitList.cpp
@@ -32,17 +32,23 @@ class GeneralDataTest : public GeneralData {
         nTransceiverBytes = value;
     }
 
+    void SetCtbDbitOffset(const int value) { ctbDbitOffset = value; }
+
+    void SetCtbDbitList(const std::vector<int> &value) { ctbDbitList = value; }
+
+    void SetCtbDbitReorder(const bool value) { ctbDbitReorder = value; }
+
   private:
-    int nAnalogBytes;
-    int nDigitalBytes;
-    int nTransceiverBytes;
+    int nAnalogBytes{};
+    int nDigitalBytes{};
+    int nTransceiverBytes{};
 };
 
 // dummy DataProcessor class for testing
 class DataProcessorTest : public DataProcessor {
   public:
-    DataProcessorTest() : DataProcessor(0){};
-    ~DataProcessorTest(){};
+    DataProcessorTest() : DataProcessor(0) {};
+    ~DataProcessorTest() {};
     void ArrangeDbitData(size_t &size, char *data) {
         DataProcessor::ArrangeDbitData(size, data);
     }
@@ -140,7 +146,7 @@ TEST_CASE_METHOD(DataProcessorTestFixture, "Remove Trailing Bits",
     set_random_offset_bytes(num_random_offset_bytes);
     set_data();
 
-    dataprocessor->SetCtbDbitOffset(num_random_offset_bytes);
+    generaldata->SetCtbDbitOffset(num_random_offset_bytes);
 
     size_t expected_size = get_size() - num_random_offset_bytes;
 
@@ -183,8 +189,8 @@ TEST_CASE_METHOD(DataProcessorTestFixture, "Reorder all",
 
     std::vector<int> bitlist(64);
     std::iota(bitlist.begin(), bitlist.end(), 0);
-    dataprocessor->SetCtbDbitList(bitlist);
-    dataprocessor->SetCtbDbitReorder(true); // set reorder to true
+    generaldata->SetCtbDbitList(bitlist);
+    generaldata->SetCtbDbitReorder(true); // set reorder to true
 
     const size_t expected_size =
         num_analog_bytes + num_transceiver_bytes + expected_num_digital_bytes;
@@ -222,9 +228,9 @@ TEST_CASE_METHOD(DataProcessorTestFixture,
 
     std::vector<int> bitlist(64);
     std::iota(bitlist.begin(), bitlist.end(), 0);
-    dataprocessor->SetCtbDbitList(bitlist);
-    dataprocessor->SetCtbDbitOffset(num_random_offset_bytes);
-    dataprocessor->SetCtbDbitReorder(true); // set reorder to true
+    generaldata->SetCtbDbitList(bitlist);
+    generaldata->SetCtbDbitOffset(num_random_offset_bytes);
+    generaldata->SetCtbDbitReorder(true); // set reorder to true
 
     const size_t expected_num_digital_bytes = 64;
     std::vector<uint8_t> expected_digital_part{0b00011111};
@@ -272,9 +278,9 @@ TEST_CASE_METHOD(DataProcessorTestFixture, "Arrange bitlist with reorder false",
     std::tie(num_samples, bitlist, expected_num_digital_bytes,
              expected_digital_part) = parameters;
 
-    dataprocessor->SetCtbDbitList(bitlist);
+    generaldata->SetCtbDbitList(bitlist);
 
-    dataprocessor->SetCtbDbitReorder(false);
+    generaldata->SetCtbDbitReorder(false);
 
     set_num_samples(num_samples);
     set_data();
@@ -324,9 +330,9 @@ TEST_CASE_METHOD(DataProcessorTestFixture, "Arrange bitlist with reorder true",
     std::tie(num_samples, bitlist, expected_num_digital_bytes,
              expected_digital_part) = parameters;
 
-    dataprocessor->SetCtbDbitList(bitlist);
+    generaldata->SetCtbDbitList(bitlist);
 
-    dataprocessor->SetCtbDbitReorder(true);
+    generaldata->SetCtbDbitReorder(true);
 
     set_num_samples(num_samples);
     set_data();
@@ -368,11 +374,11 @@ TEST_CASE_METHOD(DataProcessorTestFixture,
     set_random_offset_bytes(num_random_offset_bytes);
     set_data();
 
-    dataprocessor->SetCtbDbitList(bitlist);
+    generaldata->SetCtbDbitList(bitlist);
 
-    dataprocessor->SetCtbDbitReorder(false);
+    generaldata->SetCtbDbitReorder(false);
 
-    dataprocessor->SetCtbDbitOffset(num_random_offset_bytes);
+    generaldata->SetCtbDbitOffset(num_random_offset_bytes);
 
     std::vector<uint8_t> expected_digital_part{0b00000111};
     const size_t expected_num_digital_bytes = 5;


### PR DESCRIPTION
- dbitlist, dbitreorder, dbitoffset are now part of GeneralData. Dbitreorder is per default true for chipttestboard and xilinx chip testboard. For all other detectors it is set to false. 
