### PR TITLE
fix workflow cmake cache 2

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -52,7 +52,7 @@ jobs:
                 fi
 
             - name: Install System Packages
-              uses: awalsh128/cache-apt-pkgs-action@latest
+              uses: awalsh128/cache-apt-pkgs-action@v1.6.1
               with:
                 packages: libhdf5-dev doxygen libfmt-dev
                 version: 1.0

--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -27,17 +27,6 @@ jobs:
           packages: libhdf5-dev qtbase5-dev qt5-qmake libqt5svg5-dev libpng-dev libtiff-dev libfmt-dev
           version: 1.0
 
-      # debug
-      - name: Debug HDF5
-        run: |
-          dpkg -s libhdf5-dev || true
-          ls /var/lib/dpkg/info | grep hdf5 || true
-          which h5cc || true
-          find /usr/include -name H5public.h || true
-          h5c++ -show
-          ls /usr/lib/x86_64-linux-gnu/hdf5/serial
-          pkg-config --modversion hdf5 || true
-
       # verify packages restored from cache are installed.
       # This catches incomplete apt installs after cache restore.
       - name: Verify apt packages
@@ -46,6 +35,7 @@ jobs:
           failed=""
 
           for pkg in \
+            libhdf5-dev \
             qtbase5-dev \
             qt5-qmake \
             libqt5svg5-dev \
@@ -53,17 +43,11 @@ jobs:
             libtiff-dev \
             libfmt-dev
           do
-            if ! dpkg -s "$pkg" >/dev/null 2>&1; then
+            if ! dpkg -L "$pkg" >/dev/null 2>&1; then
               echo "Missing: $pkg"
               failed="$failed $pkg"
             fi
           done
-
-          # HDF5 check: verify the actual development environment
-          if ! h5c++ -show >/dev/null 2>&1; then
-            echo "Missing HDF5 C++ development environment"
-            failed="$failed hdf5"
-          fi
 
           if [ -n "$failed" ]; then
             echo "Missing packages after cache restore: $failed. Try deleting the cache and rerunning the workflow."

--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -27,34 +27,9 @@ jobs:
           packages: libhdf5-dev qtbase5-dev qt5-qmake libqt5svg5-dev libpng-dev libtiff-dev libfmt-dev
           version: 1.0
 
-      # verify packages restored from cache are installed.
-      # This catches incomplete apt installs after cache restore.
       - name: Verify apt packages
-        id: verify_packages
         run: |
-          failed=""
-
-          for pkg in \
-            libhdf5-dev \
-            qtbase5-dev \
-            qt5-qmake \
-            libqt5svg5-dev \
-            libpng-dev \
-            libtiff-dev \
-            libfmt-dev
-          do
-            if ! dpkg -L "$pkg" >/dev/null 2>&1; then
-              echo "Missing: $pkg"
-              failed="$failed $pkg"
-            fi
-          done
-
-          if [ -n "$failed" ]; then
-            echo "Missing packages after cache restore: $failed. Try deleting the cache and rerunning the workflow."
-            exit 1
-          else
-            echo "All apt packages are installed"  
-          fi
+          apt-cache policy libhdf5-dev qtbase5-dev qt5-qmake libqt5svg5-dev libpng-dev libtiff-dev libfmt-dev
 
       - name: Configure CMake
         # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -29,14 +29,11 @@ jobs:
 
       - name: Verify apt cache
         run: |
-          count=$(find ~/cache-apt-pkgs -name '*.tar' | wc -l)
-
-          if [ "$count" -eq 0 ]; then
-            echo "APT cache is empty. Delete the cache and rerun the workflow."
+          if [ ! -f ~/cache-apt-pkgs/manifest_all.log ]; then
+            echo "APT cache is incomplete (manifest_all.log missing)."
+            echo "Delete the cache and rerun the workflow."
             exit 1
           fi
-
-          echo "APT cache contains $count packages."
 
       - name: Configure CMake
         # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -46,7 +46,6 @@ jobs:
           failed=""
 
           for pkg in \
-            libhdf5-dev \
             qtbase5-dev \
             qt5-qmake \
             libqt5svg5-dev \
@@ -60,6 +59,11 @@ jobs:
             fi
           done
 
+          # HDF5 check: verify the actual development environment
+          if ! h5c++ -show >/dev/null 2>&1; then
+            echo "Missing HDF5 C++ development environment"
+            failed="$failed hdf5"
+          fi
 
           if [ -n "$failed" ]; then
             echo "Missing packages after cache restore: $failed. Try deleting the cache and rerunning the workflow."

--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -34,6 +34,9 @@ jobs:
           ls /var/lib/dpkg/info | grep hdf5 || true
           which h5cc || true
           find /usr/include -name H5public.h || true
+          h5c++ -show
+          ls /usr/lib/x86_64-linux-gnu/hdf5/serial
+          pkg-config --modversion hdf5 || true
 
       # verify packages restored from cache are installed.
       # This catches incomplete apt installs after cache restore.

--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -29,11 +29,8 @@ jobs:
 
       - name: Verify apt cache
         run: |
-          if [ ! -f ~/cache-apt-pkgs/manifest_all.log ]; then
-            echo "APT cache is incomplete (manifest_all.log missing)."
-            echo "Delete the cache and rerun the workflow."
-            exit 1
-          fi
+          echo "Cache hit: ${{ steps.apt-cache.outputs.cache-hit }}"
+          echo "Cache hit: ${{ steps.apt-cache.outputs.package-version-list }}"
 
       - name: Configure CMake
         # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -27,10 +27,6 @@ jobs:
           packages: libhdf5-dev qtbase5-dev qt5-qmake libqt5svg5-dev libpng-dev libtiff-dev libfmt-dev
           version: 1.0
 
-      - name: Verify apt packages are available
-        run: |
-          apt list --installed 2>/dev/null | grep -E 'hdf5|fmt|qt|png|tiff'
-
       - name: Configure CMake
         # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
         # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type

--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -27,6 +27,13 @@ jobs:
           packages: libhdf5-dev qtbase5-dev qt5-qmake libqt5svg5-dev libpng-dev libtiff-dev libfmt-dev
           version: 1.0
 
+      - name: Debug HDF5
+        run: |
+          dpkg -s libhdf5-dev || true
+          ls /var/lib/dpkg/info | grep hdf5 || true
+          which h5cc || true
+          find /usr/include -name H5public.h || true
+
       # verify packages restored from cache are installed.
       # This catches incomplete apt installs after cache restore.
       - name: Verify apt packages

--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Verify apt packages are available
         run: |
-          apt list --installed 2>/dev/null | grep -E 'hdf5|fmt|qt|png|tiff' || true
+          apt list --installed 2>/dev/null | grep -E 'hdf5|fmt|qt|png|tiff'
 
       - name: Configure CMake
         # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -27,6 +27,7 @@ jobs:
           packages: libhdf5-dev qtbase5-dev qt5-qmake libqt5svg5-dev libpng-dev libtiff-dev libfmt-dev
           version: 1.0
 
+      # debug
       - name: Debug HDF5
         run: |
           dpkg -s libhdf5-dev || true

--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -27,9 +27,9 @@ jobs:
           packages: libhdf5-dev qtbase5-dev qt5-qmake libqt5svg5-dev libpng-dev libtiff-dev libfmt-dev
           version: 1.0
 
-      - name: Verify apt packages
+      - name: Verify apt packages are available
         run: |
-          sudo apt-get check
+          apt list --installed 2>/dev/null | grep -E 'hdf5|fmt|qt|png|tiff' || true
 
       - name: Configure CMake
         # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -27,9 +27,16 @@ jobs:
           packages: libhdf5-dev qtbase5-dev qt5-qmake libqt5svg5-dev libpng-dev libtiff-dev libfmt-dev
           version: 1.0
 
-      - name: Verify apt packages
+      - name: Verify apt cache
         run: |
-          apt-cache policy libhdf5-dev qtbase5-dev qt5-qmake libqt5svg5-dev libpng-dev libtiff-dev libfmt-dev
+          count=$(find ~/cache-apt-pkgs -name '*.tar' | wc -l)
+
+          if [ "$count" -eq 0 ]; then
+            echo "APT cache is empty. Delete the cache and rerun the workflow."
+            exit 1
+          fi
+
+          echo "APT cache contains $count packages."
 
       - name: Configure CMake
         # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -27,10 +27,9 @@ jobs:
           packages: libhdf5-dev qtbase5-dev qt5-qmake libqt5svg5-dev libpng-dev libtiff-dev libfmt-dev
           version: 1.0
 
-      - name: Verify apt cache
+      - name: Verify apt packages
         run: |
-          echo "Cache hit: ${{ steps.apt-cache.outputs.cache-hit }}"
-          echo "Cache hit: ${{ steps.apt-cache.outputs.package-version-list }}"
+          sudo apt-get check
 
       - name: Configure CMake
         # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -23,12 +23,13 @@ jobs:
       # using a stable action version instead of latest to create/restore cache for now
       - uses: awalsh128/cache-apt-pkgs-action@v1.6.1
         with:
-          packages: libhdf5-dev libfmt-dev
+          #packages: libhdf5-dev libfmt-dev
+          packages: libfmt-dev
           version: 1.0
-          
-      - name: Verify apt packages
+
+      - name: Verify apt packages are available
         run: |
-          sudo apt-get check
+          apt list --installed 2>/dev/null | grep -E 'hdf5|fmt' || true
 
       - name: Configure CMake
         run: |

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -26,28 +26,16 @@ jobs:
           packages: libhdf5-dev libfmt-dev
           version: 1.0
 
-      - name: Verify apt packages
+      - name: Verify apt cache
         run: |
-          failed=""
+          count=$(find ~/cache-apt-pkgs -name '*.tar' | wc -l)
 
-          for pkg in \
-            libhdf5-dev \
-            libfmt-dev
-          do
-            installed=$(apt-cache policy "$pkg" | awk '/Installed:/ {print $2}')
-
-            if [ "$installed" = "(none)" ]; then
-              echo "Missing: $pkg"
-              failed="$failed $pkg"
-            fi
-          done
-
-          if [ -n "$failed" ]; then
-            echo "Missing packages after cache restore: $failed. Try deleting the cache and rerunning the workflow."
+          if [ "$count" -eq 0 ]; then
+            echo "APT cache is empty. Delete the cache and rerun the workflow."
             exit 1
           fi
 
-          echo "All apt packages are installed"  
+          echo "APT cache contains $count packages."
           
       - name: Configure CMake
         run: |

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -27,10 +27,6 @@ jobs:
           #packages: libfmt-dev
           version: 1.0
 
-      - name: Verify apt packages are available
-        run: |
-          apt list --installed 2>/dev/null | grep -E 'hdf5|fmt'
-
       - name: Configure CMake
         run: |
           cmake -B ${{github.workspace}}/build \

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -25,11 +25,10 @@ jobs:
         with:
           packages: libhdf5-dev libfmt-dev
           version: 1.0
-
-      - name: Verify apt cache
+          
+      - name: Verify apt packages
         run: |
-          echo "Cache hit: ${{ steps.apt-cache.outputs.cache-hit }}"
-          echo "Cache hit: ${{ steps.apt-cache.outputs.package-version-list }}"
+          sudo apt-get check
 
       - name: Configure CMake
         run: |

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -23,7 +23,7 @@ jobs:
       # using a stable action version instead of latest to create/restore cache for now
       - uses: awalsh128/cache-apt-pkgs-action@v1.6.1
         with:
-          packages: libhdf5-dev libfmt-dev
+          packages: libfmt-dev
           version: 1.0
 
       - name: Verify apt packages

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -23,8 +23,8 @@ jobs:
       # using a stable action version instead of latest to create/restore cache for now
       - uses: awalsh128/cache-apt-pkgs-action@v1.6.1
         with:
-          #packages: libhdf5-dev libfmt-dev
-          packages: libfmt-dev
+          packages: libhdf5-dev libfmt-dev
+          #packages: libfmt-dev
           version: 1.0
 
       - name: Verify apt packages are available

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -24,7 +24,6 @@ jobs:
       - uses: awalsh128/cache-apt-pkgs-action@v1.6.1
         with:
           packages: libhdf5-dev libfmt-dev
-          #packages: libfmt-dev
           version: 1.0
 
       - name: Configure CMake

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -28,12 +28,9 @@ jobs:
 
       - name: Verify apt cache
         run: |
-          if [ ! -f ~/cache-apt-pkgs/manifest_all.log ]; then
-            echo "APT cache is incomplete (manifest_all.log missing)."
-            echo "Delete the cache and rerun the workflow."
-            exit 1
-          fi
-          
+          echo "Cache hit: ${{ steps.apt-cache.outputs.cache-hit }}"
+          echo "Cache hit: ${{ steps.apt-cache.outputs.package-version-list }}"
+
       - name: Configure CMake
         run: |
           cmake -B ${{github.workspace}}/build \

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -28,14 +28,11 @@ jobs:
 
       - name: Verify apt cache
         run: |
-          count=$(find ~/cache-apt-pkgs -name '*.tar' | wc -l)
-
-          if [ "$count" -eq 0 ]; then
-            echo "APT cache is empty. Delete the cache and rerun the workflow."
+          if [ ! -f ~/cache-apt-pkgs/manifest_all.log ]; then
+            echo "APT cache is incomplete (manifest_all.log missing)."
+            echo "Delete the cache and rerun the workflow."
             exit 1
           fi
-
-          echo "APT cache contains $count packages."
           
       - name: Configure CMake
         run: |

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -26,6 +26,13 @@ jobs:
           packages: libhdf5-dev libfmt-dev
           version: 1.0
 
+      - name: Debug HDF5
+        run: |
+          dpkg -s libhdf5-dev || true
+          ls /var/lib/dpkg/info | grep hdf5 || true
+          which h5cc || true
+          find /usr/include -name H5public.h || true
+
       # verify packages restored from cache are installed.
       # This catches incomplete apt installs after cache restore.
       - name: Verify apt packages

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -28,7 +28,26 @@ jobs:
 
       - name: Verify apt packages
         run: |
-          apt-cache policy libhdf5-dev libfmt-dev
+          failed=""
+
+          for pkg in \
+            libhdf5-dev \
+            libfmt-dev
+          do
+            installed=$(apt-cache policy "$pkg" | awk '/Installed:/ {print $2}')
+
+            if [ "$installed" = "(none)" ]; then
+              echo "Missing: $pkg"
+              failed="$failed $pkg"
+            fi
+          done
+
+          if [ -n "$failed" ]; then
+            echo "Missing packages after cache restore: $failed. Try deleting the cache and rerunning the workflow."
+            exit 1
+          fi
+          
+          echo "All apt packages are installed"  
           
       - name: Configure CMake
         run: |

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -33,6 +33,10 @@ jobs:
           ls /var/lib/dpkg/info | grep hdf5 || true
           which h5cc || true
           find /usr/include -name H5public.h || true
+          h5cc -showconfig
+          h5c++ -show
+          ls /usr/lib/x86_64-linux-gnu/hdf5/serial
+          pkg-config --modversion hdf5 || true
 
       # verify packages restored from cache are installed.
       # This catches incomplete apt installs after cache restore.

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -26,18 +26,6 @@ jobs:
           packages: libhdf5-dev libfmt-dev
           version: 1.0
 
-      # debug
-      - name: Debug HDF5
-        run: |
-          dpkg -s libhdf5-dev || true
-          ls /var/lib/dpkg/info | grep hdf5 || true
-          which h5cc || true
-          find /usr/include -name H5public.h || true
-          h5cc -showconfig
-          h5c++ -show
-          ls /usr/lib/x86_64-linux-gnu/hdf5/serial
-          pkg-config --modversion hdf5 || true
-
       # verify packages restored from cache are installed.
       # This catches incomplete apt installs after cache restore.
       - name: Verify apt packages
@@ -46,19 +34,15 @@ jobs:
           failed=""
 
           for pkg in \
+            libhdf5-dev \
             libfmt-dev
           do
-            if ! dpkg -s "$pkg" >/dev/null 2>&1; then
+            if ! dpkg -L "$pkg" >/dev/null 2>&1; then
               echo "Missing: $pkg"
               failed="$failed $pkg"
             fi
           done
 
-          # HDF5 check: verify the actual development environment
-          if ! h5c++ -show >/dev/null 2>&1; then
-            echo "Missing HDF5 C++ development environment"
-            failed="$failed hdf5"
-          fi
           if [ -n "$failed" ]; then
             echo "Missing packages after cache restore: $failed. Try deleting the cache and rerunning the workflow."
             exit 1

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Verify apt packages are available
         run: |
-          apt list --installed 2>/dev/null | grep -E 'hdf5|fmt' || true
+          apt list --installed 2>/dev/null | grep -E 'hdf5|fmt'
 
       - name: Configure CMake
         run: |

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -26,23 +26,10 @@ jobs:
           packages: libhdf5-dev libfmt-dev
           version: 1.0
 
-      # verify packages restored from cache are installed.
-      # This catches incomplete apt installs after cache restore.
       - name: Verify apt packages
         run: |
-          sudo apt-get check
-
-          for pkg in \
-            libhdf5-dev \
-            libfmt-dev
-          do
-            if ! dpkg-query -W -f='${Status}' "$pkg" 2>/dev/null | grep -q "install ok installed"; then
-              echo "Package not registered as installed: $pkg"
-              failed="$failed $pkg"
-            fi
-          done
-
-
+          apt-cache policy libhdf5-dev libfmt-dev
+          
       - name: Configure CMake
         run: |
           cmake -B ${{github.workspace}}/build \

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -29,26 +29,18 @@ jobs:
       # verify packages restored from cache are installed.
       # This catches incomplete apt installs after cache restore.
       - name: Verify apt packages
-        id: verify_packages
         run: |
-          failed=""
+          sudo apt-get check
 
           for pkg in \
             libhdf5-dev \
             libfmt-dev
           do
-            if ! dpkg -L "$pkg" >/dev/null 2>&1; then
-              echo "Missing: $pkg"
+            if ! dpkg-query -W -f='${Status}' "$pkg" 2>/dev/null | grep -q "install ok installed"; then
+              echo "Package not registered as installed: $pkg"
               failed="$failed $pkg"
             fi
           done
-
-          if [ -n "$failed" ]; then
-            echo "Missing packages after cache restore: $failed. Try deleting the cache and rerunning the workflow."
-            exit 1
-          else
-            echo "All apt packages are installed"  
-          fi
 
 
       - name: Configure CMake

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -46,7 +46,6 @@ jobs:
           failed=""
 
           for pkg in \
-            libhdf5-dev \
             libfmt-dev
           do
             if ! dpkg -s "$pkg" >/dev/null 2>&1; then
@@ -55,6 +54,11 @@ jobs:
             fi
           done
 
+          # HDF5 check: verify the actual development environment
+          if ! h5c++ -show >/dev/null 2>&1; then
+            echo "Missing HDF5 C++ development environment"
+            failed="$failed hdf5"
+          fi
           if [ -n "$failed" ]; then
             echo "Missing packages after cache restore: $failed. Try deleting the cache and rerunning the workflow."
             exit 1

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -23,7 +23,7 @@ jobs:
       # using a stable action version instead of latest to create/restore cache for now
       - uses: awalsh128/cache-apt-pkgs-action@v1.6.1
         with:
-          packages: libfmt-dev
+          packages: libhdf5-dev libfmt-dev
           version: 1.0
 
       - name: Verify apt packages
@@ -46,7 +46,7 @@ jobs:
             echo "Missing packages after cache restore: $failed. Try deleting the cache and rerunning the workflow."
             exit 1
           fi
-          
+
           echo "All apt packages are installed"  
           
       - name: Configure CMake

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -26,6 +26,7 @@ jobs:
           packages: libhdf5-dev libfmt-dev
           version: 1.0
 
+      # debug
       - name: Debug HDF5
         run: |
           dpkg -s libhdf5-dev || true


### PR DESCRIPTION
- remnants of #1484  
- removed the verification of the packages
- added the fixed version v1.6.1 instead of latest for the awalsh128/cache-apt-pkgs-action repo to create/restore cache.