### PR TITLE
Disable building of shared libraries by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,7 +122,7 @@ endif()
 
 
 option(SLS_USE_HDF5 "HDF5 File format" OFF)
-option(SLS_BUILD_SHARED_LIBRARIES "Build shared libaries" ON)
+option(SLS_BUILD_SHARED_LIBRARIES "Build shared libaries" OFF)
 option(SLS_USE_TEXTCLIENT "Text Client" ON)
 option(SLS_USE_DETECTOR "Detector libs" ON)
 option(SLS_USE_RECEIVER "Receiver" ON)

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -26,7 +26,9 @@ This document describes the differences between vx.x.x and vx.0.2
 1 New, Changed or Resolved Features
 =====================================
 
-
+Building shared libraries is disabled by default. If you need to link 
+against any of the libSls*.so libraries, you can enable this by passing
+ -DSLS_BUILD_SHARED_LIBRARIES=ON to CMake.
  
 
 2  On-board Detector Server Compatibility


### PR DESCRIPTION
We don't use the shared libraries (.so) in our code. All binaries link statically (.a). Therefore I think we can disable building the shared libraries by default saving a bit of compile and link time. 