### PR TITLE
CI: Use conda-build instead conda build

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -35,7 +35,7 @@ jobs:
                 shell: "bash -l {0}"
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
               with:
                 fetch-depth: 0  # Fetch all history for proper git operations
                 token: ${{ secrets.GITHUB_TOKEN }}  # Use the default token
@@ -58,7 +58,7 @@ jobs:
                 version: 1.0
 
             - name: Setup Python
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@v6
               with:
                 python-version: 3.12
                 cache: 'pip'
@@ -84,7 +84,7 @@ jobs:
                 --date "$(date +'%d.%m.%Y')" 
             
             - name: Checkout gh-pages
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
               with:
                 ref: gh-pages
                 path: gh-pages

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -20,12 +20,12 @@ jobs:
         os: [ubuntu-latest,]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Build wheels
         run: pipx run cibuildwheel==3.2.1
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
@@ -34,12 +34,12 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Build sdist
       run: pipx run build --sdist
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: cibw-sdist
         path: dist/*.tar.gz
@@ -54,7 +54,7 @@ jobs:
     # or, alternatively, upload to PyPI on every tag starting with 'v' (remove on: release above to use this)
     # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     steps:
-        - uses: actions/download-artifact@v4
+        - uses: actions/download-artifact@v7
           with:
             # unpacks all CIBW artifacts into dist/
             pattern: cibw-*

--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -14,8 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Configure and build using cmake
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.12
           cache: 'pip'

--- a/.github/workflows/conda_deploy_library.yaml
+++ b/.github/workflows/conda_deploy_library.yaml
@@ -41,7 +41,7 @@ jobs:
         run: conda-build conda-recipes/main-library --user slsdetectorgroup --token ${CONDA_TOKEN} --output-folder build_output
 
       - name: Upload all Conda to github as artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: conda-packages
           path: build_output/**  # Uploads all packages

--- a/.github/workflows/conda_deploy_library.yaml
+++ b/.github/workflows/conda_deploy_library.yaml
@@ -21,10 +21,10 @@ jobs:
         shell: "bash -l {0}"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Get conda
-        uses: conda-incubator/setup-miniconda@v3.0.4
+        uses: conda-incubator/setup-miniconda@v4
         with:
           python-version: ${{ matrix.python-version }}
           channels: conda-forge
@@ -38,7 +38,7 @@ jobs:
       - name: Build
         env:
             CONDA_TOKEN: ${{ secrets.CONDA_TOKEN }}
-        run: conda build conda-recipes/main-library --user slsdetectorgroup --token ${CONDA_TOKEN} --output-folder build_output
+        run: conda-build conda-recipes/main-library --user slsdetectorgroup --token ${CONDA_TOKEN} --output-folder build_output
 
       - name: Upload all Conda to github as artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/conda_deploy_slsdet.yaml
+++ b/.github/workflows/conda_deploy_slsdet.yaml
@@ -21,10 +21,10 @@ jobs:
         shell: "bash -l {0}"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Get conda
-        uses: conda-incubator/setup-miniconda@v3.0.4
+        uses: conda-incubator/setup-miniconda@v4
         with:
           python-version: ${{ matrix.python-version }}
           channels: conda-forge
@@ -38,10 +38,10 @@ jobs:
       - name: Build
         env:
             CONDA_TOKEN: ${{ secrets.CONDA_TOKEN }}
-        run: conda build conda-recipes/python-client --user slsdetectorgroup --token ${CONDA_TOKEN} --output-folder build_output
+        run: conda-build conda-recipes/python-client --user slsdetectorgroup --token ${CONDA_TOKEN} --output-folder build_output
 
       - name: Upload all Conda packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: conda-packages
           path: build_output/**  # Uploads all packages

--- a/.github/workflows/conda_library.yaml
+++ b/.github/workflows/conda_library.yaml
@@ -18,10 +18,10 @@ jobs:
         shell: "bash -l {0}"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Get conda
-        uses: conda-incubator/setup-miniconda@v3.0.4
+        uses: conda-incubator/setup-miniconda@v4
         with:
           python-version: ${{ matrix.python-version }}
           channels: conda-forge
@@ -33,10 +33,10 @@ jobs:
         run: conda config --set anaconda_upload no
 
       - name: Build
-        run: conda build conda-recipes/main-library --output-folder build_output
+        run: conda-build conda-recipes/main-library --output-folder build_output
 
       - name: Upload all Conda packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: conda-packages
           path: build_output/**  # Uploads all packages

--- a/.github/workflows/conda_python.yaml
+++ b/.github/workflows/conda_python.yaml
@@ -18,10 +18,10 @@ jobs:
         shell: "bash -l {0}"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Get conda
-        uses: conda-incubator/setup-miniconda@v3.0.4
+        uses: conda-incubator/setup-miniconda@v4
         with:
           python-version: ${{ matrix.python-version }}
           channels: conda-forge
@@ -33,10 +33,10 @@ jobs:
         run: conda config --set anaconda_upload no
 
       - name: Build
-        run: conda build conda-recipes/python-client --output-folder build_output 
+        run: conda-build conda-recipes/python-client --output-folder build_output
 
       - name: Upload all Conda packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: conda-packages
           path: build_output/**  # Uploads all packages


### PR DESCRIPTION
The `conda build` fails since the last update of `miniforge`. The preferred way is to use `conda-build` instead. Also updated the actions versions.