### PR TITLE
1010/test should not set rx hostname

### DIFF
--- a/slsDetectorSoftware/tests/Caller/test-Caller-rx-running.cpp
+++ b/slsDetectorSoftware/tests/Caller/test-Caller-rx-running.cpp
@@ -215,6 +215,7 @@ TEST_CASE("general - cant put if receiver is not idle",
         auto prev_findex = det.getAcquisitionIndex();
         auto prev_fwrite = det.getFileWrite();
         auto prev_fifodepth = det.getRxFifoDepth();
+        auto rx_hostname = det.getRxHostname();
 
         // start receiver
         REQUIRE_NOTHROW(caller.call("rx_start", {}, -1, PUT));
@@ -224,6 +225,7 @@ TEST_CASE("general - cant put if receiver is not idle",
         REQUIRE_THROWS(caller.call("findex", {"2"}, -1, PUT));
         REQUIRE_THROWS(caller.call("fwrite", {"0"}, -1, PUT));
         REQUIRE_THROWS(caller.call("rx_fifodepth", {"1000"}, -1, PUT));
+        REQUIRE_THROWS(caller.call("rx_hostname", {rx_hostname[0]}, 0, PUT));
 
         // stop receiver
         REQUIRE_NOTHROW(caller.call("rx_stop", {}, -1, PUT));

--- a/slsDetectorSoftware/tests/Caller/test-Caller-rx-running.cpp
+++ b/slsDetectorSoftware/tests/Caller/test-Caller-rx-running.cpp
@@ -215,7 +215,6 @@ TEST_CASE("general - cant put if receiver is not idle",
         auto prev_findex = det.getAcquisitionIndex();
         auto prev_fwrite = det.getFileWrite();
         auto prev_fifodepth = det.getRxFifoDepth();
-        auto rx_hostname = det.getRxHostname();
 
         // start receiver
         REQUIRE_NOTHROW(caller.call("rx_start", {}, -1, PUT));
@@ -225,7 +224,6 @@ TEST_CASE("general - cant put if receiver is not idle",
         REQUIRE_THROWS(caller.call("findex", {"2"}, -1, PUT));
         REQUIRE_THROWS(caller.call("fwrite", {"0"}, -1, PUT));
         REQUIRE_THROWS(caller.call("rx_fifodepth", {"1000"}, -1, PUT));
-        REQUIRE_THROWS(caller.call("rx_hostname", {rx_hostname[0]}, 0, PUT));
 
         // stop receiver
         REQUIRE_NOTHROW(caller.call("rx_stop", {}, -1, PUT));
@@ -236,7 +234,6 @@ TEST_CASE("general - cant put if receiver is not idle",
             det.setAcquisitionIndex(prev_findex[i], {i});
             det.setFileWrite(prev_fwrite[i], {i});
             det.setRxFifoDepth(prev_fifodepth[i], {i});
-            det.setRxHostname(rx_hostname[i], {i});
         }
     }
 }


### PR DESCRIPTION
related to https://github.com/slsdetectorgroup/slsDetectorPackage/pull/1504
removed the test that set rx_hostname because it will reset parameters and some failures might be hidden for past or future tests