### PR TITLE
clang-tidy [unhandled-self-assignment]

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -29,7 +29,6 @@ Checks:          '*,
                     -llvmlibc-*'
 
 HeaderFilterRegex: \.h
-AnalyzeTemporaryDtors: false
 FormatStyle:     none
 CheckOptions:
   - { key: readability-identifier-naming.NamespaceCase,       value: lower_case }

--- a/slsSupportLib/include/sls/sls_detector_defs.h
+++ b/slsSupportLib/include/sls/sls_detector_defs.h
@@ -804,6 +804,8 @@ typedef struct {
     }
 
     sls_detector_module &operator=(const sls_detector_module &other) {
+        if(this == &other)
+            return *this;
         delete[] dacs;
         delete[] chanregs;
         serialnumber = other.serialnumber;


### PR DESCRIPTION
Handle self assignment in sls_detector_module. 


https://clang.llvm.org/extra/clang-tidy/checks/bugprone/unhandled-self-assignment.html