### PR TITLE
1000/shm_fix_remove

### DIFF
--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -35,6 +35,8 @@ This document describes the differences between v10.0.0 and v9.2.0
     *   PATCH 
         Find PATCH command required for compilation. Needed for lib zeromq patching.
 
+
+    *   pmodules support discontinued
     
 
 2 New or Changed Features
@@ -62,6 +64,13 @@ This document describes the differences between v10.0.0 and v9.2.0
     *   TCP API Incompatibility
         The size of the expected structure has changed when setting rx_hostname compared to previous versions. This change makes it incompatible.
 
+
+    *   User details
+        One can get user or detector details directly from shared memory without
+        creating the Detector class. It is now a free function.
+        C++ API: getUserDetails
+        python/ command line: user
+        
 
     Receiver
     --------

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -7,11 +7,12 @@ This document describes the differences between v10.0.0 and v9.2.0
 
     CONTENTS
     --------
-    1           Compilation Changes
-    2.1         New or Changed Features
-        2.1     Breaking API
-        2.2     Resolved or Changed Features
-        2.3     New Features
+    1           Changes
+    1.1         Compilation Changes
+    1.2         New or Changed Features
+        1.2.1   Breaking API
+        1.2.2   Resolved or Changed Features
+        1.2.3   New Features
     3           On-board Detector Server Compatibility
     4           Firmware Requirements
     5           Kernel Requirements
@@ -20,8 +21,13 @@ This document describes the differences between v10.0.0 and v9.2.0
 
 
 
-1 Compilation Changes
-======================
+1 Changes
+==========
+
+
+
+1.1 Compilation Changes
+========================
 
 
     *   C++ standard
@@ -39,13 +45,13 @@ This document describes the differences between v10.0.0 and v9.2.0
     *   pmodules support discontinued
     
 
-2 New or Changed Features
-=========================
+1.2 New or Changed Features
+============================
 
 
 
-2.1 Breaking API
-================
+1.2.1 Breaking API
+===================
 
 
     Client
@@ -108,8 +114,8 @@ This document describes the differences between v10.0.0 and v9.2.0
 
 
 
-2.2 Resolved or Changed Features
-================================
+1.2.2 Resolved or Changed Features
+===================================
 
 
     Python
@@ -166,8 +172,8 @@ This document describes the differences between v10.0.0 and v9.2.0
 
 
 
-2.3 New Features
-================
+1.2.3 New Features
+===================
 
 
     Compilation

--- a/slsDetectorSoftware/src/Detector.cpp
+++ b/slsDetectorSoftware/src/Detector.cpp
@@ -29,7 +29,6 @@ void freeSharedMemory(const int detectorIndex, const int moduleIndex) {
     if (moduleIndex >= 0) {
         SharedMemory<sharedModule> moduleShm(detectorIndex, moduleIndex);
         if (moduleShm.exists()) {
-            moduleShm.openSharedMemory(false);
             moduleShm.removeSharedMemory();
         }
         return;
@@ -48,7 +47,6 @@ void freeSharedMemory(const int detectorIndex, const int moduleIndex) {
     for (int i = 0; i < numDetectors; ++i) {
         SharedMemory<sharedModule> moduleShm(detectorIndex, i);
         if (moduleShm.exists()) {
-            moduleShm.openSharedMemory(false);
             moduleShm.removeSharedMemory();
         }
     }
@@ -56,7 +54,6 @@ void freeSharedMemory(const int detectorIndex, const int moduleIndex) {
     // Ctb configuration
     SharedMemory<CtbConfig> ctbShm(detectorIndex, -1, CtbConfig::shm_tag());
     if (ctbShm.exists()) {
-        ctbShm.openSharedMemory(false);
         ctbShm.removeSharedMemory();
     }
 }

--- a/slsDetectorSoftware/src/Module.cpp
+++ b/slsDetectorSoftware/src/Module.cpp
@@ -3396,11 +3396,11 @@ void Module::createSharedMemory(detectorType type, int det_id) {
 
     // ensure shared memory was not created before
     if (shm.exists()) {
-        throw SharedMemoryError(
-            "This shared memory " + shm.getName() +
-            " should have been deleted before! Free it to continue.");
+        LOG(logWARNING)
+            << "This shared memory " + shm.getName() +
+                   " should have been deleted before! Freeing it to continue.";
+        shm.removeSharedMemory();
     }
-
     shm.createSharedMemory();
     initializeModuleStructure(type);
 }

--- a/slsDetectorSoftware/src/SharedMemory.h
+++ b/slsDetectorSoftware/src/SharedMemory.h
@@ -57,6 +57,8 @@ template <typename T> class SharedMemory {
         name = constructSharedMemoryName(detectorId, moduleIndex, tag);
     }
 
+    explicit SharedMemory(const std::string &shm_name) : name(shm_name) {}
+
     // Disable copy, since we refer to a unique location
     SharedMemory(const SharedMemory &) = delete;
     SharedMemory &operator=(const SharedMemory &other) = delete;
@@ -81,8 +83,12 @@ template <typename T> class SharedMemory {
     }
 
     bool memoryHasValidFlag() const {
+        if (shared_struct == nullptr) {
+            throw SharedMemoryError(
+                "Shared memory not mapped. Cannot check validity.");
+        }
+        // CtbConfig did not have shmversion before, so exact value check
         if constexpr (is_type<CtbConfig, T>()) {
-            // CtbConfig did not have shmversion before, so exact value check
             if (shared_struct->shmversion == SHM_IS_VALID_CHECK_VERSION) {
                 return true;
             }
@@ -99,11 +105,18 @@ template <typename T> class SharedMemory {
     }
 
     void invalidate() {
+        bool wasValid = true;
+        if (shared_struct == nullptr) {
+            wasValid = false;
+            openSharedMemory(false);
+        }
         // also called by obsolete shm test structure (so check added)
         if constexpr (has_bool_isValid<T>::value) {
             if (memoryHasValidFlag())
                 shared_struct->isValid = false;
         }
+        if (!wasValid)
+            unmapSharedMemory();
     }
 
     T *operator()() {

--- a/slsDetectorSoftware/tests/test-SharedMemory.cpp
+++ b/slsDetectorSoftware/tests/test-SharedMemory.cpp
@@ -33,7 +33,6 @@ struct ObsoleteCtbData {
 void freeShm(const int dindex, const int mIndex) {
     SharedMemory<Data> shm(dindex, mIndex);
     if (shm.exists()) {
-        shm.openSharedMemory(false);
         shm.removeSharedMemory();
     }
 }


### PR DESCRIPTION
one doesnt need to open shared memory to call removesharedmemory, and calling hasMemoryvalid without opening will cause segfault (not used now, but could in the future)