### PR TITLE
marked unused functions readDataFile/writeDataFile deprecated

### DIFF
--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -37,6 +37,8 @@ Experimental support for building the detector client (including python bindings
 
 ``rx_dbitlist`` keeps the order of the passed bit list 
 
+Marked unused functions readDataFile/writeDataFile deprecated in file_utils.h
+
 2  On-board Detector Server Compatibility
 ==========================================
 

--- a/slsSupportLib/include/sls/file_utils.h
+++ b/slsSupportLib/include/sls/file_utils.h
@@ -16,6 +16,7 @@ namespace sls {
  * @param nch number of channels
  * @param offset start channel value
  */
+[[deprecated]]
 int readDataFile(std::ifstream &infile, short int *data, int nch,
                  int offset = 0);
 
@@ -23,6 +24,7 @@ int readDataFile(std::ifstream &infile, short int *data, int nch,
  * @param data array of data value
  * @param nch number of channels
  */
+[[deprecated]]
 int readDataFile(std::string fname, short int *data, int nch);
 
 std::vector<char> readBinaryFile(const std::string &fname,
@@ -33,6 +35,7 @@ std::vector<char> readBinaryFile(const std::string &fname,
  * @param data array of data values
  * @param offset start channel number
  */
+[[deprecated]]
 int writeDataFile(std::ofstream &outfile, int nch, short int *data,
                   int offset = 0);
 
@@ -40,6 +43,7 @@ int writeDataFile(std::ofstream &outfile, int nch, short int *data,
  * @param nch number of channels
  * @param data array of data values
  */
+[[deprecated]]
 int writeDataFile(std::string fname, int nch, short int *data);
 
 // mkdir -p path implemented by recursive calls


### PR DESCRIPTION
readDataFile and writeDataFile in file_utils.h doesn't seem to be used and I can't think of how external people would use them. 

Marked deprecated for now, but maybe we can remove them?