### PR TITLE
Fix/fmt install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,21 +209,10 @@ else()
             URL ${CMAKE_CURRENT_SOURCE_DIR}/libs/fmt/fmt-12.1.0.tar.gz
             # Compute hash: md5sum fmt-12.1.0.tar.gz 
             URL_HASH MD5=92eb6f492e4838e5f024ce5207beafc7) 
+    set(FMT_INSTALL ON CACHE BOOL "")
     FetchContent_MakeAvailable(fmt)
     set_property(TARGET fmt PROPERTY POSITION_INDEPENDENT_CODE ON)
 endif()
-
-# Export fmt 
-if(SLS_MASTER_PROJECT)
-    install(TARGETS fmt
-        EXPORT ${TARGETS_EXPORT_NAME}
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-    )
-endif()
-
 
 option(SLS_USE_HDF5 "HDF5 File format" OFF)
 option(SLS_BUILD_SHARED_LIBRARIES "Build shared libaries" OFF)

--- a/conda-recipes/main-library/copy_lib.sh
+++ b/conda-recipes/main-library/copy_lib.sh
@@ -6,7 +6,7 @@ mkdir -p $PREFIX/bin
 mkdir -p $PREFIX/include/sls
 
 #Shared and static libraries
-cp build/install/lib/* $PREFIX/lib/
+cp -r build/install/lib/* $PREFIX/lib/
 
 #Binaries
 cp build/install/bin/sls_detector_acquire $PREFIX/bin/.

--- a/python/slsdet/detector.py
+++ b/python/slsdet/detector.py
@@ -827,16 +827,21 @@ class Detector(CppDetectorApi):
     @property
     @element
     def txdelay(self):
-        """
+        r"""
         [Eiger][Jungfrau][Moench][Mythen3] Set transmission delay for all modules in the detector using the step size provided.
         
         Note
         ----
-        Sets up the following for every module:\n
-        \t\t[Eiger] txdelay_left to (2 \* mod_index \* n_delay), \n
-        \t\t[Eiger] txdelay_right to ((2 \* mod_index + 1) \* n_delay) and \n
-        \t\t[Eiger] txdelay_frame to (2 \* num_modules \* n_delay)  \n
-        \t\t[Jungfrau][Moench][Mythen3] txdelay_frame to (num_modules \* n_delay)\n\n
+        Sets up the following for every module:
+
+        [Eiger] txdelay_left to (2 \* mod_index \* n_delay), 
+
+        [Eiger] txdelay_right to ((2 \* mod_index + 1) \* n_delay) and 
+
+        [Eiger] txdelay_frame to (2 \* num_modules \* n_delay)  
+
+        [Jungfrau][Moench][Mythen3] txdelay_frame to (num_modules \* n_delay)
+        
         Please refer txdelay_left, txdelay_right and txdelay_frame for details.
         """
         return self.getTransmissionDelay()


### PR DESCRIPTION
- fix python warning escaped \* in docstring 
- avoid second install of fmt