### PR TITLE
Adding offset to RegisterAddress

### DIFF
--- a/python/src/bit.cpp
+++ b/python/src/bit.cpp
@@ -26,7 +26,10 @@ void init_bit(py::module &m) {
         .def("__str__", &RegisterAddress::str)
         .def("value", &RegisterAddress::value)
         .def(py::self == py::self)
-        .def(py::self != py::self);
+        .def(py::self != py::self)
+        .def("__add__",&RegisterAddress::operator+)
+        .def("__radd__",&RegisterAddress::operator+)
+        .def("__iadd__",&RegisterAddress::operator+=, py::return_value_policy::reference_internal);
 
     py::class_<BitAddress>(m, "BitAddress")
         .def(py::init())

--- a/python/tests/test_bits.py
+++ b/python/tests/test_bits.py
@@ -1,4 +1,5 @@
 from slsdet.bits import clearbit, clearbit_arr, setbit, setbit_arr
+from slsdet import RegisterAddress
 import numpy as np
 
 
@@ -48,3 +49,12 @@ def test_clearbit_arr():
     arr = np.array((5, 5, 5), dtype=np.int8)
     clearbit_arr(0, arr)
     assert all(arr == (4, 4, 4))
+
+def test_RegisterAddress_addition():
+    r = RegisterAddress(0x10)
+    r2 = r + 0x5
+    assert r2.value() == 0x15
+    r3 = 0x5 + r
+    assert r3.value() == 0x15
+    r += 0x5
+    assert r.value() == 0x15

--- a/slsDetectorSoftware/tests/test-SharedMemory.cpp
+++ b/slsDetectorSoftware/tests/test-SharedMemory.cpp
@@ -42,9 +42,11 @@ constexpr int shm_id = 10;
 // macOS does not expose shm in the filesystem
 #ifndef __APPLE__
 
+const char *env_p = std::getenv(SHM_ENV_NAME);
+std::string env_name = env_p ? ("_" + std::string(env_p)) : "";
 const std::string file_path =
     std::string("/dev/shm/slsDetectorPackage_detector_") +
-    std::to_string(shm_id);
+    std::to_string(shm_id) + env_name;
 
 TEST_CASE("Free obsolete (without isValid)", "[detector][shm]") {
 

--- a/slsSupportLib/include/sls/bit_utils.h
+++ b/slsSupportLib/include/sls/bit_utils.h
@@ -36,6 +36,15 @@ class RegisterAddress {
     constexpr bool operator!=(const RegisterAddress &other) const {
         return (value_ != other.value_);
     }
+    constexpr RegisterAddress &operator+=(uint32_t offset) noexcept {
+        value_ += offset;
+        return *this;
+    }
+    constexpr RegisterAddress operator+(uint32_t offset) const noexcept {
+        RegisterAddress tmp(*this);
+        tmp += offset;
+        return tmp;
+    }
 };
 
 class BitAddress {
@@ -101,5 +110,10 @@ class RegisterValue {
 std::ostream &operator<<(std::ostream &os, const RegisterAddress &r);
 std::ostream &operator<<(std::ostream &os, const BitAddress &r);
 std::ostream &operator<<(std::ostream &os, const RegisterValue &r);
+
+constexpr RegisterAddress operator+(uint32_t offset,
+                                    const RegisterAddress &addr) noexcept {
+    return addr + offset;
+}
 
 } // namespace sls

--- a/slsSupportLib/tests/test-bit_utils.cpp
+++ b/slsSupportLib/tests/test-bit_utils.cpp
@@ -43,7 +43,7 @@ TEST_CASE("Get set bits from 523") {
     REQUIRE(vec == std::vector<int>{0, 1, 3, 9});
 }
 
-TEST_CASE("Convert RegisterAddress using classes ", "[support][.bit_utils]") {
+TEST_CASE("Convert RegisterAddress using classes ", "[support]") {
     std::vector<uint32_t> vec_addr{0x305, 0xffffffff, 0x0, 0x34550987,
                                    0x1fff1fff};
     std::vector<std::string> vec_ans{"0x305", "0xffffffff", "0x0", "0x34550987",
@@ -64,7 +64,7 @@ TEST_CASE("Convert RegisterAddress using classes ", "[support][.bit_utils]") {
     }
 }
 
-TEST_CASE("Convert RegisterValue using classes ", "[support][.bit_utils]") {
+TEST_CASE("Convert RegisterValue using classes ", "[support]") {
     std::vector<uint32_t> vec_addr{0x305, 0xffffffff, 0x0, 500254562,
                                    0x1fff1fff};
     std::vector<std::string> vec_ans{"0x305", "0xffffffff", "0x0", "0x1dd14762",
@@ -80,11 +80,10 @@ TEST_CASE("Convert RegisterValue using classes ", "[support][.bit_utils]") {
         CHECK(reg0.str() == vec_ans[i]);
         CHECK((reg0 | 0xffffffffu) == RegisterValue(0xffffffffu));
         CHECK((reg0 | 0x0) == reg0);
-        CHECK((reg0 | 0x1) == reg0);
     }
 }
 
-TEST_CASE("Convert BitAddress using classes", "[support][.bit_utils]") {
+TEST_CASE("Convert BitAddress using classes", "[support]") {
     std::vector<RegisterAddress> vec_addr{
         RegisterAddress(0x305), RegisterAddress(0xffffffffu),
         RegisterAddress(0x0), RegisterAddress(0x34550987),
@@ -123,7 +122,7 @@ TEST_CASE("Convert BitAddress using classes", "[support][.bit_utils]") {
 }
 
 TEST_CASE("Output operator gives same result as string",
-          "[support][.bit_utils]") {
+          "[support]") {
     {
         RegisterAddress addr{0x3456af};
         std::ostringstream os;
@@ -148,3 +147,23 @@ TEST_CASE("Output operator gives same result as string",
 }
 
 } // namespace sls
+
+TEST_CASE("RegisterAddress addition with uint", "[support]") {
+    using sls::RegisterAddress;
+
+    RegisterAddress r{0x10u};
+
+    // member operator+
+    auto r_plus = r + 5u;
+    CHECK(r_plus == RegisterAddress(0x15u));
+    // original unchanged
+    CHECK(r == RegisterAddress(0x10u));
+
+    // operator+=
+    r += 2u;
+    CHECK(r == RegisterAddress(0x12u));
+
+    // non-member uint + RegisterAddress
+    auto uint_plus = 3u + r; // 0x12 + 3 == 0x15
+    CHECK(uint_plus == RegisterAddress(0x15u));
+}


### PR DESCRIPTION
1. Added operator + and += to RegisterAddress for uint32_t
2. Added tests
3. Added python bindings and tests
4. Fixed failing tests and removed [.bit_utils] which was preventing them from running

Additional fix for failing shm test when SLSDETNAME was set. 