### PR TITLE
Dev/fix workflow cmake cache

### DIFF
--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -11,7 +11,7 @@ jobs:
     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
     # You can convert this to a matrix build if you need cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Configure and build using cmake
     steps:
       - uses: actions/checkout@v6
@@ -24,7 +24,7 @@ jobs:
       - uses: awalsh128/cache-apt-pkgs-action@latest
         with:
           packages: libhdf5-dev qtbase5-dev qt5-qmake libqt5svg5-dev libpng-dev libtiff-dev libfmt-dev
-          version: 1.1
+          version: 1.2
 
       # verify packages restored from cache are installed.
       # This catches incomplete apt installs after cache restore.

--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -11,7 +11,7 @@ jobs:
     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
     # You can convert this to a matrix build if you need cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     name: Configure and build using cmake
     steps:
       - uses: actions/checkout@v6
@@ -21,10 +21,10 @@ jobs:
           cache: 'pip'
       - run: pip install pytest numpy colorama
 
-      - uses: awalsh128/cache-apt-pkgs-action@v1.61
+      - uses: awalsh128/cache-apt-pkgs-action@v1.6.1
         with:
           packages: libhdf5-dev qtbase5-dev qt5-qmake libqt5svg5-dev libpng-dev libtiff-dev libfmt-dev
-          version: 1.3
+          version: 1.4
 
       # verify packages restored from cache are installed.
       # This catches incomplete apt installs after cache restore.

--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -26,7 +26,8 @@ jobs:
           packages: libhdf5-dev qtbase5-dev qt5-qmake libqt5svg5-dev libpng-dev libtiff-dev libfmt-dev
           version: 1.0
 
-      # verify the packages in cache are installed (can be missing if ubunti updates and mirror is not updated)
+      # verify packages restored from cache are installed.
+      # This catches incomplete apt installs after cache restore.
       - name: Verify apt packages
         id: verify_packages
         continue-on-error: true
@@ -62,21 +63,8 @@ jobs:
         if: steps.verify_packages.outputs.failed_packages != ''
         run: |
           sudo apt-get update
+          sudo apt-get install --fix-broken -y
           sudo apt-get install --reinstall -y ${{ steps.verify_packages.outputs.failed_packages }}
-
-      # hdf5: also needs to find C++ component, headers and libraries
-      - name: Verify HDF5
-        id: verify_hdf5
-        continue-on-error: true
-        run: |
-          h5cc -showconfig
-          h5c++ -show
-
-      - name: Repair HDF5
-        if: steps.verify_packages.outputs.failed_packages != ''
-        run: |
-          sudo apt-get update
-          sudo apt-get install --reinstall -y libhdf5-dev
 
 
       - name: Configure CMake

--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -59,7 +59,7 @@ jobs:
           fi
 
       - name: Repair missing apt packages
-        if: steps.verify_packages.outcome == 'failure'
+        if: steps.verify_packages.outputs.failed_packages != ''
         run: |
           sudo apt-get update
           sudo apt-get install --reinstall -y ${{ steps.verify_packages.outputs.failed_packages }}
@@ -73,7 +73,7 @@ jobs:
           h5c++ -show
 
       - name: Repair HDF5
-        if: steps.verify_hdf5.outcome == 'failure'
+        if: steps.verify_packages.outputs.failed_packages != ''
         run: |
           sudo apt-get update
           sudo apt-get install --reinstall -y libhdf5-dev

--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -30,7 +30,6 @@ jobs:
       # This catches incomplete apt installs after cache restore.
       - name: Verify apt packages
         id: verify_packages
-        continue-on-error: true
         run: |
           failed=""
 
@@ -42,7 +41,6 @@ jobs:
             libpng-dev \
             libtiff-dev \
             libfmt-dev
-          # remember failed packages to repair in next step
           do
             if ! dpkg -s "$pkg" >/dev/null 2>&1; then
               echo "Missing: $pkg"
@@ -50,22 +48,13 @@ jobs:
             fi
           done
 
-          echo "failed_packages=$failed" >> "$GITHUB_OUTPUT"
 
           if [ -n "$failed" ]; then
-            echo "Missing packages after cache restore: $failed"
+            echo "Missing packages after cache restore: $failed. Try deleting the cache and rerunning the workflow."
             exit 1
           else
             echo "All apt packages are installed"  
           fi
-
-      - name: Repair missing apt packages
-        if: steps.verify_packages.outputs.failed_packages != ''
-        run: |
-          sudo apt-get update
-          sudo apt-get install --fix-broken -y
-          sudo apt-get install --reinstall -y ${{ steps.verify_packages.outputs.failed_packages }}
-
 
       - name: Configure CMake
         # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -29,7 +29,7 @@ jobs:
       # verify the packages in cache are installed (can be missing if ubunti updates and mirror is not updated)
       - name: Verify apt packages
         id: verify_packages
-        #continue-on-error: true
+        continue-on-error: true
         run: |
           failed=""
 

--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -24,7 +24,7 @@ jobs:
       - uses: awalsh128/cache-apt-pkgs-action@latest
         with:
           packages: libhdf5-dev qtbase5-dev qt5-qmake libqt5svg5-dev libpng-dev libtiff-dev libfmt-dev
-          version: 1.0
+          version: 1.1
 
       # verify packages restored from cache are installed.
       # This catches incomplete apt installs after cache restore.

--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -21,10 +21,10 @@ jobs:
           cache: 'pip'
       - run: pip install pytest numpy colorama
 
-      - uses: awalsh128/cache-apt-pkgs-action@latest
+      - uses: awalsh128/cache-apt-pkgs-action@v1.61
         with:
           packages: libhdf5-dev qtbase5-dev qt5-qmake libqt5svg5-dev libpng-dev libtiff-dev libfmt-dev
-          version: 1.2
+          version: 1.3
 
       # verify packages restored from cache are installed.
       # This catches incomplete apt installs after cache restore.

--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -21,6 +21,7 @@ jobs:
           cache: 'pip'
       - run: pip install pytest numpy colorama
 
+      # using a stable action version instead of latest to create/restore cache for now
       - uses: awalsh128/cache-apt-pkgs-action@v1.6.1
         with:
           packages: libhdf5-dev qtbase5-dev qt5-qmake libqt5svg5-dev libpng-dev libtiff-dev libfmt-dev

--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -26,6 +26,59 @@ jobs:
           packages: libhdf5-dev qtbase5-dev qt5-qmake libqt5svg5-dev libpng-dev libtiff-dev libfmt-dev
           version: 1.0
 
+      # verify the packages in cache are installed (can be missing if ubunti updates and mirror is not updated)
+      - name: Verify apt packages
+        id: verify_packages
+        #continue-on-error: true
+        run: |
+          failed=""
+
+          for pkg in \
+            libhdf5-dev \
+            qtbase5-dev \
+            qt5-qmake \
+            libqt5svg5-dev \
+            libpng-dev \
+            libtiff-dev \
+            libfmt-dev
+          # remember failed packages to repair in next step
+          do
+            if ! dpkg -s "$pkg" >/dev/null 2>&1; then
+              echo "Missing: $pkg"
+              failed="$failed $pkg"
+            fi
+          done
+
+          echo "failed_packages=$failed" >> "$GITHUB_OUTPUT"
+
+          if [ -n "$failed" ]; then
+            echo "Missing packages after cache restore: $failed"
+            exit 1
+          else
+            echo "All apt packages are installed"  
+          fi
+
+      - name: Repair missing apt packages
+        if: steps.verify_packages.outcome == 'failure'
+        run: |
+          sudo apt-get update
+          sudo apt-get install --reinstall -y ${{ steps.verify_packages.outputs.failed_packages }}
+
+      # hdf5: also needs to find C++ component, headers and libraries
+      - name: Verify HDF5
+        id: verify_hdf5
+        continue-on-error: true
+        run: |
+          h5cc -showconfig
+          h5c++ -show
+
+      - name: Repair HDF5
+        if: steps.verify_hdf5.outcome == 'failure'
+        run: |
+          sudo apt-get update
+          sudo apt-get install --reinstall -y libhdf5-dev
+
+
       - name: Configure CMake
         # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
         # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type

--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -24,7 +24,7 @@ jobs:
       - uses: awalsh128/cache-apt-pkgs-action@v1.6.1
         with:
           packages: libhdf5-dev qtbase5-dev qt5-qmake libqt5svg5-dev libpng-dev libtiff-dev libfmt-dev
-          version: 1.4
+          version: 1.0
 
       # verify packages restored from cache are installed.
       # This catches incomplete apt installs after cache restore.

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -20,10 +20,10 @@ jobs:
           cache: 'pip'
       - run: pip install pytest numpy colorama pyzmq
 
-      - uses: awalsh128/cache-apt-pkgs-action@latest
+      - uses: awalsh128/cache-apt-pkgs-action@v1.61
         with:
           packages: libhdf5-dev libfmt-dev
-          version: 1.2
+          version: 1.3
 
       # verify packages restored from cache are installed.
       # This catches incomplete apt installs after cache restore.

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -29,14 +29,12 @@ jobs:
       # This catches incomplete apt installs after cache restore.
       - name: Verify apt packages
         id: verify_packages
-        continue-on-error: true
         run: |
           failed=""
 
           for pkg in \
             libhdf5-dev \
             libfmt-dev
-          # remember failed packages to repair in next step
           do
             if ! dpkg -s "$pkg" >/dev/null 2>&1; then
               echo "Missing: $pkg"
@@ -44,21 +42,12 @@ jobs:
             fi
           done
 
-          echo "failed_packages=$failed" >> "$GITHUB_OUTPUT"
-
           if [ -n "$failed" ]; then
-            echo "Missing packages after cache restore: $failed"
+            echo "Missing packages after cache restore: $failed. Try deleting the cache and rerunning the workflow."
             exit 1
           else
             echo "All apt packages are installed"  
           fi
-
-      - name: Repair missing apt packages
-        if: steps.verify_packages.outputs.failed_packages != ''
-        run: |
-          sudo apt-get update
-          sudo apt-get install --fix-broken -y
-          sudo apt-get install --reinstall -y ${{ steps.verify_packages.outputs.failed_packages }}
 
 
       - name: Configure CMake

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -25,6 +25,42 @@ jobs:
           packages: libhdf5-dev libfmt-dev
           version: 1.0
 
+      # verify packages restored from cache are installed.
+      # This catches incomplete apt installs after cache restore.
+      - name: Verify apt packages
+        id: verify_packages
+        continue-on-error: true
+        run: |
+          failed=""
+
+          for pkg in \
+            libhdf5-dev \
+            libfmt-dev
+          # remember failed packages to repair in next step
+          do
+            if ! dpkg -s "$pkg" >/dev/null 2>&1; then
+              echo "Missing: $pkg"
+              failed="$failed $pkg"
+            fi
+          done
+
+          echo "failed_packages=$failed" >> "$GITHUB_OUTPUT"
+
+          if [ -n "$failed" ]; then
+            echo "Missing packages after cache restore: $failed"
+            exit 1
+          else
+            echo "All apt packages are installed"  
+          fi
+
+      - name: Repair missing apt packages
+        if: steps.verify_packages.outputs.failed_packages != ''
+        run: |
+          sudo apt-get update
+          sudo apt-get install --fix-broken -y
+          sudo apt-get install --reinstall -y ${{ steps.verify_packages.outputs.failed_packages }}
+
+
       - name: Configure CMake
         run: |
           cmake -B ${{github.workspace}}/build \

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -20,6 +20,7 @@ jobs:
           cache: 'pip'
       - run: pip install pytest numpy colorama pyzmq
 
+      # using a stable action version instead of latest to create/restore cache for now
       - uses: awalsh128/cache-apt-pkgs-action@v1.6.1
         with:
           packages: libhdf5-dev libfmt-dev

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -23,7 +23,7 @@ jobs:
       - uses: awalsh128/cache-apt-pkgs-action@latest
         with:
           packages: libhdf5-dev libfmt-dev
-          version: 1.1
+          version: 1.2
 
       # verify packages restored from cache are installed.
       # This catches incomplete apt installs after cache restore.

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -23,7 +23,7 @@ jobs:
       - uses: awalsh128/cache-apt-pkgs-action@latest
         with:
           packages: libhdf5-dev libfmt-dev
-          version: 1.0
+          version: 1.1
 
       # verify packages restored from cache are installed.
       # This catches incomplete apt installs after cache restore.

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -20,10 +20,10 @@ jobs:
           cache: 'pip'
       - run: pip install pytest numpy colorama pyzmq
 
-      - uses: awalsh128/cache-apt-pkgs-action@v1.61
+      - uses: awalsh128/cache-apt-pkgs-action@v1.6.1
         with:
           packages: libhdf5-dev libfmt-dev
-          version: 1.3
+          version: 1.4
 
       # verify packages restored from cache are installed.
       # This catches incomplete apt installs after cache restore.

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -23,7 +23,7 @@ jobs:
       - uses: awalsh128/cache-apt-pkgs-action@v1.6.1
         with:
           packages: libhdf5-dev libfmt-dev
-          version: 1.4
+          version: 1.0
 
       # verify packages restored from cache are installed.
       # This catches incomplete apt installs after cache restore.


### PR DESCRIPTION
- Add checks for cached apt dependencies to catch incomplete installations. 
- A temporary Ubuntu mirror/package index mismatch caused apt installation to fail, but the failure was not detected before CMake ran.
- awalsh128/cache-apt-pkgs-action@v1.6.1 (instead of latest): issue: https://github.com/awalsh128/cache-apt-pkgs-action/issues/218 
- deleted all the caches to start with fresh caches.