### PR TITLE
python setBit backwards compatible

### DIFF
--- a/python/slsdet/detector.py
+++ b/python/slsdet/detector.py
@@ -1907,6 +1907,8 @@ class Detector(CppDetectorApi):
                 raise ValueError("bit_position must be provided when passing int address")
             if not isinstance(bit_position, int):
                 raise ValueError("bit_position must be int")
+            if isinstance(bitname_or_addr, int):
+                bitname_or_addr = RegisterAddress(bitname_or_addr)
             return BitAddress(bitname_or_addr, bit_position)
 
         # New usage with str or BitAddress


### PR DESCRIPTION
- BitAddress only takes RegisterAddress and int as constructor arguments, convert integer first to RegisterAddress 