### PR TITLE
Dev/update rx metadata threshold m3

### DIFF
--- a/slsDetectorSoftware/src/Module.cpp
+++ b/slsDetectorSoftware/src/Module.cpp
@@ -196,7 +196,7 @@ void Module::setSettings(detectorSettings isettings) {
             "Cannot set settings for Eiger. Use threshold energy.");
     }
     sendToDetector<int>(F_SET_SETTINGS, isettings);
-    updateRxAllThresholdMetadata();
+    updateRxThresholdEnergyMetadata();
 }
 
 int Module::getThresholdEnergy() const {
@@ -417,7 +417,7 @@ void Module::setAllThresholdEnergy(std::array<int, 3> e_eV,
     }
 }
 
-void Module::updateRxAllThresholdMetadata() {
+void Module::updateRxThresholdEnergyMetadata() {
     if (shm()->useReceiverFlag) {
         if (shm()->detType == MYTHEN3) {
             auto e_eV = getAllThresholdEnergy();
@@ -483,7 +483,7 @@ int Module::getAllTrimbits() const {
 
 void Module::setAllTrimbits(int val) {
     sendToDetector<int>(F_SET_ALL_TRIMBITS, val);
-    updateRxAllThresholdMetadata();
+    updateRxThresholdEnergyMetadata();
 }
 
 std::vector<int> Module::getTrimEn() const {
@@ -791,7 +791,7 @@ void Module::setDAC(int val, dacIndex index, bool mV) {
     }
     int args[]{static_cast<int>(index), static_cast<int>(mV), val};
     sendToDetector<int>(F_SET_DAC, args);
-    updateRxAllThresholdMetadata();
+    updateRxThresholdEnergyMetadata();
 }
 
 bool Module::getPowerChip() const {
@@ -3560,7 +3560,7 @@ void Module::setModule(sls_detector_module &module, bool trimbits) {
     client.sendCommand(F_SET_MODULE, nullptr, 0);
     sendModule(&module, client);
     client.readReply(nullptr, 0);
-    updateRxAllThresholdMetadata();
+    updateRxThresholdEnergyMetadata();
 }
 
 sls_detector_module Module::getModule() {

--- a/slsDetectorSoftware/src/Module.cpp
+++ b/slsDetectorSoftware/src/Module.cpp
@@ -196,6 +196,9 @@ void Module::setSettings(detectorSettings isettings) {
             "Cannot set settings for Eiger. Use threshold energy.");
     }
     sendToDetector<int>(F_SET_SETTINGS, isettings);
+    if (shm()->detType == MYTHEN3) {
+        updateRxAllThresholdMetadata(getAllThresholdEnergy());
+    }
 }
 
 int Module::getThresholdEnergy() const {
@@ -265,6 +268,8 @@ void Module::setThresholdEnergy(int e_eV, detectorSettings isettings,
         sendToReceiver(F_RECEIVER_SET_THRESHOLD, e_eV, nullptr);
     }
 }
+
+
 
 void Module::setAllThresholdEnergy(std::array<int, 3> e_eV,
                                    detectorSettings isettings, bool trimbits) {
@@ -414,7 +419,9 @@ void Module::setAllThresholdEnergy(std::array<int, 3> e_eV,
         throw RuntimeError("setThresholdEnergyAndSettings: Could not set "
                            "settings in Module");
     }
+}
 
+void Module::updateRxAllThresholdMetadata(std::array<int, 3> e_eV) {
     if (shm()->useReceiverFlag) {
         sendToReceiver(F_RECEIVER_SET_ALL_THRESHOLD, e_eV, nullptr);
     }
@@ -477,6 +484,9 @@ int Module::getAllTrimbits() const {
 
 void Module::setAllTrimbits(int val) {
     sendToDetector<int>(F_SET_ALL_TRIMBITS, val);
+    if (shm()->detType == MYTHEN3) {
+        updateRxAllThresholdMetadata(getAllThresholdEnergy());
+    }
 }
 
 std::vector<int> Module::getTrimEn() const {
@@ -784,6 +794,9 @@ void Module::setDAC(int val, dacIndex index, bool mV) {
     }
     int args[]{static_cast<int>(index), static_cast<int>(mV), val};
     sendToDetector<int>(F_SET_DAC, args);
+    if (shm()->detType == MYTHEN3) {
+        updateRxAllThresholdMetadata(getAllThresholdEnergy());
+    }
 }
 
 bool Module::getPowerChip() const {
@@ -3552,6 +3565,9 @@ void Module::setModule(sls_detector_module &module, bool trimbits) {
     client.sendCommand(F_SET_MODULE, nullptr, 0);
     sendModule(&module, client);
     client.readReply(nullptr, 0);
+    if (shm()->detType == MYTHEN3) {
+        updateRxAllThresholdMetadata(getAllThresholdEnergy());
+    }
 }
 
 sls_detector_module Module::getModule() {

--- a/slsDetectorSoftware/src/Module.cpp
+++ b/slsDetectorSoftware/src/Module.cpp
@@ -269,8 +269,6 @@ void Module::setThresholdEnergy(int e_eV, detectorSettings isettings,
     }
 }
 
-
-
 void Module::setAllThresholdEnergy(std::array<int, 3> e_eV,
                                    detectorSettings isettings, bool trimbits) {
     if (shm()->detType != MYTHEN3) {

--- a/slsDetectorSoftware/src/Module.cpp
+++ b/slsDetectorSoftware/src/Module.cpp
@@ -196,9 +196,7 @@ void Module::setSettings(detectorSettings isettings) {
             "Cannot set settings for Eiger. Use threshold energy.");
     }
     sendToDetector<int>(F_SET_SETTINGS, isettings);
-    if (shm()->detType == MYTHEN3) {
-        updateRxAllThresholdMetadata(getAllThresholdEnergy());
-    }
+    updateRxAllThresholdMetadata();
 }
 
 int Module::getThresholdEnergy() const {
@@ -419,9 +417,12 @@ void Module::setAllThresholdEnergy(std::array<int, 3> e_eV,
     }
 }
 
-void Module::updateRxAllThresholdMetadata(std::array<int, 3> e_eV) {
+void Module::updateRxAllThresholdMetadata() {
     if (shm()->useReceiverFlag) {
-        sendToReceiver(F_RECEIVER_SET_ALL_THRESHOLD, e_eV, nullptr);
+        if (shm()->detType == MYTHEN3) {
+            auto e_eV = getAllThresholdEnergy();
+            sendToReceiver(F_RECEIVER_SET_ALL_THRESHOLD, e_eV, nullptr);
+        }
     }
 }
 
@@ -482,9 +483,7 @@ int Module::getAllTrimbits() const {
 
 void Module::setAllTrimbits(int val) {
     sendToDetector<int>(F_SET_ALL_TRIMBITS, val);
-    if (shm()->detType == MYTHEN3) {
-        updateRxAllThresholdMetadata(getAllThresholdEnergy());
-    }
+    updateRxAllThresholdMetadata();
 }
 
 std::vector<int> Module::getTrimEn() const {
@@ -792,9 +791,7 @@ void Module::setDAC(int val, dacIndex index, bool mV) {
     }
     int args[]{static_cast<int>(index), static_cast<int>(mV), val};
     sendToDetector<int>(F_SET_DAC, args);
-    if (shm()->detType == MYTHEN3) {
-        updateRxAllThresholdMetadata(getAllThresholdEnergy());
-    }
+    updateRxAllThresholdMetadata();
 }
 
 bool Module::getPowerChip() const {
@@ -3563,9 +3560,7 @@ void Module::setModule(sls_detector_module &module, bool trimbits) {
     client.sendCommand(F_SET_MODULE, nullptr, 0);
     sendModule(&module, client);
     client.readReply(nullptr, 0);
-    if (shm()->detType == MYTHEN3) {
-        updateRxAllThresholdMetadata(getAllThresholdEnergy());
-    }
+    updateRxAllThresholdMetadata();
 }
 
 sls_detector_module Module::getModule() {

--- a/slsDetectorSoftware/src/Module.h
+++ b/slsDetectorSoftware/src/Module.h
@@ -111,7 +111,7 @@ class Module : public virtual slsDetectorDefs {
     void setAllThresholdEnergy(std::array<int, 3> e_eV,
                                detectorSettings isettings, bool trimbits);
     std::string getSettingsDir() const;
-    void updateRxAllThresholdMetadata();
+    void updateRxThresholdEnergyMetadata();
     std::string setSettingsDir(const std::string &dir);
     void loadTrimbits(const std::string &fname);
     void saveTrimbits(const std::string &fname);

--- a/slsDetectorSoftware/src/Module.h
+++ b/slsDetectorSoftware/src/Module.h
@@ -111,7 +111,7 @@ class Module : public virtual slsDetectorDefs {
     void setAllThresholdEnergy(std::array<int, 3> e_eV,
                                detectorSettings isettings, bool trimbits);
     std::string getSettingsDir() const;
-    void updateRxAllThresholdMetadata(std::array<int, 3> e_eV);
+    void updateRxAllThresholdMetadata();
     std::string setSettingsDir(const std::string &dir);
     void loadTrimbits(const std::string &fname);
     void saveTrimbits(const std::string &fname);

--- a/slsDetectorSoftware/src/Module.h
+++ b/slsDetectorSoftware/src/Module.h
@@ -110,7 +110,7 @@ class Module : public virtual slsDetectorDefs {
                             bool trimbits);
     void setAllThresholdEnergy(std::array<int, 3> e_eV,
                                detectorSettings isettings, bool trimbits);
-                               std::string getSettingsDir() const;
+    std::string getSettingsDir() const;
     void updateRxAllThresholdMetadata(std::array<int, 3> e_eV);
     std::string setSettingsDir(const std::string &dir);
     void loadTrimbits(const std::string &fname);

--- a/slsDetectorSoftware/src/Module.h
+++ b/slsDetectorSoftware/src/Module.h
@@ -110,7 +110,8 @@ class Module : public virtual slsDetectorDefs {
                             bool trimbits);
     void setAllThresholdEnergy(std::array<int, 3> e_eV,
                                detectorSettings isettings, bool trimbits);
-    std::string getSettingsDir() const;
+                               std::string getSettingsDir() const;
+    void updateRxAllThresholdMetadata(std::array<int, 3> e_eV);
     std::string setSettingsDir(const std::string &dir);
     void loadTrimbits(const std::string &fname);
     void saveTrimbits(const std::string &fname);


### PR DESCRIPTION
updating rx master file for threshold energy whenever we set dacs directly, load custom trimbits or set trimbits etc. (the threshold energy is set to -1 in the detector server)

= should also fix the tests.

related to #1508 