### PR TITLE
Using system libzmq in conda builds

### DIFF
--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build wheels
-        run: pipx run cibuildwheel==2.23.0
+        run: pipx run cibuildwheel==3.2.1
 
       - uses: actions/upload-artifact@v4
         with:

--- a/conda-recipes/python-client/conda_build_config.yaml
+++ b/conda-recipes/python-client/conda_build_config.yaml
@@ -2,6 +2,8 @@ python:
     - 3.11 
     - 3.12
     - 3.13
+    - 3.14
+
 
 c_compiler:
   - gcc                        # [linux]

--- a/conda-recipes/python-client/meta.yaml
+++ b/conda-recipes/python-client/meta.yaml
@@ -9,11 +9,11 @@ package:
 build:
   number: 0
   script:
-    - unset CMAKE_GENERATOR && {{ PYTHON }} -m pip install . -vv  # [not win]
+    - unset CMAKE_GENERATOR && {{ PYTHON }} -m pip install . -vv --config-settings=cmake.define.SLS_USE_SYSTEM_ZMQ=ON # [not win]
 
 requirements:
   build:
-    - python {{python}}
+    - python 
     - {{ compiler('c') }}
     - {{ stdlib("c") }}
     - {{ compiler('cxx') }}
@@ -21,7 +21,7 @@ requirements:
   host:
     - cmake
     - ninja
-    - python {{python}}
+    - python 
     - pip
     - scikit-build-core
     - pybind11 >=2.13.0
@@ -31,7 +31,7 @@ requirements:
     - catch2
 
   run:
-    - python {{python}}
+    - python 
     - numpy
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
 
 [tool.cibuildwheel]
 before-all = "uname -a"
-build = "cp{311,312,313}-manylinux_x86_64"
+build = "cp{311,312,313,314}-manylinux_x86_64"
 
 [tool.scikit-build.build]
 verbose = true


### PR DESCRIPTION
- Using system libzmq by passing --config-settings=cmake.define.SLS_USE_SYSTEM_ZMQ=ON for conda builds
- wheels for pypi still uses the internal libzmq
- added python 3.14 to automatic builds
- bumped cibuildwheel version and therefore also the manylinux image to 2_28