### PR TITLE
added option to use system zmq

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ include(cmake/SlsAddFlag.cmake)
 include(cmake/helpers.cmake)
 
 
+option(SLS_USE_SYSTEM_ZMQ "Use system installed libzmq" OFF)
 
 # Using FetchContent to get libzmq
 include(FetchContent)
@@ -50,50 +51,112 @@ if(NOT PATCH_EXECUTABLE)
     message(FATAL_ERROR "The 'patch' tool is required for patching lib zeromq. Please install it.")
 endif()
 
-if(SLS_FETCH_ZMQ_FROM_GITHUB)
-    # Opt in to pull down a zmq version from github instead of
-    # using the bundled version
-    FetchContent_Declare(
-        libzmq
-        GIT_REPOSITORY https://github.com/zeromq/libzmq.git
-        GIT_TAG        v${SLS_LIBZMQ_VERSION}
-        PATCH_COMMAND ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> patch -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/libs/libzmq/libzmq_cmake_version.patch
-        UPDATE_DISCONNECTED 1
-    )
+if(SLS_USE_SYSTEM_ZMQ)
+    # find_package(ZeroMQ REQUIRED)
+    # 1) Try a CMake package config if available (vcpkg, Homebrew, source builds)
+    #    Many installs export either ZeroMQ::libzmq or libzmq.
+    find_package(ZeroMQ QUIET CONFIG)
+
+    set(ZEROMQ_TARGET "")
+
+    if (TARGET ZeroMQ::libzmq)
+        set(ZEROMQ_TARGET ZeroMQ::libzmq)
+        message(STATUS "Found target: ${ZEROMQ_TARGET}")
+    elseif (TARGET libzmq)
+        set(ZEROMQ_TARGET libzmq)
+        message(STATUS "Found target: ${ZEROMQ_TARGET}")
+    elseif (TARGET ZeroMQ::ZeroMQ) # rare older naming
+        set(ZEROMQ_TARGET ZeroMQ::ZeroMQ)
+        message(STATUS "Found target: ${ZEROMQ_TARGET}")
+    endif()
+
+    # 2) Fallback: use pkg-config hints + manual find_* to create an imported target
+    if (NOT ZEROMQ_TARGET)
+        find_package(PkgConfig QUIET)
+        if (PkgConfig_FOUND)
+            pkg_check_modules(PC_ZeroMQ QUIET libzmq)
+        endif()
+
+        find_path(ZEROMQ_INCLUDE_DIR
+            NAMES zmq.h
+            HINTS ${PC_ZeroMQ_INCLUDE_DIRS}
+        )
+
+        find_library(ZEROMQ_LIBRARY
+            NAMES zmq libzmq
+            HINTS ${PC_ZeroMQ_LIBRARY_DIRS}
+        )
+
+        if (ZEROMQ_INCLUDE_DIR AND ZEROMQ_LIBRARY)
+            add_library(libzmq UNKNOWN IMPORTED)
+            set_target_properties(libzmq PROPERTIES
+            IMPORTED_LOCATION "${ZEROMQ_LIBRARY}"
+            INTERFACE_INCLUDE_DIRECTORIES "${ZEROMQ_INCLUDE_DIR}"
+            )
+            set(ZEROMQ_TARGET libzmq)
+        endif()
+    endif()
+
+    # 3) Error out if still not found, with a helpful message
+    if (NOT ZEROMQ_TARGET)
+    message(FATAL_ERROR
+        "ZeroMQ (libzmq) not found.\n"
+        "Install it (e.g. Debian/Ubuntu: 'sudo apt install libzmq3-dev' or 'libzmq5-dev', "
+        "Fedora: 'sudo dnf install zeromq-devel', macOS: 'brew install zeromq', "
+        "Windows (vcpkg): 'vcpkg install zeromq').")
+    endif()
+
+# Use it
+# target_link_libraries(your_target PRIVATE ${ZEROMQ_TARGET})
+
+    message(STATUS "Using system installed libzmq: ${ZeroMQ_LIBRARIES}")
+    message(STATUS "ZeroMQ target: ${ZEROMQ_TARGET}")
+    message(STATUS "ZeroMQ include dirs: ${ZeroMQ_INCLUDE_DIRS}")
 else()
-    # Standard behaviour use libzmq included in this repo (libs/libzmq)
-    FetchContent_Declare(
-        libzmq
-        URL ${CMAKE_CURRENT_SOURCE_DIR}/libs/libzmq/libzmq-${SLS_LIBZMQ_VERSION}.tar.gz
-        URL_HASH MD5=cc20b769ac10afa352e5ed2769bb23b3
-        PATCH_COMMAND ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> patch -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/libs/libzmq/libzmq_cmake_version.patch
-        UPDATE_DISCONNECTED 1
-    )
+    if(SLS_FETCH_ZMQ_FROM_GITHUB)
+        # Opt in to pull down a zmq version from github instead of
+        # using the bundled version
+        FetchContent_Declare(
+            libzmq
+            GIT_REPOSITORY https://github.com/zeromq/libzmq.git
+            GIT_TAG        v${SLS_LIBZMQ_VERSION}
+            PATCH_COMMAND ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> patch -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/libs/libzmq/libzmq_cmake_version.patch
+            UPDATE_DISCONNECTED 1
+        )
+    else()
+        # Standard behaviour use libzmq included in this repo (libs/libzmq)
+        FetchContent_Declare(
+            libzmq
+            URL ${CMAKE_CURRENT_SOURCE_DIR}/libs/libzmq/libzmq-${SLS_LIBZMQ_VERSION}.tar.gz
+            URL_HASH MD5=cc20b769ac10afa352e5ed2769bb23b3
+            PATCH_COMMAND ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> patch -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/libs/libzmq/libzmq_cmake_version.patch
+            UPDATE_DISCONNECTED 1
+        )
+    endif()
+
+
+    # Disable unwanted options from libzmq
+    set(BUILD_TESTS OFF CACHE BOOL "Switch off libzmq test build")
+    set(BUILD_SHARED OFF CACHE BOOL "Switch off libzmq shared libs")
+    set(WITH_PERF_TOOL OFF CACHE BOOL "")
+    set(ENABLE_CPACK OFF CACHE BOOL "")
+    set(ENABLE_CLANG OFF CACHE BOOL "")
+    set(ENABLE_CURVE OFF CACHE BOOL "")
+    set(ENABLE_DRAFTS OFF CACHE BOOL "")
+    set(ENABLE_PRECOMPILED OFF CACHE BOOL "")
+    set(WITH_DOC OFF CACHE BOOL "")
+    set(WITH_DOCS OFF CACHE BOOL "")
+
+
+    # Using GetProperties and Populate to be able to exclude zmq
+    # from install (not possible with FetchContent_MakeAvailable(libzmq))
+    FetchContent_GetProperties(libzmq)
+    if(NOT libzmq_POPULATED)
+    FetchContent_Populate(libzmq)
+    add_subdirectory(${libzmq_SOURCE_DIR} ${libzmq_BINARY_DIR} EXCLUDE_FROM_ALL)
+    endif()
+
 endif()
-
-# Disable unwanted options from libzmq
-set(BUILD_TESTS OFF CACHE BOOL "Switch off libzmq test build")
-set(BUILD_SHARED OFF CACHE BOOL "Switch off libzmq shared libs")
-set(WITH_PERF_TOOL OFF CACHE BOOL "")
-set(ENABLE_CPACK OFF CACHE BOOL "")
-set(ENABLE_CLANG OFF CACHE BOOL "")
-set(ENABLE_CURVE OFF CACHE BOOL "")
-set(ENABLE_DRAFTS OFF CACHE BOOL "")
-set(ENABLE_PRECOMPILED OFF CACHE BOOL "")
-set(WITH_DOC OFF CACHE BOOL "")
-set(WITH_DOCS OFF CACHE BOOL "")
-
- 
-
-# Using GetProperties and Populate to be able to exclude zmq
-# from install (not possible with FetchContent_MakeAvailable(libzmq))
-FetchContent_GetProperties(libzmq)
-if(NOT libzmq_POPULATED)
-  FetchContent_Populate(libzmq)
-  add_subdirectory(${libzmq_SOURCE_DIR} ${libzmq_BINARY_DIR} EXCLUDE_FROM_ALL)
-endif()
-
-
 
 include(GNUInstallDirs)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,13 +61,13 @@ if(SLS_USE_SYSTEM_ZMQ)
 
     if (TARGET ZeroMQ::libzmq)
         set(ZEROMQ_TARGET ZeroMQ::libzmq)
-        message(STATUS "Found target: ${ZEROMQ_TARGET}")
+        message(STATUS "Found target: ${ZEROMQ_TARGET} version: ${ZeroMQ_VERSION}")
     elseif (TARGET libzmq)
         set(ZEROMQ_TARGET libzmq)
-        message(STATUS "Found target: ${ZEROMQ_TARGET}")
+        message(STATUS "Found target: ${ZEROMQ_TARGET} version: ${ZeroMQ_VERSION}")
     elseif (TARGET ZeroMQ::ZeroMQ) # rare older naming
         set(ZEROMQ_TARGET ZeroMQ::ZeroMQ)
-        message(STATUS "Found target: ${ZEROMQ_TARGET}")
+        message(STATUS "Found target: ${ZEROMQ_TARGET} version: ${ZeroMQ_VERSION}")
     endif()
 
     # 2) Fallback: use pkg-config hints + manual find_* to create an imported target
@@ -95,15 +95,13 @@ if(SLS_USE_SYSTEM_ZMQ)
             )
             set(ZEROMQ_TARGET libzmq)
         endif()
+        message(STATUS "ZeroMQ version (pkg-config): ${PC_ZeroMQ_VERSION}")
+        
     endif()
 
     # 3) Error out if still not found, with a helpful message
     if (NOT ZEROMQ_TARGET)
-    message(FATAL_ERROR
-        "ZeroMQ (libzmq) not found.\n"
-        "Install it (e.g. Debian/Ubuntu: 'sudo apt install libzmq3-dev' or 'libzmq5-dev', "
-        "Fedora: 'sudo dnf install zeromq-devel', macOS: 'brew install zeromq', "
-        "Windows (vcpkg): 'vcpkg install zeromq').")
+        message(FATAL_ERROR "ZeroMQ (libzmq) not found. Please install ZeroMQ development files.")
     endif()
 
 # Use it

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -26,6 +26,8 @@ This document describes the differences between vx.x.x and vx.0.2
 1 New, Changed or Resolved Features
 =====================================
 
+Added SLS_USE_SYSTEM_ZMQ option (default OFF) to use the libzmq of the host
+instead of the one included in our repo. 
 
  
 

--- a/slsReceiverSoftware/CMakeLists.txt
+++ b/slsReceiverSoftware/CMakeLists.txt
@@ -162,8 +162,16 @@ if (SLS_USE_RECEIVER_BINARIES)
         rt
     PRIVATE
         slsProjectWarnings
-        "$<BUILD_INTERFACE:libzmq-static>"
+        
     )
+
+    #Treat both vendored and system zmq as interface for receiver binaries
+    if(SLS_USE_SYSTEM_ZMQ)
+        message(STATUS "slsFrameSynchronizer ZEROMQ_TARGET=${ZEROMQ_TARGET}")
+        target_link_libraries(slsFrameSynchronizer PRIVATE "${ZEROMQ_TARGET}")
+    else()
+        target_link_libraries(slsFrameSynchronizer PRIVATE "$<BUILD_INTERFACE:libzmq-static>")
+    endif()
 
     install(TARGETS slsReceiver slsMultiReceiver slsFrameSynchronizer
         EXPORT "${TARGETS_EXPORT_NAME}"

--- a/slsSupportLib/CMakeLists.txt
+++ b/slsSupportLib/CMakeLists.txt
@@ -93,8 +93,15 @@ target_link_libraries(slsSupportObject
   PRIVATE
     slsProjectWarnings
     md5sls     
-    "$<BUILD_INTERFACE:libzmq-static>"
 )
+
+#Treat both vendored and system zmq as interface for receiver binaries
+if(SLS_USE_SYSTEM_ZMQ)
+    message(STATUS "slsSupportLib using ZEROMQ_TARGET=${ZEROMQ_TARGET}")
+    target_link_libraries(slsSupportObject PRIVATE "${ZEROMQ_TARGET}")
+else()
+    target_link_libraries(slsSupportObject PRIVATE "$<BUILD_INTERFACE:libzmq-static>")
+endif()
 
 if (SLS_USE_TESTS)
     add_subdirectory(tests)


### PR DESCRIPTION
Added an option SLS_USE_SYSTEM_ZMQ to disable building libzmq as a part of the project
closes #1308

Should maybe be back ported to 10.1, maybe even 9.3