### PR TITLE
1010/update rx metadata threshold m3

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -58,6 +58,8 @@ added rx_streamdummyheader to send the zmq dummy header any time. Allows pre-con
 
 zmqsocket - allowing hwm to be set already at the constructor level. As before, can still be set after construction with socket reconnection.
 
+M3: threshold energy updated to -1 in receiver master file whenever it is set in the detector server (setting dacs directly, custom trimbit file, set all trimbits etc.)
+
 2  On-board Detector Server Compatibility
 ==========================================
 

--- a/slsDetectorSoftware/src/Module.cpp
+++ b/slsDetectorSoftware/src/Module.cpp
@@ -270,8 +270,6 @@ void Module::setThresholdEnergy(int e_eV, detectorSettings isettings,
     }
 }
 
-
-
 void Module::setAllThresholdEnergy(std::array<int, 3> e_eV,
                                    detectorSettings isettings, bool trimbits) {
     if (shm()->detType != MYTHEN3) {

--- a/slsDetectorSoftware/src/Module.cpp
+++ b/slsDetectorSoftware/src/Module.cpp
@@ -197,9 +197,7 @@ void Module::setSettings(detectorSettings isettings) {
             "Cannot set settings for Eiger. Use threshold energy.");
     }
     sendToDetector<int>(F_SET_SETTINGS, isettings);
-    if (shm()->detType == MYTHEN3) {
-        updateRxAllThresholdMetadata(getAllThresholdEnergy());
-    }
+    updateRxAllThresholdMetadata();
 }
 
 int Module::getThresholdEnergy() const {
@@ -420,9 +418,12 @@ void Module::setAllThresholdEnergy(std::array<int, 3> e_eV,
     }
 }
 
-void Module::updateRxAllThresholdMetadata(std::array<int, 3> e_eV) {
+void Module::updateRxAllThresholdMetadata() {
     if (shm()->useReceiverFlag) {
-        sendToReceiver(F_RECEIVER_SET_ALL_THRESHOLD, e_eV, nullptr);
+        if (shm()->detType == MYTHEN3) {
+            auto e_eV = getAllThresholdEnergy();
+            sendToReceiver(F_RECEIVER_SET_ALL_THRESHOLD, e_eV, nullptr);
+        }
     }
 }
 
@@ -483,9 +484,7 @@ int Module::getAllTrimbits() const {
 
 void Module::setAllTrimbits(int val) {
     sendToDetector<int>(F_SET_ALL_TRIMBITS, val);
-    if (shm()->detType == MYTHEN3) {
-        updateRxAllThresholdMetadata(getAllThresholdEnergy());
-    }
+    updateRxAllThresholdMetadata();
 }
 
 std::vector<int> Module::getTrimEn() const {
@@ -813,9 +812,7 @@ void Module::resetToDefaultDacs(const bool hardReset) {
 void Module::setDAC(int val, dacIndex index, bool mV) {
     int args[]{static_cast<int>(index), static_cast<int>(mV), val};
     sendToDetector<int>(F_SET_DAC, args);
-    if (shm()->detType == MYTHEN3) {
-        updateRxAllThresholdMetadata(getAllThresholdEnergy());
-    }
+    updateRxAllThresholdMetadata();
 }
 
 bool Module::getPowerChip() const {
@@ -3616,9 +3613,7 @@ void Module::setModule(sls_detector_module &module, bool trimbits) {
         throw DetectorError("Module " + std::to_string(moduleIndex) +
                             " returned error: " + client.readErrorMessage());
     }
-    if (shm()->detType == MYTHEN3) {
-        updateRxAllThresholdMetadata(getAllThresholdEnergy());
-    }
+    updateRxAllThresholdMetadata();
 }
 
 sls_detector_module Module::getModule() {

--- a/slsDetectorSoftware/src/Module.cpp
+++ b/slsDetectorSoftware/src/Module.cpp
@@ -197,7 +197,7 @@ void Module::setSettings(detectorSettings isettings) {
             "Cannot set settings for Eiger. Use threshold energy.");
     }
     sendToDetector<int>(F_SET_SETTINGS, isettings);
-    updateRxAllThresholdMetadata();
+    updateRxThresholdEnergyMetadata();
 }
 
 int Module::getThresholdEnergy() const {
@@ -418,7 +418,7 @@ void Module::setAllThresholdEnergy(std::array<int, 3> e_eV,
     }
 }
 
-void Module::updateRxAllThresholdMetadata() {
+void Module::updateRxThresholdEnergyMetadata() {
     if (shm()->useReceiverFlag) {
         if (shm()->detType == MYTHEN3) {
             auto e_eV = getAllThresholdEnergy();
@@ -484,7 +484,7 @@ int Module::getAllTrimbits() const {
 
 void Module::setAllTrimbits(int val) {
     sendToDetector<int>(F_SET_ALL_TRIMBITS, val);
-    updateRxAllThresholdMetadata();
+    updateRxThresholdEnergyMetadata();
 }
 
 std::vector<int> Module::getTrimEn() const {
@@ -812,7 +812,7 @@ void Module::resetToDefaultDacs(const bool hardReset) {
 void Module::setDAC(int val, dacIndex index, bool mV) {
     int args[]{static_cast<int>(index), static_cast<int>(mV), val};
     sendToDetector<int>(F_SET_DAC, args);
-    updateRxAllThresholdMetadata();
+    updateRxThresholdEnergyMetadata();
 }
 
 bool Module::getPowerChip() const {
@@ -3613,7 +3613,7 @@ void Module::setModule(sls_detector_module &module, bool trimbits) {
         throw DetectorError("Module " + std::to_string(moduleIndex) +
                             " returned error: " + client.readErrorMessage());
     }
-    updateRxAllThresholdMetadata();
+    updateRxThresholdEnergyMetadata();
 }
 
 sls_detector_module Module::getModule() {

--- a/slsDetectorSoftware/src/Module.cpp
+++ b/slsDetectorSoftware/src/Module.cpp
@@ -197,6 +197,9 @@ void Module::setSettings(detectorSettings isettings) {
             "Cannot set settings for Eiger. Use threshold energy.");
     }
     sendToDetector<int>(F_SET_SETTINGS, isettings);
+    if (shm()->detType == MYTHEN3) {
+        updateRxAllThresholdMetadata(getAllThresholdEnergy());
+    }
 }
 
 int Module::getThresholdEnergy() const {
@@ -266,6 +269,8 @@ void Module::setThresholdEnergy(int e_eV, detectorSettings isettings,
         sendToReceiver(F_RECEIVER_SET_THRESHOLD, e_eV, nullptr);
     }
 }
+
+
 
 void Module::setAllThresholdEnergy(std::array<int, 3> e_eV,
                                    detectorSettings isettings, bool trimbits) {
@@ -415,7 +420,9 @@ void Module::setAllThresholdEnergy(std::array<int, 3> e_eV,
         throw RuntimeError("setThresholdEnergyAndSettings: Could not set "
                            "settings in Module");
     }
+}
 
+void Module::updateRxAllThresholdMetadata(std::array<int, 3> e_eV) {
     if (shm()->useReceiverFlag) {
         sendToReceiver(F_RECEIVER_SET_ALL_THRESHOLD, e_eV, nullptr);
     }
@@ -478,6 +485,9 @@ int Module::getAllTrimbits() const {
 
 void Module::setAllTrimbits(int val) {
     sendToDetector<int>(F_SET_ALL_TRIMBITS, val);
+    if (shm()->detType == MYTHEN3) {
+        updateRxAllThresholdMetadata(getAllThresholdEnergy());
+    }
 }
 
 std::vector<int> Module::getTrimEn() const {
@@ -805,6 +815,9 @@ void Module::resetToDefaultDacs(const bool hardReset) {
 void Module::setDAC(int val, dacIndex index, bool mV) {
     int args[]{static_cast<int>(index), static_cast<int>(mV), val};
     sendToDetector<int>(F_SET_DAC, args);
+    if (shm()->detType == MYTHEN3) {
+        updateRxAllThresholdMetadata(getAllThresholdEnergy());
+    }
 }
 
 bool Module::getPowerChip() const {
@@ -3604,6 +3617,9 @@ void Module::setModule(sls_detector_module &module, bool trimbits) {
     if (client.Receive<int>() == FAIL) {
         throw DetectorError("Module " + std::to_string(moduleIndex) +
                             " returned error: " + client.readErrorMessage());
+    }
+    if (shm()->detType == MYTHEN3) {
+        updateRxAllThresholdMetadata(getAllThresholdEnergy());
     }
 }
 

--- a/slsDetectorSoftware/src/Module.h
+++ b/slsDetectorSoftware/src/Module.h
@@ -109,7 +109,8 @@ class Module : public virtual slsDetectorDefs {
                             bool trimbits);
     void setAllThresholdEnergy(std::array<int, 3> e_eV,
                                detectorSettings isettings, bool trimbits);
-    std::string getSettingsDir() const;
+                               std::string getSettingsDir() const;
+    void updateRxAllThresholdMetadata(std::array<int, 3> e_eV);
     std::string setSettingsDir(const std::string &dir);
     void loadTrimbits(const std::string &fname);
     void saveTrimbits(const std::string &fname);

--- a/slsDetectorSoftware/src/Module.h
+++ b/slsDetectorSoftware/src/Module.h
@@ -110,7 +110,7 @@ class Module : public virtual slsDetectorDefs {
     void setAllThresholdEnergy(std::array<int, 3> e_eV,
                                detectorSettings isettings, bool trimbits);
     std::string getSettingsDir() const;
-    void updateRxAllThresholdMetadata();
+    void updateRxThresholdEnergyMetadata();
     std::string setSettingsDir(const std::string &dir);
     void loadTrimbits(const std::string &fname);
     void saveTrimbits(const std::string &fname);

--- a/slsDetectorSoftware/src/Module.h
+++ b/slsDetectorSoftware/src/Module.h
@@ -110,7 +110,7 @@ class Module : public virtual slsDetectorDefs {
     void setAllThresholdEnergy(std::array<int, 3> e_eV,
                                detectorSettings isettings, bool trimbits);
     std::string getSettingsDir() const;
-    void updateRxAllThresholdMetadata(std::array<int, 3> e_eV);
+    void updateRxAllThresholdMetadata();
     std::string setSettingsDir(const std::string &dir);
     void loadTrimbits(const std::string &fname);
     void saveTrimbits(const std::string &fname);

--- a/slsDetectorSoftware/src/Module.h
+++ b/slsDetectorSoftware/src/Module.h
@@ -109,7 +109,7 @@ class Module : public virtual slsDetectorDefs {
                             bool trimbits);
     void setAllThresholdEnergy(std::array<int, 3> e_eV,
                                detectorSettings isettings, bool trimbits);
-                               std::string getSettingsDir() const;
+    std::string getSettingsDir() const;
     void updateRxAllThresholdMetadata(std::array<int, 3> e_eV);
     std::string setSettingsDir(const std::string &dir);
     void loadTrimbits(const std::string &fname);


### PR DESCRIPTION
updating rx master file for threshold energy whenever we set dacs directly, load custom trimbits or set trimbits etc. (the threshold energy is set to -1 in the detector server)

= should also fix the tests.
related to #1509 