### PR TITLE
accept comma separated rx_dbitlist

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -35,7 +35,7 @@ jobs:
                 shell: "bash -l {0}"
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
               with:
                 fetch-depth: 0  # Fetch all history for proper git operations
                 token: ${{ secrets.GITHUB_TOKEN }}  # Use the default token
@@ -84,7 +84,7 @@ jobs:
                 --date "$(date +'%d.%m.%Y')" 
             
             - name: Checkout gh-pages
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
               with:
                 ref: gh-pages
                 path: gh-pages

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -34,12 +34,12 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Build sdist
       run: pipx run build --sdist
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: cibw-sdist
         path: dist/*.tar.gz

--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -14,8 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Configure and build using cmake
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.12
           cache: 'pip'

--- a/.github/workflows/conda_deploy_library.yaml
+++ b/.github/workflows/conda_deploy_library.yaml
@@ -21,10 +21,10 @@ jobs:
         shell: "bash -l {0}"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Get conda
-        uses: conda-incubator/setup-miniconda@v3.0.4
+        uses: conda-incubator/setup-miniconda@v4
         with:
           python-version: ${{ matrix.python-version }}
           channels: conda-forge
@@ -38,10 +38,10 @@ jobs:
       - name: Build
         env:
             CONDA_TOKEN: ${{ secrets.CONDA_TOKEN }}
-        run: conda build conda-recipes/main-library --user slsdetectorgroup --token ${CONDA_TOKEN} --output-folder build_output
+        run: conda-build conda-recipes/main-library --user slsdetectorgroup --token ${CONDA_TOKEN} --output-folder build_output
 
       - name: Upload all Conda to github as artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: conda-packages
           path: build_output/**  # Uploads all packages

--- a/.github/workflows/conda_deploy_slsdet.yaml
+++ b/.github/workflows/conda_deploy_slsdet.yaml
@@ -21,10 +21,10 @@ jobs:
         shell: "bash -l {0}"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Get conda
-        uses: conda-incubator/setup-miniconda@v3.0.4
+        uses: conda-incubator/setup-miniconda@v4
         with:
           python-version: ${{ matrix.python-version }}
           channels: conda-forge
@@ -38,10 +38,10 @@ jobs:
       - name: Build
         env:
             CONDA_TOKEN: ${{ secrets.CONDA_TOKEN }}
-        run: conda build conda-recipes/python-client --user slsdetectorgroup --token ${CONDA_TOKEN} --output-folder build_output
+        run: conda-build conda-recipes/python-client --user slsdetectorgroup --token ${CONDA_TOKEN} --output-folder build_output
 
       - name: Upload all Conda packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: conda-packages
           path: build_output/**  # Uploads all packages

--- a/.github/workflows/conda_library.yaml
+++ b/.github/workflows/conda_library.yaml
@@ -18,10 +18,10 @@ jobs:
         shell: "bash -l {0}"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Get conda
-        uses: conda-incubator/setup-miniconda@v3.0.4
+        uses: conda-incubator/setup-miniconda@v4
         with:
           python-version: ${{ matrix.python-version }}
           channels: conda-forge

--- a/.github/workflows/conda_library.yaml
+++ b/.github/workflows/conda_library.yaml
@@ -33,10 +33,10 @@ jobs:
         run: conda config --set anaconda_upload no
 
       - name: Build
-        run: conda build conda-recipes/main-library --output-folder build_output
+        run: conda-build conda-recipes/main-library --output-folder build_output
 
       - name: Upload all Conda packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: conda-packages
           path: build_output/**  # Uploads all packages

--- a/.github/workflows/conda_python.yaml
+++ b/.github/workflows/conda_python.yaml
@@ -18,10 +18,10 @@ jobs:
         shell: "bash -l {0}"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Get conda
-        uses: conda-incubator/setup-miniconda@v3.0.4
+        uses: conda-incubator/setup-miniconda@v4
         with:
           python-version: ${{ matrix.python-version }}
           channels: conda-forge
@@ -33,10 +33,10 @@ jobs:
         run: conda config --set anaconda_upload no
 
       - name: Build
-        run: conda build conda-recipes/python-client --output-folder build_output 
+        run: conda-build conda-recipes/python-client --output-folder build_output 
 
       - name: Upload all Conda packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: conda-packages
           path: build_output/**  # Uploads all packages

--- a/slsDetectorSoftware/src/CallerSpecial.cpp
+++ b/slsDetectorSoftware/src/CallerSpecial.cpp
@@ -1014,15 +1014,16 @@ std::string Caller::counters(int action) {
         if (args.empty()) {
             WrongNumberOfParameters(1);
         }
-        if (std::any_of(args.cbegin(), args.cend(), [](std::string s) {
-                return (StringTo<int>(s) < 0 || StringTo<int>(s) > 2);
+        //convert args to string and then to a vector of ints
+        auto counters = StringTo<std::vector<int>>( ToString(args));
+        if (std::any_of(counters.cbegin(), counters.cend(), [](int val) {
+                return (val < 0 || val > 2);
             })) {
             throw RuntimeError("Invalid counter indices list. Example: 0 1 2");
         }
         // convert vector to counter enable mask
         uint32_t mask = 0;
-        for (size_t i = 0; i < args.size(); ++i) {
-            int val = StringTo<int>(args[i]);
+        for (auto val : counters) {
             // already enabled earlier
             if (mask & (1 << val)) {
                 std::ostringstream oss;

--- a/slsDetectorSoftware/src/CallerSpecial.cpp
+++ b/slsDetectorSoftware/src/CallerSpecial.cpp
@@ -1226,11 +1226,7 @@ std::string Caller::rx_dbitlist(int action) {
         }
         // 'none' option already covered as t is empty by default
         else if (args[0] != "none") {
-            unsigned int ntrim = args.size();
-            t.resize(ntrim);
-            for (unsigned int i = 0; i < ntrim; ++i) {
-                t[i] = StringTo<int>(args[i]);
-            }
+            t = StringTo<std::vector<int>>(ToString(args));
         }
         det->setRxDbitList(t, std::vector<int>{det_id});
         os << ToString(args) << '\n';

--- a/slsSupportLib/include/sls/ToString.h
+++ b/slsSupportLib/include/sls/ToString.h
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-or-other
 // Copyright (C) 2021 Contributors to the SLS Detector Package
 #pragma once
-
 /**
  * \file ToString.h
  *
@@ -353,7 +352,9 @@ T StringTo(const std::string &f, const std::string &unit) {
     }
 }
 
-template <typename T> T StringTo(const std::string &t) {
+template <typename T,
+          std::enable_if_t<!is_container<T>::value, int> = 0>
+T StringTo(const std::string &t) {
     std::string tmp{t};
     auto unit = RemoveUnit(tmp);
     return StringTo<T>(tmp, unit);
@@ -398,6 +399,7 @@ ToString(const T &obj) {
     return obj.str();
 }
 
+/** Convert vector of strings to vector of type T */
 template <typename T>
 std::vector<T> StringTo(const std::vector<std::string> &strings) {
     std::vector<T> result;
@@ -405,6 +407,38 @@ std::vector<T> StringTo(const std::vector<std::string> &strings) {
     for (const auto &s : strings)
         result.push_back(StringTo<T>(s));
     return result;
+}
+
+/** Parse comma-separated string into vector type T (e.g.,
+ * StringTo<std::vector<int>>()) */
+template <typename T, std::enable_if_t<is_container<T>::value &&
+                                           !std::is_same_v<T, std::string>,
+                                       int> = 0>
+T StringTo(const std::string &s) {
+    using ElementType = typename T::value_type;
+    T res;
+    std::istringstream ss(s);
+    std::string item;
+    while (std::getline(ss, item, ',')) {
+        item.erase(std::remove_if(item.begin(), item.end(),
+                                  [](char c) {
+                                      return c == '[' || c == ']' || c == '"' ||
+                                             c == ' ';
+                                  }),
+                   item.end());
+
+        try {
+            if (item.empty())
+                continue;
+            auto val = StringTo<ElementType>(item);
+            res.push_back(val);
+        } catch (const std::exception &e) {
+            throw RuntimeError("Could not convert '" + item +
+                               "' to the container element type. " +
+                               std::string(e.what()));
+        }
+    }
+    return res;
 }
 
 } // namespace sls

--- a/slsSupportLib/tests/test-ToString.cpp
+++ b/slsSupportLib/tests/test-ToString.cpp
@@ -415,4 +415,13 @@ TEST_CASE("string to timingInfoDecoder") {
             defs::timingInfoDecoder::SHINE);
 }
 
+
+TEST_CASE("Convert string to vector of ints") {
+    REQUIRE(StringTo<std::vector<int>>("1, 2, 3") == std::vector<int>{1, 2, 3});
+    REQUIRE(StringTo<std::vector<int>>(" 4 ,5,6 ") == std::vector<int>{4, 5, 6});
+    REQUIRE(StringTo<std::vector<int>>("[8]") == std::vector<int>{8});
+    REQUIRE(StringTo<std::vector<int>>("9, ") == std::vector<int>{9});
+    REQUIRE(StringTo<std::vector<int>>("") == std::vector<int>{});
+}
+
 } // namespace sls


### PR DESCRIPTION
_**PR included fix to github actions needed for conda build to work**_ 
[https://github.com/slsdetectorgroup/aare/pull/309](url)

**Actual change to detector software**:

- Accept comma separated list of rx_dbitlist without requiring space

```bash
p rx_dbitlist 12,13 45, 27
```

- Added same parsing for counters

Open question should we do a get, reformat args or just print what the user put in? 