### PR TITLE
Dev/mac receiver

### DIFF
--- a/slsDetectorServers/matterhornServer/src/MatterhornApp.cpp
+++ b/slsDetectorServers/matterhornServer/src/MatterhornApp.cpp
@@ -11,7 +11,15 @@
 #include <unistd.h>
 
 // gettid added in glibc 2.30
-#if __GLIBC__ == 2 && __GLIBC_MINOR__ < 30
+#if defined(__APPLE__)
+#include <cstdint>
+#include <pthread.h>
+static inline uint64_t gettid() {
+    uint64_t tid = 0;
+    pthread_threadid_np(nullptr, &tid);
+    return tid;
+}
+#elif __GLIBC__ == 2 && __GLIBC_MINOR__ < 30
 #include <sys/syscall.h>
 #define gettid() syscall(SYS_gettid)
 #endif

--- a/slsDetectorServers/matterhornServer/src/MatterhornApp.cpp
+++ b/slsDetectorServers/matterhornServer/src/MatterhornApp.cpp
@@ -1,5 +1,6 @@
 #include "CommandLineOptions.h"
 #include "VirtualMatterhornServer.h"
+#include "sls/thread_utils.h"
 #include "sls/logger.h"
 #include "sls/sls_detector_exceptions.h"
 #include "sls/versionAPI.h"
@@ -9,20 +10,6 @@
 #include <signal.h>
 #include <sys/wait.h>
 #include <unistd.h>
-
-// gettid added in glibc 2.30
-#if defined(__APPLE__)
-#include <cstdint>
-#include <pthread.h>
-static inline uint64_t gettid() {
-    uint64_t tid = 0;
-    pthread_threadid_np(nullptr, &tid);
-    return tid;
-}
-#elif __GLIBC__ == 2 && __GLIBC_MINOR__ < 30
-#include <sys/syscall.h>
-#define gettid() syscall(SYS_gettid)
-#endif
 
 using namespace sls;
 
@@ -84,7 +71,7 @@ int main(int argc, char *argv[]) {
                                      // also return EXIT_FAILURE
         }
         LOG(TLogLevel::logINFOBLUE)
-            << "Exiting Stop Server [ Tid: " << gettid() << " ]";
+            << "Exiting Stop Server [ Tid: " << getThreadId() << " ]";
         LOG(sls::logINFO) << "Exiting Stop Server";
     } else if (pid > 0) {
         // parent
@@ -101,7 +88,7 @@ int main(int argc, char *argv[]) {
             }
         } catch (...) {
             LOG(sls::logINFOBLUE)
-                << "Exiting Control Server [ Tid: " << gettid() << " ]";
+                << "Exiting Control Server [ Tid: " << getThreadId() << " ]";
             LOG(sls::logINFO) << "Exiting Detector Server";
             kill(pid, SIGINT);        // tell child to exit
             waitpid(pid, nullptr, 0); // wait for child to exit
@@ -109,7 +96,8 @@ int main(int argc, char *argv[]) {
         }
         waitpid(pid, nullptr, 0); // wait for child to exit
         LOG(sls::logINFOBLUE)
-            << "Exiting Detector Control Server [ Tid: " << gettid() << " ]";
+            << "Exiting Detector Control Server [ Tid: " << getThreadId()
+            << " ]";
         LOG(sls::logINFO) << "Exiting Detector Server";
     } else {
         LOG(sls::logERROR)

--- a/slsDetectorServers/slsDetectorServer/src/ASIC_Driver.c
+++ b/slsDetectorServers/slsDetectorServer/src/ASIC_Driver.c
@@ -11,8 +11,10 @@
 #include <stdlib.h>
 
 #include <fcntl.h>
+#ifndef __APPLE__
 #include <linux/spi/spidev.h>
 #include <linux/types.h>
+#endif
 #include <string.h>
 #include <sys/ioctl.h>
 #include <unistd.h>

--- a/slsDetectorServers/slsDetectorServer/src/common.c
+++ b/slsDetectorServers/slsDetectorServer/src/common.c
@@ -11,6 +11,12 @@
 #include <sys/stat.h>    // stat
 #include <sys/utsname.h> // uname
 #include <unistd.h>      // readlink
+#ifdef __APPLE__
+#include <limits.h>      // PATH_MAX
+#include <mach-o/dyld.h> // _NSGetExecutablePath
+#include <stdint.h>      // uint32_t
+#include <stdlib.h>      // realpath
+#endif
 
 extern int executeCommand(char *command, char *result, enum TLogLevel level);
 
@@ -58,12 +64,33 @@ int getAbsPath(char *buf, size_t bufSize, char *fname) {
     // get path of current binary
     char path[bufSize];
     memset(path, 0, bufSize);
+#ifdef __APPLE__
+    // macOS has no /proc; use _NSGetExecutablePath and canonicalize with
+    // realpath (the path returned may contain ".." or symlinks).
+    char raw[PATH_MAX];
+    uint32_t rawSize = sizeof(raw);
+    if (_NSGetExecutablePath(raw, &rawSize) != 0) {
+        LOG(logWARNING,
+            ("Could not get current binary path for %s (buffer too small)\n",
+             fname));
+        return FAIL;
+    }
+    char resolved[PATH_MAX];
+    const char *src = realpath(raw, resolved) != NULL ? resolved : raw;
+    if (strlen(src) >= bufSize) {
+        LOG(logWARNING,
+            ("Current binary path too long for buffer (%s)\n", fname));
+        return FAIL;
+    }
+    strcpy(path, src);
+#else
     ssize_t len = readlink("/proc/self/exe", path, bufSize - 1);
     if (len < 0) {
         LOG(logWARNING, ("Could not readlink current binary for %s\n", fname));
         return FAIL;
     }
     path[len] = '\0';
+#endif
 
     // get dir path and attach file name
     char *dir = dirname(path);

--- a/slsDetectorServers/slsDetectorServer/src/programViaBlackfin.c
+++ b/slsDetectorServers/slsDetectorServer/src/programViaBlackfin.c
@@ -8,7 +8,9 @@
 
 #include <string.h>
 #include <sys/stat.h>
+#ifndef __APPLE__
 #include <sys/sysinfo.h>
+#endif
 #include <unistd.h> // usleep
 
 /* global variables */
@@ -309,6 +311,7 @@ int preparetoCopyProgram(char *mess, char *functionType, FILE **fd,
     }
 
     // check available memory to copy program
+#ifndef __APPLE__
     {
         struct sysinfo info;
         sysinfo(&info);
@@ -322,6 +325,7 @@ int preparetoCopyProgram(char *mess, char *functionType, FILE **fd,
             return FAIL;
         }
     }
+#endif
 
     // open file to copy program
     *fd = fopen(TEMP_PROG_FILE_NAME, "w");

--- a/slsDetectorServers/slsDetectorServer/src/slsDetectorServer_funcs.c
+++ b/slsDetectorServers/slsDetectorServer/src/slsDetectorServer_funcs.c
@@ -20,10 +20,24 @@
 #include <arpa/inet.h>
 #include <pthread.h>
 #include <string.h>
+#ifndef __APPLE__
 #include <sys/sysinfo.h>
+#endif
 #include <unistd.h>
 
+#ifdef __APPLE__
+// spidev is Linux-only; provide a minimal stub so virtual builds compile.
+// The real ioctl(SPI_IOC_MESSAGE(...)) calls are guarded by detector
+// macros (XILINX_CHIPTESTBOARDD) that are never set on macOS.
+struct spi_ioc_transfer {
+    unsigned long tx_buf;
+    unsigned long rx_buf;
+    unsigned int len;
+    unsigned char cs_change;
+};
+#else
 #include <linux/spi/spidev.h>
+#endif
 
 // defined in the detector specific Makefile
 #ifdef EIGERD
@@ -127,6 +141,10 @@ int sendError(int file_des) {
 }
 
 void setMemoryAllocationErrorMessage() {
+#ifdef __APPLE__
+    sprintf(mess, "Memory allocation error (%s). Please reboot",
+            getFunctionNameFromEnum((enum detFuncs)fnum));
+#else
     struct sysinfo info;
     sysinfo(&info);
     sprintf(
@@ -134,6 +152,7 @@ void setMemoryAllocationErrorMessage() {
         "Memory allocation error (%s). Available space: %d MB. Please reboot",
         getFunctionNameFromEnum((enum detFuncs)fnum),
         (int)(info.freeram / (1024 * 1024)));
+#endif
 #ifdef EIGERD
     strcat(mess, ".\n");
 #else
@@ -9784,12 +9803,17 @@ void receive_program_default(int file_des, enum PROGRAM_INDEX index,
     if (ret == OK) {
         src = malloc(filesize);
         if (src == NULL) {
+#ifdef __APPLE__
+            sprintf(mess, "Could not %s. Memory allocation failure.\n",
+                    functionType);
+#else
             struct sysinfo info;
             sysinfo(&info);
             sprintf(mess,
                     "Could not %s. Memory allocation failure. Free "
                     "space: %d MB\n",
                     functionType, (int)(info.freeram / (1024 * 1024)));
+#endif
             LOG(logERROR, (mess));
             ret = FAIL;
         }

--- a/slsReceiverSoftware/include/sls/CircularFifo.h
+++ b/slsReceiverSoftware/include/sls/CircularFifo.h
@@ -9,8 +9,10 @@
  * modified by the sls detector group
  * */
 
-#include <iostream>
-#include <semaphore.h>
+#include "sls/thread_utils.h"
+
+#include <atomic>
+#include <cstddef>
 #include <vector>
 
 namespace sls {
@@ -23,23 +25,21 @@ template <typename Element> class CircularFifo {
     size_t head{0};
     size_t capacity;
     std::vector<Element *> data;
-    mutable sem_t data_mutex;
-    mutable sem_t free_mutex;
-    size_t increment(size_t i) const;
+    counting_semaphore data_sem; // # of items available to read
+    counting_semaphore free_sem; // # of slots available to write
+    std::atomic<int> count_{0};  // current number of items, for diagnostics
+
+    size_t increment(size_t i) const { return (i + 1) % capacity; }
 
   public:
-    explicit CircularFifo(size_t size) : capacity(size + 1), data(capacity) {
-        sem_init(&data_mutex, 0, 0);
-        sem_init(&free_mutex, 0, size);
-    }
+    explicit CircularFifo(size_t size)
+        : capacity(size + 1), data(capacity), data_sem(0),
+          free_sem(static_cast<int>(size)) {}
 
     CircularFifo(const CircularFifo &) = delete;
     CircularFifo(CircularFifo &&) = delete;
 
-    virtual ~CircularFifo() {
-        sem_destroy(&data_mutex);
-        sem_destroy(&free_mutex);
-    }
+    virtual ~CircularFifo() = default;
 
     bool push(Element *&item, bool no_block = false);
     bool pop(Element *&item, bool no_block = false);
@@ -52,15 +52,11 @@ template <typename Element> class CircularFifo {
 };
 
 template <typename Element> int CircularFifo<Element>::getDataValue() const {
-    int value;
-    sem_getvalue(&data_mutex, &value);
-    return value;
+    return count_.load(std::memory_order_relaxed);
 }
 
 template <typename Element> int CircularFifo<Element>::getFreeValue() const {
-    int value;
-    sem_getvalue(&free_mutex, &value);
-    return value;
+    return static_cast<int>(capacity - 1) - getDataValue();
 }
 
 /** Producer only: Adds item to the circular queue.
@@ -72,14 +68,16 @@ template <typename Element> int CircularFifo<Element>::getFreeValue() const {
  * \return whether operation was successful or not */
 template <typename Element>
 bool CircularFifo<Element>::push(Element *&item, bool no_block) {
-    // check for fifo full
-    if (no_block && isFull())
-        return false;
-
-    sem_wait(&free_mutex);
+    if (no_block) {
+        if (!free_sem.try_acquire())
+            return false;
+    } else {
+        free_sem.acquire();
+    }
     data[tail] = item;
     tail = increment(tail);
-    sem_post(&data_mutex);
+    count_.fetch_add(1, std::memory_order_relaxed);
+    data_sem.release();
     return true;
 }
 
@@ -92,14 +90,16 @@ bool CircularFifo<Element>::push(Element *&item, bool no_block) {
  * \return whether operation was successful or not */
 template <typename Element>
 bool CircularFifo<Element>::pop(Element *&item, bool no_block) {
-    // check for fifo empty
-    if (no_block && isEmpty())
-        return false;
-
-    sem_wait(&data_mutex);
+    if (no_block) {
+        if (!data_sem.try_acquire())
+            return false;
+    } else {
+        data_sem.acquire();
+    }
     item = data[head];
     head = increment(head);
-    sem_post(&free_mutex);
+    count_.fetch_sub(1, std::memory_order_relaxed);
+    free_sem.release();
     return true;
 }
 
@@ -109,7 +109,7 @@ bool CircularFifo<Element>::pop(Element *&item, bool no_block) {
  *
  * \return true if circular buffer is empty */
 template <typename Element> bool CircularFifo<Element>::isEmpty() const {
-    return (getDataValue() == 0);
+    return getDataValue() == 0;
 }
 
 /** Useful for testing and Producer check of status
@@ -118,18 +118,7 @@ template <typename Element> bool CircularFifo<Element>::isEmpty() const {
  *
  * \return true if circular buffer is full.  */
 template <typename Element> bool CircularFifo<Element>::isFull() const {
-    return (getFreeValue() == 0);
-}
-
-/** Increment helper function for index of the circular queue
- * index is incremented or wrapped
- *
- *  \param i the index to the incremented/wrapped
- *  \return new value for the index */
-template <typename Element>
-size_t CircularFifo<Element>::increment(size_t i) const {
-    i = (i + 1) % capacity;
-    return i;
+    return getFreeValue() == 0;
 }
 
 } // namespace sls

--- a/slsReceiverSoftware/src/Arping.cpp
+++ b/slsReceiverSoftware/src/Arping.cpp
@@ -2,6 +2,7 @@
 // Copyright (C) 2021 Contributors to the SLS Detector Package
 
 #include "Arping.h"
+#include "sls/thread_utils.h"
 
 #include <chrono>
 #include <signal.h>
@@ -10,12 +11,6 @@
 #include <unistd.h>
 
 namespace sls {
-
-// gettid added in glibc 2.30
-#if __GLIBC__ == 2 && __GLIBC_MINOR__ < 30
-#include <sys/syscall.h>
-#define gettid() syscall(SYS_gettid)
-#endif
 
 void func(int signum) { wait(NULL); }
 
@@ -59,7 +54,7 @@ void Arping::StartProcess() {
     childPid = fork();
     // child process
     if (childPid == 0) {
-        LOG(logINFOBLUE) << "Created [ Arping Process, Tid: " << gettid()
+        LOG(logINFOBLUE) << "Created [ Arping Process, Tid: " << getThreadId()
                          << " ]";
         ProcessExecution();
     }

--- a/slsReceiverSoftware/src/ClientInterface.cpp
+++ b/slsReceiverSoftware/src/ClientInterface.cpp
@@ -3,6 +3,7 @@
 #include "ClientInterface.h"
 #include "sls/ServerSocket.h"
 #include "sls/StaticVector.h"
+#include "sls/thread_utils.h"
 #include "sls/ToString.h"
 
 #include "sls/sls_detector_exceptions.h"
@@ -27,12 +28,6 @@ namespace sls {
 using ns = std::chrono::nanoseconds;
 using Interface = ServerInterface;
 
-// gettid added in glibc 2.30
-#if __GLIBC__ == 2 && __GLIBC_MINOR__ < 30
-#include <sys/syscall.h>
-#define gettid() syscall(SYS_gettid)
-#endif
-
 std::mutex ClientInterface::callbackMutex;
 
 ClientInterface::~ClientInterface() {
@@ -47,7 +42,7 @@ ClientInterface::ClientInterface(uint16_t portNumber)
     : detType(GENERIC), portNumber(portNumber), server(portNumber) {
     validatePortNumber(portNumber);
     functionTable();
-    parentThreadId = gettid();
+    parentThreadId = getThreadId();
     tcpThread =
         make_unique<std::thread>(&ClientInterface::startTCPServer, this);
 }
@@ -79,7 +74,7 @@ void ClientInterface::registerCallBackRawDataReady(
 }
 
 void ClientInterface::startTCPServer() {
-    tcpThreadId = gettid();
+    tcpThreadId = getThreadId();
     LOG(logINFOBLUE) << "Created [ TCP server Tid: " << tcpThreadId << "]";
     LOG(logINFO) << "SLS Receiver starting TCP Server on port " << portNumber
                  << '\n';

--- a/slsReceiverSoftware/src/FrameSynchronizerApp.cpp
+++ b/slsReceiverSoftware/src/FrameSynchronizerApp.cpp
@@ -7,6 +7,7 @@
  */
 #include "CommandLineOptions.h"
 #include "sls/Receiver.h"
+#include "sls/thread_utils.h"
 #include "sls/ToString.h"
 #include "sls/container_utils.h"
 #include "sls/logger.h"
@@ -30,12 +31,6 @@
 
 std::vector<std::thread> threads;
 sls::TLogLevel printHeadersLevel = sls::logDEBUG;
-
-// gettid added in glibc 2.30
-#if __GLIBC__ == 2 && __GLIBC_MINOR__ < 30
-#include <sys/syscall.h>
-#define gettid() syscall(SYS_gettid)
-#endif
 
 /** Define Colors to print data call back in different colors for different
  * recievers */
@@ -522,7 +517,8 @@ int main(int argc, char *argv[]) {
         return EXIT_SUCCESS;
     }
 
-    LOG(sls::logINFOBLUE) << "Current Process [ Tid: " << gettid() << ']';
+    LOG(sls::logINFOBLUE) << "Current Process [ Tid: " << sls::getThreadId()
+                          << ']';
 
     // close files on ctrl+c
     sls::setupSignalHandler(SIGINT, sigInterruptHandler);
@@ -548,8 +544,8 @@ int main(int argc, char *argv[]) {
         sem_t *semaphore = &semaphores[i];
         threads.emplace_back(
             [i, semaphore, port, user_data, &threadException]() {
-                LOG(sls::logINFOBLUE)
-                    << "Thread " << i << " [ Tid: " << gettid() << ']';
+                LOG(sls::logINFOBLUE) << "Thread " << i << " [ Tid: "
+                                      << sls::getThreadId() << ']';
                 try {
                     sls::Receiver receiver(port);
                     receiver.registerCallBackStartAcquisition(
@@ -567,8 +563,8 @@ int main(int argc, char *argv[]) {
                     threadException = std::current_exception();
                     raise(SIGINT);
                 }
-                LOG(sls::logINFOBLUE)
-                    << "Exiting Thread " << i << " [ Tid: " << gettid() << " ]";
+                LOG(sls::logINFOBLUE) << "Exiting Thread " << i << " [ Tid: "
+                                      << sls::getThreadId() << " ]";
             });
     }
 

--- a/slsReceiverSoftware/src/MultiReceiverApp.cpp
+++ b/slsReceiverSoftware/src/MultiReceiverApp.cpp
@@ -13,7 +13,7 @@
 
 #include <csignal> //SIGINT
 #include <cstring>
-#include <semaphore.h>
+#include <pthread.h>
 #include <sys/wait.h> //wait
 #include <unistd.h>
 
@@ -125,18 +125,6 @@ void GetData(slsDetectorDefs::sls_receiver_header &header,
     // imageSize = 26000;
 }
 
-sem_t semaphore;
-
-/**
- * Control+C Interrupt Handler
- * to let all the processes know to exit properly
- * All child processes will call the handler (parent process set to ignore)
- */
-void sigInterruptHandler(int signal) {
-    (void)signal; // suppress unused warning if needed
-    sem_post(&semaphore);
-}
-
 int main(int argc, char *argv[]) {
 
     CommandLineOptions cli(AppType::MultiReceiver);
@@ -154,12 +142,19 @@ int main(int argc, char *argv[]) {
     LOG(sls::logINFOBLUE) << "Current Process [ Tid: " << sls::getThreadId()
                           << ']';
 
-    // close files on ctrl+c
-    sls::setupSignalHandler(SIGINT, sigInterruptHandler);
+    // Block SIGINT before fork() so every child inherits the block. Each
+    // child waits for SIGINT synchronously via sigwait() instead of using a
+    // signal handler that posts to a semaphore. This avoids relying on
+    // sem_init() on unnamed semaphores, which is unimplemented on macOS.
+    sigset_t sigset;
+    sigemptyset(&sigset);
+    sigaddset(&sigset, SIGINT);
+    if (pthread_sigmask(SIG_BLOCK, &sigset, nullptr) != 0) {
+        LOG(sls::logERROR) << "Could not block SIGINT";
+        return EXIT_FAILURE;
+    }
     // handle locally on socket crash
     sls::setupSignalHandler(SIGPIPE, SIG_IGN);
-
-    sem_init(&semaphore, 1, 0);
 
     /** - loop over receivers */
     for (int i = 0; i < m.numReceivers; ++i) {
@@ -207,14 +202,15 @@ int main(int argc, char *argv[]) {
                 }
 
                 /**	- as long as no Ctrl+C */
-                // each child process gets a copy of the semaphore
-                sem_wait(&semaphore);
-                sem_destroy(&semaphore);
+                // SIGINT is blocked in this child (inherited from parent);
+                // sigwait atomically waits for it without competing with any
+                // signal handler.
+                int sig = 0;
+                sigwait(&sigset, &sig);
                 LOG(sls::logINFOBLUE) << "Exiting Child Process [ Tid: "
                                       << sls::getThreadId() << ']';
                 exit(EXIT_SUCCESS);
             } catch (...) {
-                sem_destroy(&semaphore);
                 LOG(sls::logINFOBLUE) << "Exiting Child Process [ Tid: "
                                       << sls::getThreadId() << " ]";
                 exit(EXIT_FAILURE);
@@ -222,9 +218,9 @@ int main(int argc, char *argv[]) {
         }
     }
 
-    /** - Parent process ignores SIGINT and waits for all the child processes to
-     * handle the signal */
-    sls::setupSignalHandler(SIGINT, SIG_IGN);
+    /** - Parent process keeps SIGINT blocked (set above before fork) so it is
+     * never delivered here while waitpid() runs. Each child handles SIGINT
+     * via sigwait(). */
 
     /** - Print Ready and Instructions how to exit */
     std::cout << "Ready ... \n";

--- a/slsReceiverSoftware/src/MultiReceiverApp.cpp
+++ b/slsReceiverSoftware/src/MultiReceiverApp.cpp
@@ -4,6 +4,7 @@
  * binary */
 #include "CommandLineOptions.h"
 #include "sls/Receiver.h"
+#include "sls/thread_utils.h"
 #include "sls/ToString.h"
 #include "sls/container_utils.h"
 #include "sls/logger.h"
@@ -15,12 +16,6 @@
 #include <semaphore.h>
 #include <sys/wait.h> //wait
 #include <unistd.h>
-
-// gettid added in glibc 2.30
-#if __GLIBC__ == 2 && __GLIBC_MINOR__ < 30
-#include <sys/syscall.h>
-#define gettid() syscall(SYS_gettid)
-#endif
 
 /** Define Colors to print data call back in different colors for different
  * recievers */
@@ -156,7 +151,8 @@ int main(int argc, char *argv[]) {
         return EXIT_SUCCESS;
     }
 
-    LOG(sls::logINFOBLUE) << "Current Process [ Tid: " << gettid() << ']';
+    LOG(sls::logINFOBLUE) << "Current Process [ Tid: " << sls::getThreadId()
+                          << ']';
 
     // close files on ctrl+c
     sls::setupSignalHandler(SIGINT, sigInterruptHandler);
@@ -182,7 +178,8 @@ int main(int argc, char *argv[]) {
         /**	- if child process */
         else if (pid == 0) {
             LOG(sls::logINFOBLUE)
-                << "Child process " << i << " [ Tid: " << gettid() << ']';
+                << "Child process " << i << " [ Tid: " << sls::getThreadId()
+                << ']';
 
             try {
                 uint16_t port = m.port + i;
@@ -213,13 +210,13 @@ int main(int argc, char *argv[]) {
                 // each child process gets a copy of the semaphore
                 sem_wait(&semaphore);
                 sem_destroy(&semaphore);
-                LOG(sls::logINFOBLUE)
-                    << "Exiting Child Process [ Tid: " << gettid() << ']';
+                LOG(sls::logINFOBLUE) << "Exiting Child Process [ Tid: "
+                                      << sls::getThreadId() << ']';
                 exit(EXIT_SUCCESS);
             } catch (...) {
                 sem_destroy(&semaphore);
-                LOG(sls::logINFOBLUE)
-                    << "Exiting Child Process [ Tid: " << gettid() << " ]";
+                LOG(sls::logINFOBLUE) << "Exiting Child Process [ Tid: "
+                                      << sls::getThreadId() << " ]";
                 exit(EXIT_FAILURE);
             }
         }

--- a/slsReceiverSoftware/src/Receiver.cpp
+++ b/slsReceiverSoftware/src/Receiver.cpp
@@ -19,12 +19,6 @@
 
 namespace sls {
 
-// gettid added in glibc 2.30
-#if __GLIBC__ == 2 && __GLIBC_MINOR__ < 30
-#include <sys/syscall.h>
-#define gettid() syscall(SYS_gettid)
-#endif
-
 Receiver::~Receiver() = default;
 
 Receiver::Receiver(uint16_t port) {

--- a/slsReceiverSoftware/src/ReceiverApp.cpp
+++ b/slsReceiverSoftware/src/ReceiverApp.cpp
@@ -11,19 +11,8 @@
 #include "sls/sls_detector_defs.h"
 
 #include <csignal> //SIGINT
-#include <semaphore.h>
+#include <pthread.h>
 #include <unistd.h>
-
-sem_t semaphore;
-
-/**
- * Control+C Interrupt Handler
- * to let all the other process know to exit properly
- */
-void sigInterruptHandler(int signal) {
-    (void)signal; // suppress unused warning if needed
-    sem_post(&semaphore);
-}
 
 int main(int argc, char *argv[]) {
 
@@ -42,20 +31,28 @@ int main(int argc, char *argv[]) {
     LOG(sls::logINFOBLUE) << "Current Process [ Tid: " << sls::getThreadId()
                           << " ]";
 
-    // close files on ctrl+c
-    sls::setupSignalHandler(SIGINT, sigInterruptHandler);
+    // Block SIGINT on this thread before any other thread is created so that
+    // every thread spawned by Receiver inherits the block. We wait for the
+    // signal synchronously with sigwait() further down. This avoids needing a
+    // signal handler that posts to a semaphore, which is not portable to
+    // macOS (sem_init on unnamed semaphores is unimplemented there).
+    sigset_t sigset;
+    sigemptyset(&sigset);
+    sigaddset(&sigset, SIGINT);
+    if (pthread_sigmask(SIG_BLOCK, &sigset, nullptr) != 0) {
+        LOG(sls::logERROR) << "Could not block SIGINT";
+        return EXIT_FAILURE;
+    }
+
     // handle locally on socket crash
     sls::setupSignalHandler(SIGPIPE, SIG_IGN);
-
-    sem_init(&semaphore, 1, 0);
 
     try {
         sls::Receiver r(o.port);
         LOG(sls::logINFO) << "[ Press \'Ctrl+c\' to exit ]";
-        sem_wait(&semaphore);
-        sem_destroy(&semaphore);
+        int sig = 0;
+        sigwait(&sigset, &sig);
     } catch (...) {
-        sem_destroy(&semaphore);
         LOG(sls::logINFOBLUE)
             << "Exiting [ Tid: " << sls::getThreadId() << " ]";
         throw;

--- a/slsReceiverSoftware/src/ReceiverApp.cpp
+++ b/slsReceiverSoftware/src/ReceiverApp.cpp
@@ -3,6 +3,7 @@
 /* slsReceiver */
 #include "CommandLineOptions.h"
 #include "sls/Receiver.h"
+#include "sls/thread_utils.h"
 #include "sls/ToString.h"
 #include "sls/container_utils.h"
 #include "sls/logger.h"
@@ -12,12 +13,6 @@
 #include <csignal> //SIGINT
 #include <semaphore.h>
 #include <unistd.h>
-
-// gettid added in glibc 2.30
-#if __GLIBC__ == 2 && __GLIBC_MINOR__ < 30
-#include <sys/syscall.h>
-#define gettid() syscall(SYS_gettid)
-#endif
 
 sem_t semaphore;
 
@@ -44,7 +39,8 @@ int main(int argc, char *argv[]) {
         return EXIT_SUCCESS;
     }
 
-    LOG(sls::logINFOBLUE) << "Current Process [ Tid: " << gettid() << " ]";
+    LOG(sls::logINFOBLUE) << "Current Process [ Tid: " << sls::getThreadId()
+                          << " ]";
 
     // close files on ctrl+c
     sls::setupSignalHandler(SIGINT, sigInterruptHandler);
@@ -60,10 +56,11 @@ int main(int argc, char *argv[]) {
         sem_destroy(&semaphore);
     } catch (...) {
         sem_destroy(&semaphore);
-        LOG(sls::logINFOBLUE) << "Exiting [ Tid: " << gettid() << " ]";
+        LOG(sls::logINFOBLUE)
+            << "Exiting [ Tid: " << sls::getThreadId() << " ]";
         throw;
     }
-    LOG(sls::logINFOBLUE) << "Exiting [ Tid: " << gettid() << " ]";
+    LOG(sls::logINFOBLUE) << "Exiting [ Tid: " << sls::getThreadId() << " ]";
     LOG(sls::logINFO) << "Exiting Receiver";
     return EXIT_SUCCESS;
 }

--- a/slsReceiverSoftware/src/ThreadObject.cpp
+++ b/slsReceiverSoftware/src/ThreadObject.cpp
@@ -6,17 +6,12 @@
  ***********************************************/
 
 #include "ThreadObject.h"
+#include "sls/thread_utils.h"
 #include "sls/container_utils.h"
 #include <iostream>
 #include <unistd.h>
 
 namespace sls {
-
-// gettid added in glibc 2.30
-#if __GLIBC__ == 2 && __GLIBC_MINOR__ < 30
-#include <sys/syscall.h>
-#define gettid() syscall(SYS_gettid)
-#endif
 
 ThreadObject::ThreadObject(int index, std::string type)
     : index(index), type(type) {
@@ -46,7 +41,7 @@ void ThreadObject::StartRunning() { runningFlag = true; }
 void ThreadObject::StopRunning() { runningFlag = false; }
 
 void ThreadObject::RunningThread() {
-    threadId = gettid();
+    threadId = getThreadId();
     LOG(logINFOBLUE) << "Created [ " << type << "Thread " << index
                      << ", Tid: " << threadId << "]";
     while (!killThread) {

--- a/slsReceiverSoftware/src/ThreadObject.cpp
+++ b/slsReceiverSoftware/src/ThreadObject.cpp
@@ -16,7 +16,6 @@ namespace sls {
 ThreadObject::ThreadObject(int index, std::string type)
     : index(index), type(type) {
     LOG(logDEBUG) << type << " thread created: " << index;
-    sem_init(&semaphore, 1, 0);
     try {
         threadObject = std::thread(&ThreadObject::RunningThread, this);
     } catch (...) {
@@ -27,9 +26,8 @@ ThreadObject::ThreadObject(int index, std::string type)
 
 ThreadObject::~ThreadObject() {
     killThread = true;
-    sem_post(&semaphore);
+    semaphore.release();
     threadObject.join();
-    sem_destroy(&semaphore);
 }
 
 pid_t ThreadObject::GetThreadId() const { return threadId; }
@@ -49,14 +47,14 @@ void ThreadObject::RunningThread() {
             ThreadExecution();
         }
         // wait till the next acquisition
-        sem_wait(&semaphore);
+        semaphore.acquire();
     }
     LOG(logINFOBLUE) << "Exiting [ " << type << " Thread " << index
                      << ", Tid: " << threadId << "]";
     threadId = 0;
 }
 
-void ThreadObject::Continue() { sem_post(&semaphore); }
+void ThreadObject::Continue() { semaphore.release(); }
 
 void ThreadObject::SetThreadPriority(int priority) {
     struct sched_param param;

--- a/slsReceiverSoftware/src/ThreadObject.h
+++ b/slsReceiverSoftware/src/ThreadObject.h
@@ -11,9 +11,9 @@
 
 #include "sls/logger.h"
 #include "sls/sls_detector_defs.h"
+#include "sls/thread_utils.h"
 
 #include <atomic>
-#include <semaphore.h>
 #include <string>
 #include <thread>
 
@@ -45,7 +45,7 @@ class ThreadObject : private virtual slsDetectorDefs {
     std::atomic<bool> killThread{false};
     std::atomic<bool> runningFlag{false};
     std::thread threadObject;
-    sem_t semaphore;
+    binary_semaphore semaphore{0};
     const std::string type;
     std::atomic<pid_t> threadId{0};
 };

--- a/slsSupportLib/include/sls/thread_utils.h
+++ b/slsSupportLib/include/sls/thread_utils.h
@@ -49,18 +49,19 @@ inline pid_t getThreadId() noexcept {
 }
 
 /**
- * Minimal C++17 backport of the subset of std::binary_semaphore used in this
- * project. API matches std::binary_semaphore so call sites can switch to
- * <semaphore> verbatim once the project moves to C++20. Built on
- * std::mutex + std::condition_variable; therefore NOT async-signal-safe, do
- * not call release() from a signal handler.
+ * Minimal C++17 backport of the subset of std::counting_semaphore /
+ * std::binary_semaphore used in this project. API matches the C++20 std types
+ * (acquire / try_acquire / release with optional update count) so call sites
+ * can switch to <semaphore> verbatim once the project moves to C++20. Built
+ * on std::mutex + std::condition_variable; therefore NOT async-signal-safe,
+ * do not call release() from a signal handler.
  */
-class binary_semaphore {
+class counting_semaphore {
   public:
-    explicit binary_semaphore(int desired) : count_(desired) {}
+    explicit counting_semaphore(int desired) : count_(desired) {}
 
-    binary_semaphore(const binary_semaphore &) = delete;
-    binary_semaphore &operator=(const binary_semaphore &) = delete;
+    counting_semaphore(const counting_semaphore &) = delete;
+    counting_semaphore &operator=(const counting_semaphore &) = delete;
 
     void acquire() {
         std::unique_lock<std::mutex> lk(mtx_);
@@ -68,12 +69,23 @@ class binary_semaphore {
         --count_;
     }
 
-    void release() {
+    bool try_acquire() noexcept {
+        std::lock_guard<std::mutex> lk(mtx_);
+        if (count_ == 0)
+            return false;
+        --count_;
+        return true;
+    }
+
+    void release(int update = 1) {
         {
             std::lock_guard<std::mutex> lk(mtx_);
-            ++count_;
+            count_ += update;
         }
-        cv_.notify_one();
+        if (update == 1)
+            cv_.notify_one();
+        else
+            cv_.notify_all();
     }
 
   private:
@@ -81,5 +93,7 @@ class binary_semaphore {
     std::condition_variable cv_;
     int count_;
 };
+
+using binary_semaphore = counting_semaphore;
 
 } // namespace sls

--- a/slsSupportLib/include/sls/thread_utils.h
+++ b/slsSupportLib/include/sls/thread_utils.h
@@ -18,6 +18,8 @@
  * within a single process.
  */
 
+#include <condition_variable>
+#include <mutex>
 #include <sys/types.h> // pid_t
 
 #if defined(__APPLE__)
@@ -45,5 +47,39 @@ inline pid_t getThreadId() noexcept {
     return static_cast<pid_t>(::syscall(SYS_gettid));
 #endif
 }
+
+/**
+ * Minimal C++17 backport of the subset of std::binary_semaphore used in this
+ * project. API matches std::binary_semaphore so call sites can switch to
+ * <semaphore> verbatim once the project moves to C++20. Built on
+ * std::mutex + std::condition_variable; therefore NOT async-signal-safe, do
+ * not call release() from a signal handler.
+ */
+class binary_semaphore {
+  public:
+    explicit binary_semaphore(int desired) : count_(desired) {}
+
+    binary_semaphore(const binary_semaphore &) = delete;
+    binary_semaphore &operator=(const binary_semaphore &) = delete;
+
+    void acquire() {
+        std::unique_lock<std::mutex> lk(mtx_);
+        cv_.wait(lk, [this] { return count_ > 0; });
+        --count_;
+    }
+
+    void release() {
+        {
+            std::lock_guard<std::mutex> lk(mtx_);
+            ++count_;
+        }
+        cv_.notify_one();
+    }
+
+  private:
+    std::mutex mtx_;
+    std::condition_variable cv_;
+    int count_;
+};
 
 } // namespace sls

--- a/slsSupportLib/include/sls/thread_utils.h
+++ b/slsSupportLib/include/sls/thread_utils.h
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: LGPL-3.0-or-other
+// Copyright (C) 2021 Contributors to the SLS Detector Package
+#pragma once
+
+/**
+ * @file thread_utils.h
+ * @short Portable per-thread identifier for diagnostics/logging.
+ *
+ * Returns a unique-within-process thread id of the calling thread:
+ *   - Linux, glibc >= 2.30: the system gettid() (pid_t).
+ *   - Linux, glibc <  2.30: syscall(SYS_gettid) (long, cast to pid_t).
+ *   - macOS:                pthread_threadid_np() (uint64_t, truncated to pid_t).
+ *
+ * The macOS kernel thread id is 64-bit. To stay drop-in compatible with the
+ * existing call sites that store the result in pid_t (e.g. ThreadObject::
+ * threadId, ClientInterface::parentThreadId / tcpThreadId), we truncate to
+ * pid_t. The value is used for diagnostics only and is still unique enough
+ * within a single process.
+ */
+
+#include <sys/types.h> // pid_t
+
+#if defined(__APPLE__)
+#include <cstdint>
+#include <pthread.h>
+#elif defined(__linux__)
+#include <unistd.h>
+#if !defined(__GLIBC__) ||                                                     \
+    !(__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 30))
+#include <sys/syscall.h>
+#endif
+#endif
+
+namespace sls {
+
+inline pid_t getThreadId() noexcept {
+#if defined(__APPLE__)
+    std::uint64_t tid = 0;
+    pthread_threadid_np(nullptr, &tid);
+    return static_cast<pid_t>(tid);
+#elif defined(__GLIBC__) &&                                                    \
+    (__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 30))
+    return ::gettid();
+#else
+    return static_cast<pid_t>(::syscall(SYS_gettid));
+#endif
+}
+
+} // namespace sls

--- a/slsSupportLib/src/network_utils.cpp
+++ b/slsSupportLib/src/network_utils.cpp
@@ -15,10 +15,15 @@
 #include <net/if.h>
 #include <netdb.h>
 #include <sstream>
-#include <sys/ioctl.h>
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <unistd.h>
+
+#ifdef __APPLE__
+#include <net/if_dl.h> // sockaddr_dl, LLADDR
+#else
+#include <netpacket/packet.h> // sockaddr_ll
+#endif
 
 namespace sls {
 
@@ -177,37 +182,45 @@ IpAddr InterfaceNameToIp(const std::string &ifn) {
 }
 
 MacAddr InterfaceNameToMac(const std::string &inf) {
-
-#ifdef __APPLE__
-    throw RuntimeError("InterfaceNameToMac not implemented on macOS yet");
-#else
-
-    // TODO! Copied from genericSocket needs to be refactored!
-    struct ifreq ifr;
-    char mac[32];
-    const int mac_len = sizeof(mac);
-    memset(mac, 0, mac_len);
-
-    int sock = socket(PF_INET, SOCK_STREAM, 0);
-    strncpy(ifr.ifr_name, inf.c_str(), sizeof(ifr.ifr_name) - 1);
-    ifr.ifr_name[sizeof(ifr.ifr_name) - 1] = '\0';
-
-    if (-1 == ioctl(sock, SIOCGIFHWADDR, &ifr)) {
-        perror("ioctl(SIOCGIFHWADDR) ");
+    // Single getifaddrs()-based implementation for both Linux and macOS.
+    // The link-layer address is found on:
+    //   - Linux:       AF_PACKET entries (sockaddr_ll, sll_addr / sll_halen)
+    //   - macOS / BSD: AF_LINK   entries (sockaddr_dl, LLADDR / sdl_alen)
+    struct ifaddrs *ifaddr = nullptr;
+    if (getifaddrs(&ifaddr) == -1) {
         return MacAddr{};
     }
-    for (int j = 0, k = 0; j < 6; j++) {
-        k += snprintf(
-            mac + k, mac_len - k - 1, j ? ":%02X" : "%02X",
-            (int)(unsigned int)(unsigned char)ifr.ifr_hwaddr.sa_data[j]);
-    }
-    mac[mac_len - 1] = '\0';
+    MacAddr result{};
+    for (struct ifaddrs *ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next) {
+        if (ifa->ifa_addr == nullptr)
+            continue;
+        if (inf != ifa->ifa_name)
+            continue;
 
-    if (sock != 1) {
-        close(sock);
-    }
-    return MacAddr(mac);
+#ifdef __APPLE__
+        if (ifa->ifa_addr->sa_family != AF_LINK)
+            continue;
+        auto *sdl = reinterpret_cast<struct sockaddr_dl *>(ifa->ifa_addr);
+        if (sdl->sdl_alen != 6)
+            continue;
+        const auto *p = reinterpret_cast<const unsigned char *>(LLADDR(sdl));
+#else
+        if (ifa->ifa_addr->sa_family != AF_PACKET)
+            continue;
+        auto *sll = reinterpret_cast<struct sockaddr_ll *>(ifa->ifa_addr);
+        if (sll->sll_halen != 6)
+            continue;
+        const auto *p = sll->sll_addr;
 #endif
+
+        char mac[18];
+        snprintf(mac, sizeof(mac), "%02X:%02X:%02X:%02X:%02X:%02X", p[0], p[1],
+                 p[2], p[3], p[4], p[5]);
+        result = MacAddr(mac);
+        break;
+    }
+    freeifaddrs(ifaddr);
+    return result;
 }
 
 void validatePortNumber(uint16_t port) {


### PR DESCRIPTION
Making the slsReceiver work on macOS to facilitate testing. More important move from a linux only implementation to something portable. The counting_semaphore can be directly switch to the standard library implementation once we enable C++20

**Work in progress**
- [x] Portable gettid() replacement
- [x] Receiver compiles on mac
- [ ] Work on semaphores etc. 