### PR TITLE
rewrote end() for StaticVector

### DIFF
--- a/slsSupportLib/include/sls/StaticVector.h
+++ b/slsSupportLib/include/sls/StaticVector.h
@@ -113,10 +113,10 @@ template <typename T, size_t Capacity> class StaticVector {
     // auto begin() noexcept -> decltype(data_.begin()) { return data_.begin();
     // }
     const_iterator begin() const noexcept { return data_.begin(); }
-    iterator end() noexcept { return &data_[current_size]; }
-    const_iterator end() const noexcept { return &data_[current_size]; }
+    iterator end() noexcept { return data_.begin()+current_size; }
+    const_iterator end() const noexcept { return data_.begin()+current_size; }
     const_iterator cbegin() const noexcept { return data_.cbegin(); }
-    const_iterator cend() const noexcept { return &data_[current_size]; }
+    const_iterator cend() const noexcept { return  data_.cbegin()+current_size; }
 
     void size_check(size_type s) const {
         if (s > Capacity) {

--- a/slsSupportLib/tests/test-StaticVector.cpp
+++ b/slsSupportLib/tests/test-StaticVector.cpp
@@ -8,11 +8,14 @@
 #include <sstream>
 #include <vector>
 
-namespace sls {
+
+using sls::StaticVector;
 
 TEST_CASE("StaticVector is a container") {
-    REQUIRE(is_container<StaticVector<int, 7>>::value == true);
+    REQUIRE(sls::is_container<StaticVector<int, 7>>::value == true);
 }
+
+
 
 TEST_CASE("Comparing StaticVector containers") {
     StaticVector<int, 5> a{0, 1, 2};
@@ -90,10 +93,17 @@ TEST_CASE("Copy construct from array") {
     REQUIRE(fcc == arr);
 }
 
+TEST_CASE("Construct from a smaller StaticVector") {
+    StaticVector<int, 3> sv{1, 2, 3};
+    StaticVector<int, 5> sv2{sv};
+    REQUIRE(sv == sv2);
+}
+
 TEST_CASE("Free function and method gives the same iterators") {
     StaticVector<int, 3> fcc{1, 2, 3};
     REQUIRE(std::begin(fcc) == fcc.begin());
 }
+
 SCENARIO("StaticVectors can be sized and resized", "[support]") {
 
     GIVEN("A default constructed container") {
@@ -246,23 +256,23 @@ SCENARIO("Sorting, removing and other manipulation of a container",
                 REQUIRE(a[3] == 90);
             }
         }
-        // WHEN("Sorting is done using free function for begin and end") {
-        //     std::sort(begin(a), end(a));
-        //     THEN("it also works") {
-        //         REQUIRE(a[0] == 12);
-        //         REQUIRE(a[1] == 12);
-        //         REQUIRE(a[2] == 14);
-        //         REQUIRE(a[3] == 90);
-        //     }
-        // }
-        // WHEN("Erasing elements of a certain value") {
-        //     a.erase(std::remove(begin(a), end(a), 12));
-        //     THEN("all elements of that value are removed") {
-        //         REQUIRE(a.size() == 2);
-        //         REQUIRE(a[0] == 14);
-        //         REQUIRE(a[1] == 90);
-        //     }
-        // }
+        WHEN("Sorting is done using free function for begin and end") {
+            std::sort(std::begin(a), std::end(a));
+            THEN("it also works") {
+                REQUIRE(a[0] == 12);
+                REQUIRE(a[1] == 12);
+                REQUIRE(a[2] == 14);
+                REQUIRE(a[3] == 90);
+            }
+        }
+        WHEN("Erasing elements of a certain value") {
+            a.erase(std::remove(std::begin(a), std::end(a), 12));
+            THEN("all elements of that value are removed") {
+                REQUIRE(a.size() == 2);
+                REQUIRE(a[0] == 14);
+                REQUIRE(a[1] == 90);
+            }
+        }
     }
 }
 
@@ -335,4 +345,3 @@ TEST_CASE("StaticVector stream") {
     REQUIRE(oss.str() == "[33, 85667, 2]");
 }
 
-} // namespace sls


### PR DESCRIPTION
Rewrote end and cend of StaticVector to not trigger an assert in gcc 15 debug mode

```cpp
//Using address of element at current size as end triggers an assert if the capacity is filled
//since it was technically dereferencing one past end
iterator end() noexcept { return &data_[current_size]; }
```

Now using begin + size instead 
```cpp
iterator end() noexcept { return data_.begin()+current_size; }
```




