### PR TITLE
added support for int() for RegisterAddress and RegisterValue

### DIFF
--- a/python/src/bit.cpp
+++ b/python/src/bit.cpp
@@ -25,6 +25,7 @@ void init_bit(py::module &m) {
              })
         .def("__str__", &RegisterAddress::str)
         .def("value", &RegisterAddress::value)
+        .def("__int__", &RegisterAddress::value)
         .def(py::self == py::self)
         .def(py::self != py::self)
         .def("__add__",&RegisterAddress::operator+)
@@ -54,6 +55,7 @@ void init_bit(py::module &m) {
              })
         .def("__str__", &RegisterValue::str)
         .def("value", &RegisterValue::value)
+        .def("__int__", &RegisterValue::value)
         .def(py::self == py::self)
         .def(py::self != py::self)
         .def("__or__", [](const RegisterValue &lhs,


### PR DESCRIPTION
Added support for:

```python
from slsdet import RegisterAddress, RegisterValue
a = RegisterAddress(0x5)
i = int(a)

v = RegisterValue(32)
i = int(v)
```

Uses the .value() conversion