### PR TITLE
send back the result of the SPI write

### DIFF
--- a/python/src/detector.cpp
+++ b/python/src/detector.cpp
@@ -2206,8 +2206,8 @@ void init_det(py::module &m) {
                        py::arg() = Positions{});
     CppDetectorApi.def(
         "writeSpi",
-        (void (Detector::*)(int, int, const std::vector<uint8_t> &,
-                            sls::Positions)) &
+        (Result<std::vector<uint8_t>>(Detector::*)(
+            int, int, const std::vector<uint8_t> &, sls::Positions)) &
             Detector::writeSpi,
         py::arg(), py::arg(), py::arg(), py::arg() = Positions{});
     ;

--- a/slsDetectorServers/slsDetectorServer/src/slsDetectorServer_funcs.c
+++ b/slsDetectorServers/slsDetectorServer/src/slsDetectorServer_funcs.c
@@ -11375,7 +11375,10 @@ int spi_write(int file_des){
 		local_tx[i+1] = data[i];
 
 #ifdef VIRTUAL
-    // For the virtual detector we have nothing to do
+    // For the virtual detector copy the data from local_tx to local_rx
+    for (int i=0; i < n_bytes+1; i++){
+        local_rx[i] = local_tx[i];
+    }
 #else
     int spifd = open("/dev/spidev2.0", O_RDWR);
     LOG(logINFO, ("SPI Read: opened spidev2.0 with fd=%d\n", spifd));
@@ -11397,11 +11400,13 @@ int spi_write(int file_des){
     close(spifd);
 #endif
 
+    ret = OK;
+    LOG(logDEBUG1, ("SPI Write Complete\n"));
+    Server_SendResult(file_des, INT32, NULL, 0);
+    sendData(file_des, local_rx+1, n_bytes, OTHER);
+
     free(data);
     free(local_tx);
     free(local_rx);
-
-    ret = OK;
-    LOG(logDEBUG1, ("SPI Write Complete\n"));
-    return Server_SendResult(file_des, INT32, NULL, 0);
+    return ret;
 }

--- a/slsDetectorSoftware/include/sls/Detector.h
+++ b/slsDetectorSoftware/include/sls/Detector.h
@@ -2250,7 +2250,7 @@ class Detector {
     Result<std::vector<uint8_t>> readSpi(int chip_id, int register_id,
                                         int n_bytes, Positions pos = {}) const;
 
-    void writeSpi(int chip_id, int register_id,
+    Result<std::vector<uint8_t>> writeSpi(int chip_id, int register_id,
                                         const std::vector<uint8_t> &data, Positions pos = {});
 
   private:

--- a/slsDetectorSoftware/src/Detector.cpp
+++ b/slsDetectorSoftware/src/Detector.cpp
@@ -2961,9 +2961,9 @@ Result<std::vector<uint8_t>> Detector::readSpi(int chip_id, int register_id,
                            n_bytes);
 }
 
-void Detector::writeSpi(int chip_id, int register_id,
+Result<std::vector<uint8_t>> Detector::writeSpi(int chip_id, int register_id,
                                         const std::vector<uint8_t> &data, Positions pos){
-    pimpl->Parallel(&Module::writeSpi, pos, chip_id, register_id, data);
+    return pimpl->Parallel(&Module::writeSpi, pos, chip_id, register_id, data);
                                         }
 
 

--- a/slsDetectorSoftware/src/Module.cpp
+++ b/slsDetectorSoftware/src/Module.cpp
@@ -4097,7 +4097,7 @@ std::vector<uint8_t> Module::readSpi(int chip_id, int register_id,
     
 }
 
-void Module::writeSpi(int chip_id, int register_id,
+std::vector<uint8_t> Module::writeSpi(int chip_id, int register_id,
                       const std::vector<uint8_t> &data){
     auto client = DetectorSocket(shm()->hostname, shm()->controlPort);
     client.Send(F_SPI_WRITE);
@@ -4113,6 +4113,11 @@ void Module::writeSpi(int chip_id, int register_id,
            << " returned error: " << client.readErrorMessage();
         throw DetectorError(os.str());
     }
+
+    // Read the output from the SPI write. This contains the data before the write.
+    std::vector<uint8_t> ret(data.size());
+    client.Receive(ret);
+    return ret;
 }
 
 } // namespace sls

--- a/slsDetectorSoftware/src/Module.h
+++ b/slsDetectorSoftware/src/Module.h
@@ -610,7 +610,7 @@ class Module : public virtual slsDetectorDefs {
     std::vector<uint8_t> readSpi(int chip_id, int register_id,
                                                int n_bytes) const;
 
-    void writeSpi(int chip_id, int register_id, const std::vector<uint8_t> &data);
+    std::vector<uint8_t> writeSpi(int chip_id, int register_id, const std::vector<uint8_t> &data);
 
   private:
     std::string getReceiverLongVersion() const;


### PR DESCRIPTION
The result of the SPI write is needed if we want to read the alse registers. It can also be useful for debugging. 